### PR TITLE
feat(x402): add Casper wCSPR payment network

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ keeps routing and x402 payment policy in the tunnel process, and avoids requirin
   vendor lock-in.
 
 - **Built-in x402 Payments** - Routed HTTP paths can require Sui gasless
-  USDC x402 payment before proxying. Browser apps can import `/x402/client.js`,
-  and native clients can call `/x402/prepare` directly and send `X-PAYMENT`.
+  USDC or Casper wCSPR x402 payment before proxying. Browser apps can import
+  `/x402/client.js`, and native clients can call `/x402/prepare` directly and
+  send `X-PAYMENT`.
 
 ## Comparison
 

--- a/docs/src/routes/configuration/+page.md
+++ b/docs/src/routes/configuration/+page.md
@@ -277,6 +277,17 @@ send the signed payload as `X-PAYMENT`. Payment is still enforced by the tunnel
 on the paid route prefix. Tunnel paid routes default to Sui mainnet and use Sui
 testnet when `x402_testnet = true`.
 
+#### x402 payment networks
+
+| Network | Asset | Decimals | Facilitator |
+|---|---|---|---|
+| `sui:mainnet`, `sui:testnet` | USDC gasless stablecoin | 6 | Built-in Sui facilitator |
+| `casper:casper`, `casper:casper-test` | wCSPR CEP-18 token | 9 | `https://x402-facilitator.cspr.cloud`, overridable per payment |
+
+Casper has no Go chain SDK, so `casper:*` payments delegate `/verify` and
+`/settle` to a remote x402 facilitator over HTTP. The wCSPR CEP-18 contract
+hash differs per network deployment, so it must be set as the payment asset.
+
 For a task-oriented walkthrough, see [Portal Agent](/portal-agent).
 
 ### `identity.json`

--- a/portal/x402/casper.go
+++ b/portal/x402/casper.go
@@ -1,0 +1,221 @@
+package x402
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/apd/v3"
+	facilitatorclient "github.com/gosuda/x402-facilitator/api/client"
+	facilitatorcore "github.com/gosuda/x402-facilitator/facilitator"
+	facilitatortypes "github.com/gosuda/x402-facilitator/types"
+
+	"github.com/gosuda/portal-tunnel/v2/types"
+)
+
+const (
+	CasperMainnetNetwork = "casper:casper"
+	CasperTestnetNetwork = "casper:casper-test"
+
+	// DefaultCasperFacilitatorURL is the hosted x402 facilitator used when a
+	// Casper payment does not configure its own endpoint.
+	DefaultCasperFacilitatorURL = "https://x402-facilitator.cspr.cloud"
+
+	// csprDecimals is the motes precision shared by CSPR and the wCSPR CEP-18 token.
+	csprDecimals = 9
+)
+
+var casperNetworkDisplayNames = map[string]string{
+	CasperMainnetNetwork: "Casper Mainnet",
+	CasperTestnetNetwork: "Casper Testnet",
+}
+
+// CasperNetwork returns the CAIP-2 Casper network for a mainnet/testnet choice.
+func CasperNetwork(testnet bool) string {
+	if testnet {
+		return CasperTestnetNetwork
+	}
+	return CasperMainnetNetwork
+}
+
+// IsCasperNetwork reports whether network is a Casper CAIP-2 identifier.
+func IsCasperNetwork(network string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(network)), "casper:")
+}
+
+// NormalizeCasperAddress canonicalizes a Casper account hash or public key.
+func NormalizeCasperAddress(address string) string {
+	address = strings.ToLower(strings.TrimSpace(address))
+	if address == "" {
+		return ""
+	}
+	if rest, ok := strings.CutPrefix(address, "account-hash-"); ok {
+		return "account-hash-" + rest
+	}
+	return address
+}
+
+// CSPRAmountToAtomic converts a human wCSPR amount, such as "0.01", to motes
+// for the x402 facilitator. CSPR and wCSPR both have 9 decimals.
+func CSPRAmountToAtomic(amount string) (string, error) {
+	amount = strings.TrimSpace(amount)
+	if amount == "" {
+		return "", errors.New("x402 wCSPR payment amount is required")
+	}
+	d, _, err := new(apd.Decimal).SetString(amount)
+	if err != nil {
+		return "", fmt.Errorf("x402 wCSPR payment amount must be a decimal CSPR amount: %s", amount)
+	}
+	d.Exponent += int32(csprDecimals)
+	d.Reduce(d)
+	if d.Form != apd.Finite || d.Sign() <= 0 {
+		return "", fmt.Errorf("x402 wCSPR payment amount must be positive: %s", amount)
+	}
+	if d.Exponent < 0 {
+		return "", fmt.Errorf("x402 wCSPR payment amount supports up to %d decimals: %s", csprDecimals, amount)
+	}
+	return fmt.Sprintf("%f", d), nil
+}
+
+// FormatCSPRAtomicAmount renders a motes amount as a human wCSPR amount.
+func FormatCSPRAtomicAmount(amount string) string {
+	amount = strings.TrimSpace(amount)
+	if amount == "" {
+		return ""
+	}
+	d, _, err := new(apd.Decimal).SetString(amount)
+	if err != nil {
+		return amount + " motes"
+	}
+	d.Exponent -= int32(csprDecimals)
+	d.Reduce(d)
+	if d.Form != apd.Finite || d.Sign() < 0 {
+		return amount + " motes"
+	}
+	return fmt.Sprintf("%f wCSPR", d)
+}
+
+var _ facilitatorcore.Facilitator = (*casperFacilitator)(nil)
+
+// casperFacilitator verifies and settles Casper payments through a remote x402
+// facilitator. Casper has no Go chain SDK, so verify/settle are delegated over
+// HTTP the same way any hosted x402 facilitator is used.
+type casperFacilitator struct {
+	network string
+	client  *facilitatorclient.Client
+}
+
+func newCasperFacilitator(network string, endpoints ...string) (facilitatorcore.Facilitator, error) {
+	network = strings.ToLower(strings.TrimSpace(network))
+	if network == "" {
+		network = CasperMainnetNetwork
+	}
+	if _, ok := casperNetworkDisplayNames[network]; !ok {
+		return nil, fmt.Errorf("unsupported Casper network %q", network)
+	}
+	url := DefaultCasperFacilitatorURL
+	for _, endpoint := range endpoints {
+		if endpoint = strings.TrimSpace(endpoint); endpoint != "" {
+			url = endpoint
+			break
+		}
+	}
+	client, err := facilitatorclient.NewClient(url)
+	if err != nil {
+		return nil, fmt.Errorf("create casper x402 facilitator: %w", err)
+	}
+	return &casperFacilitator{network: network, client: client}, nil
+}
+
+func (f *casperFacilitator) Verify(ctx context.Context, payment *facilitatortypes.PaymentPayload, req *facilitatortypes.PaymentRequirements) (*facilitatortypes.PaymentVerifyResponse, error) {
+	if payment == nil || req == nil {
+		return nil, errors.New("casper x402 verify requires a payment payload and requirements")
+	}
+	return f.client.Verify(ctx, payment, req)
+}
+
+func (f *casperFacilitator) Settle(ctx context.Context, payment *facilitatortypes.PaymentPayload, req *facilitatortypes.PaymentRequirements) (*facilitatortypes.PaymentSettleResponse, error) {
+	if payment == nil || req == nil {
+		return nil, errors.New("casper x402 settle requires a payment payload and requirements")
+	}
+	return f.client.Settle(ctx, payment, req)
+}
+
+func (f *casperFacilitator) Supported() *facilitatortypes.SupportedResponse {
+	return &facilitatortypes.SupportedResponse{
+		Kinds: []facilitatortypes.SupportedKind{{
+			X402Version: int(facilitatortypes.X402VersionV2),
+			Scheme:      string(facilitatortypes.Exact),
+			Network:     f.network,
+		}},
+		Extensions: []string{},
+		Signers:    map[string][]string{},
+	}
+}
+
+// NewCasperPayment builds a wCSPR x402 payment contract settled by a Casper
+// x402 facilitator. The wCSPR CEP-18 contract hash must be configured through
+// payment.Asset because it differs per network deployment.
+func NewCasperPayment(payment types.X402Payment) (*Payment, error) {
+	network := strings.TrimSpace(payment.Network)
+	if network == "" {
+		network = CasperNetwork(payment.Testnet)
+	}
+	network = strings.ToLower(network)
+	if _, ok := casperNetworkDisplayNames[network]; !ok {
+		return nil, fmt.Errorf("unsupported Casper network %q", network)
+	}
+	asset := strings.ToLower(strings.TrimSpace(payment.Asset))
+	if asset == "" {
+		return nil, errors.New("x402 wCSPR payment requires the wCSPR CEP-18 contract hash")
+	}
+	payTo := NormalizeCasperAddress(payment.PayTo)
+	if payTo == "" {
+		return nil, errors.New("x402 wCSPR payment requires a Casper pay-to address")
+	}
+	amount, err := CSPRAmountToAtomic(payment.Amount)
+	if err != nil {
+		return nil, err
+	}
+	maxTimeoutSeconds := payment.MaxTimeoutSeconds
+	if maxTimeoutSeconds <= 0 {
+		maxTimeoutSeconds = defaultMaxTimeoutSeconds
+	}
+	requirements := facilitatortypes.PaymentRequirements{
+		Scheme:            string(facilitatortypes.Exact),
+		Network:           network,
+		Asset:             asset,
+		Amount:            amount,
+		PayTo:             payTo,
+		MaxTimeoutSeconds: maxTimeoutSeconds,
+		Extra: map[string]interface{}{
+			"asset":               "wCSPR",
+			"assetTransferMethod": "casper-cep18-transfer",
+			"decimals":            csprDecimals,
+		},
+	}
+	endpoints := append([]string(nil), payment.Endpoints...)
+	facilitator, err := newCasperFacilitator(requirements.Network, endpoints...)
+	if err != nil {
+		return nil, err
+	}
+
+	payment.Testnet = strings.EqualFold(requirements.Network, CasperTestnetNetwork)
+	payment.Network = requirements.Network
+	payment.NetworkName = casperNetworkDisplayNames[requirements.Network]
+	payment.Asset = requirements.Asset
+	payment.PayTo = requirements.PayTo
+	payment.Amount = requirements.Amount
+	payment.MaxTimeoutSeconds = requirements.MaxTimeoutSeconds
+	payment.Endpoints = endpoints
+	payment.ResourcePath = strings.TrimSpace(payment.ResourcePath)
+	payment.ResourceDescription = strings.TrimSpace(payment.ResourceDescription)
+	payment.ResourceMimeType = strings.TrimSpace(payment.ResourceMimeType)
+
+	return &Payment{
+		payment:      payment,
+		facilitator:  facilitator,
+		requirements: requirements,
+	}, nil
+}

--- a/portal/x402/casper_test.go
+++ b/portal/x402/casper_test.go
@@ -1,0 +1,317 @@
+package x402
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	facilitatortypes "github.com/gosuda/x402-facilitator/types"
+
+	"github.com/gosuda/portal-tunnel/v2/types"
+)
+
+func TestCasperNetwork(t *testing.T) {
+	if got := CasperNetwork(false); got != CasperMainnetNetwork {
+		t.Fatalf("CasperNetwork(false) = %q, want %q", got, CasperMainnetNetwork)
+	}
+	if got := CasperNetwork(true); got != CasperTestnetNetwork {
+		t.Fatalf("CasperNetwork(true) = %q, want %q", got, CasperTestnetNetwork)
+	}
+}
+
+func TestIsCasperNetwork(t *testing.T) {
+	tests := []struct {
+		name    string
+		network string
+		want    bool
+	}{
+		{name: "mainnet", network: CasperMainnetNetwork, want: true},
+		{name: "testnet", network: CasperTestnetNetwork, want: true},
+		{name: "mixed case with spaces", network: "  Casper:Casper-Test ", want: true},
+		{name: "sui", network: MainnetNetwork, want: false},
+		{name: "empty", network: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsCasperNetwork(tt.network); got != tt.want {
+				t.Fatalf("IsCasperNetwork(%q) = %v, want %v", tt.network, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCSPRAmountToAtomic(t *testing.T) {
+	tests := []struct {
+		name    string
+		amount  string
+		want    string
+		wantErr bool
+	}{
+		{name: "whole", amount: "1", want: "1000000000"},
+		{name: "cents", amount: "0.01", want: "10000000"},
+		{name: "one mote", amount: "0.000000001", want: "1"},
+		{name: "padded", amount: " 2.5 ", want: "2500000000"},
+		{name: "empty", amount: "", wantErr: true},
+		{name: "not a number", amount: "abc", wantErr: true},
+		{name: "zero", amount: "0", wantErr: true},
+		{name: "negative", amount: "-1", wantErr: true},
+		{name: "too many decimals", amount: "0.0000000001", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CSPRAmountToAtomic(tt.amount)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("CSPRAmountToAtomic(%q) = %q, want error", tt.amount, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CSPRAmountToAtomic(%q) error: %v", tt.amount, err)
+			}
+			if got != tt.want {
+				t.Fatalf("CSPRAmountToAtomic(%q) = %q, want %q", tt.amount, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatCSPRAtomicAmount(t *testing.T) {
+	tests := []struct {
+		name   string
+		amount string
+		want   string
+	}{
+		{name: "whole", amount: "1000000000", want: "1 wCSPR"},
+		{name: "fraction", amount: "10000000", want: "0.01 wCSPR"},
+		{name: "one mote", amount: "1", want: "0.000000001 wCSPR"},
+		{name: "empty", amount: "", want: ""},
+		{name: "invalid", amount: "abc", want: "abc motes"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatCSPRAtomicAmount(tt.amount); got != tt.want {
+				t.Fatalf("FormatCSPRAtomicAmount(%q) = %q, want %q", tt.amount, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeCasperAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		want    string
+	}{
+		{
+			name:    "account hash lowercased",
+			address: "  Account-Hash-1B2C3D  ",
+			want:    "account-hash-1b2c3d",
+		},
+		{
+			name:    "public key",
+			address: "01A1B2C3",
+			want:    "01a1b2c3",
+		},
+		{name: "empty", address: "   ", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeCasperAddress(tt.address); got != tt.want {
+				t.Fatalf("NormalizeCasperAddress(%q) = %q, want %q", tt.address, got, tt.want)
+			}
+		})
+	}
+}
+
+const testWCSPRAsset = "hash-9c0d3fd7b1d9b5a94b13a5df0b1c8f1a0b3e5d7c9a1b3d5f7092a4c6e8b0d2f4"
+
+func TestNewCasperPayment(t *testing.T) {
+	payment, err := NewCasperPayment(types.X402Payment{
+		Testnet: true,
+		Asset:   testWCSPRAsset,
+		PayTo:   "Account-Hash-ABC123",
+		Amount:  "0.25",
+	})
+	if err != nil {
+		t.Fatalf("NewCasperPayment: %v", err)
+	}
+	if payment.requirements.Network != CasperTestnetNetwork {
+		t.Fatalf("network = %q, want %q", payment.requirements.Network, CasperTestnetNetwork)
+	}
+	if payment.requirements.Scheme != string(facilitatortypes.Exact) {
+		t.Fatalf("scheme = %q, want %q", payment.requirements.Scheme, facilitatortypes.Exact)
+	}
+	if payment.requirements.Amount != "250000000" {
+		t.Fatalf("amount = %q, want %q", payment.requirements.Amount, "250000000")
+	}
+	if payment.requirements.PayTo != "account-hash-abc123" {
+		t.Fatalf("payTo = %q, want %q", payment.requirements.PayTo, "account-hash-abc123")
+	}
+	if payment.requirements.MaxTimeoutSeconds != defaultMaxTimeoutSeconds {
+		t.Fatalf("maxTimeoutSeconds = %d, want %d", payment.requirements.MaxTimeoutSeconds, defaultMaxTimeoutSeconds)
+	}
+	if got := payment.requirements.Extra["asset"]; got != "wCSPR" {
+		t.Fatalf("extra asset = %v, want wCSPR", got)
+	}
+	if got := payment.payment.NetworkName; got != "Casper Testnet" {
+		t.Fatalf("network name = %q, want %q", got, "Casper Testnet")
+	}
+	if payment.facilitator == nil {
+		t.Fatal("facilitator is nil")
+	}
+}
+
+func TestNewCasperPaymentErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		payment types.X402Payment
+	}{
+		{
+			name:    "unsupported network",
+			payment: types.X402Payment{Network: "casper:nope", Asset: testWCSPRAsset, PayTo: "01ab", Amount: "1"},
+		},
+		{
+			name:    "missing asset",
+			payment: types.X402Payment{Network: CasperMainnetNetwork, PayTo: "01ab", Amount: "1"},
+		},
+		{
+			name:    "missing pay to",
+			payment: types.X402Payment{Network: CasperMainnetNetwork, Asset: testWCSPRAsset, Amount: "1"},
+		},
+		{
+			name:    "invalid amount",
+			payment: types.X402Payment{Network: CasperMainnetNetwork, Asset: testWCSPRAsset, PayTo: "01ab", Amount: "-1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewCasperPayment(tt.payment); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}
+
+func TestCasperFacilitatorSupported(t *testing.T) {
+	facilitator, err := newCasperFacilitator(CasperMainnetNetwork)
+	if err != nil {
+		t.Fatalf("newCasperFacilitator: %v", err)
+	}
+	supported := facilitator.Supported()
+	if len(supported.Kinds) != 1 {
+		t.Fatalf("kinds = %d, want 1", len(supported.Kinds))
+	}
+	kind := supported.Kinds[0]
+	if kind.Network != CasperMainnetNetwork {
+		t.Fatalf("kind network = %q, want %q", kind.Network, CasperMainnetNetwork)
+	}
+	if kind.Scheme != string(facilitatortypes.Exact) {
+		t.Fatalf("kind scheme = %q, want %q", kind.Scheme, facilitatortypes.Exact)
+	}
+	if kind.X402Version != int(facilitatortypes.X402VersionV2) {
+		t.Fatalf("kind x402Version = %d, want %d", kind.X402Version, facilitatortypes.X402VersionV2)
+	}
+}
+
+func TestCasperFacilitatorSettle(t *testing.T) {
+	var got facilitatortypes.PaymentSettleRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/settle" {
+			t.Errorf("path = %q, want /settle", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode settle request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(facilitatortypes.PaymentSettleResponse{
+			Success:     true,
+			Payer:       "01a1b2c3",
+			Transaction: "5f0e1d2c",
+			Network:     facilitatortypes.Network(CasperTestnetNetwork),
+		})
+	}))
+	defer server.Close()
+
+	payment, err := NewCasperPayment(types.X402Payment{
+		Testnet:   true,
+		Asset:     testWCSPRAsset,
+		PayTo:     "account-hash-abc123",
+		Amount:    "0.01",
+		Endpoints: []string{server.URL},
+	})
+	if err != nil {
+		t.Fatalf("NewCasperPayment: %v", err)
+	}
+
+	settled, err := payment.facilitator.Settle(context.Background(), &facilitatortypes.PaymentPayload{
+		X402Version: int(facilitatortypes.X402VersionV2),
+		Payload:     map[string]interface{}{"signature": "deadbeef"},
+		Accepted:    payment.requirements,
+	}, &payment.requirements)
+	if err != nil {
+		t.Fatalf("Settle: %v", err)
+	}
+	if !settled.Success {
+		t.Fatalf("settle success = false, error %q", settled.ErrorMessage)
+	}
+	if settled.Transaction != "5f0e1d2c" {
+		t.Fatalf("transaction = %q, want %q", settled.Transaction, "5f0e1d2c")
+	}
+	if got.PaymentRequirements.Amount != "10000000" {
+		t.Fatalf("settled amount = %q, want %q", got.PaymentRequirements.Amount, "10000000")
+	}
+	if got.PaymentRequirements.Network != CasperTestnetNetwork {
+		t.Fatalf("settled network = %q, want %q", got.PaymentRequirements.Network, CasperTestnetNetwork)
+	}
+}
+
+func TestCasperFacilitatorVerifyRejects(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(facilitatortypes.PaymentVerifyResponse{
+			IsValid:        false,
+			InvalidReason:  "insufficient_balance",
+			InvalidMessage: "payer wCSPR balance is too low",
+		})
+	}))
+	defer server.Close()
+
+	facilitator, err := newCasperFacilitator(CasperTestnetNetwork, server.URL)
+	if err != nil {
+		t.Fatalf("newCasperFacilitator: %v", err)
+	}
+	requirements := facilitatortypes.PaymentRequirements{
+		Scheme:  string(facilitatortypes.Exact),
+		Network: CasperTestnetNetwork,
+		Asset:   testWCSPRAsset,
+		Amount:  "10000000",
+		PayTo:   "account-hash-abc123",
+	}
+	verified, err := facilitator.Verify(context.Background(), &facilitatortypes.PaymentPayload{
+		X402Version: int(facilitatortypes.X402VersionV2),
+		Accepted:    requirements,
+	}, &requirements)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if verified.IsValid {
+		t.Fatal("verify isValid = true, want false")
+	}
+	if verified.InvalidReason != "insufficient_balance" {
+		t.Fatalf("invalidReason = %q, want %q", verified.InvalidReason, "insufficient_balance")
+	}
+}
+
+func TestCasperFacilitatorNilArgs(t *testing.T) {
+	facilitator, err := newCasperFacilitator(CasperMainnetNetwork)
+	if err != nil {
+		t.Fatalf("newCasperFacilitator: %v", err)
+	}
+	if _, err := facilitator.Verify(context.Background(), nil, nil); err == nil {
+		t.Fatal("Verify(nil, nil) expected an error")
+	}
+	if _, err := facilitator.Settle(context.Background(), nil, nil); err == nil {
+		t.Fatal("Settle(nil, nil) expected an error")
+	}
+}

--- a/portal/x402/payment.go
+++ b/portal/x402/payment.go
@@ -268,6 +268,13 @@ func (p *Payment) WritePrepare(w http.ResponseWriter, r *http.Request, sender, r
 	}
 	defer cancel()
 
+	if IsCasperNetwork(p.requirements.Network) {
+		// Casper payments are signed by the wallet against the published
+		// requirements, so there is no server-built transaction to prepare.
+		p.writePaymentRequired(w, r, "payment required")
+		return
+	}
+
 	sender = suischeme.NormalizeAddress(sender)
 	if sender == "" {
 		http.Error(w, "sender is required", http.StatusBadRequest)


### PR DESCRIPTION
## Summary

Adds Casper as an x402 payment network alongside the existing Sui USDC support, using wCSPR (CEP-18) as the settlement asset.

The Sui path stays exactly as it is. Casper is added as a sibling network in `portal/x402`, following the same shape: network constants, amount conversion helpers, address normalization, and a `facilitator.Facilitator` implementation that `Payment` drives through the unchanged `Settle`/`writePaymentRequired` flow.

## What's included

- `portal/x402/casper.go`
  - `casper:casper` / `casper:casper-test` CAIP-2 network identifiers.
  - `CSPRAmountToAtomic` / `FormatCSPRAtomicAmount` for the 9-decimal motes precision shared by CSPR and wCSPR (mirrors the 6-decimal USDC helpers).
  - `NormalizeCasperAddress` for account hashes and public keys.
  - `casperFacilitator`, a `facilitator.Facilitator` backed by the upstream `api/client` HTTP client. Casper has no Go chain SDK, so `/verify` and `/settle` are delegated to a remote x402 facilitator, defaulting to `https://x402-facilitator.cspr.cloud`. Any endpoint configured on the payment overrides it.
  - `NewCasperPayment`, returning the same `*Payment` the Sui constructor does, so handler, settlement, and 402 response behaviour are shared.
- `portal/x402/payment.go`: `WritePrepare` short-circuits for `casper:*` and returns the 402 requirements. Casper wallets sign against the published requirements, so there is no server-built transaction to hand back. Sui behaviour is untouched.
- Docs: README feature bullet plus a payment-network table in the configuration docs covering asset, decimals, and facilitator per network.

## Notes

- The wCSPR CEP-18 contract hash differs per network deployment, so it is required as the payment `Asset` rather than hardcoded — unlike Sui, where the facilitator carries a gasless-stablecoin allowlist.
- Decimals differ from USDC (9 vs 6); the tests cover the boundary cases explicitly.

## Testing

`go test ./...` is green, `go vet ./...` and `gofmt -l .` are clean.

```
$ go test ./portal/x402/ -v -run TestCasper
=== RUN   TestCasperNetwork
--- PASS: TestCasperNetwork (0.00s)
=== RUN   TestCasperFacilitatorSupported
--- PASS: TestCasperFacilitatorSupported (0.00s)
=== RUN   TestCasperFacilitatorSettle
--- PASS: TestCasperFacilitatorSettle (0.00s)
=== RUN   TestCasperFacilitatorVerifyRejects
--- PASS: TestCasperFacilitatorVerifyRejects (0.00s)
=== RUN   TestCasperFacilitatorNilArgs
--- PASS: TestCasperFacilitatorNilArgs (0.00s)
PASS
ok      github.com/gosuda/portal-tunnel/v2/portal/x402  0.009s
```

New tests in `portal/x402/casper_test.go` are table-driven where the existing suite is, and cover network selection, motes conversion round-trips including the one-mote and over-precision cases, address normalization, payment construction and its error paths, and verify/settle against an `httptest` facilitator asserting the on-wire x402 v2 request shape.
