### PR TITLE
docs: document portal-expose skill install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,15 @@ helper endpoints.
 
 ### Use the local AI agent plugin
 
-The repository includes a local `portal-deploy` plugin for Codex, Claude Code, and Cursor. One shared `portal-expose` skill covers app startup, Portal tunnel selection, public URL verification, and lifecycle handoff. Host-specific plugin manifests and marketplace catalogs stay separate. See [plugins/portal-deploy/README.md](plugins/portal-deploy/README.md).
+The repository includes a `portal-deploy` plugin for Codex, Claude Code, and Cursor. The shared `portal-expose` skill inspects a local app, opens a Portal tunnel, verifies the public URL, and hands off the lifecycle.
+
+Install only that skill:
+
+```bash
+npx skills add gosuda/portal-tunnel --skill portal-expose
+```
+
+Add `-g` to install it for every project. Then ask the agent to deploy, preview, or share a local app with Portal. Host-specific Codex, Claude Code, and Cursor marketplace setup is in [plugins/portal-deploy/README.md](plugins/portal-deploy/README.md).
 
 ### Keep tunnels running with Portal Agent
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -98,7 +98,15 @@ portal expose 3000 --multi-hop-depth 3
 
 ### 使用本地 AI agent 插件
 
-仓库提供面向 Codex、Claude Code 和 Cursor 的本地 `portal-deploy` 插件。共用的 `portal-expose` skill 负责应用启动、Portal 隧道选择、公网 URL 验证和生命周期交接。各宿主的 plugin manifest 与 marketplace catalog 分开存放。详见 [plugins/portal-deploy/README.md](plugins/portal-deploy/README.md)。
+仓库提供面向 Codex、Claude Code 和 Cursor 的 `portal-deploy` 插件。共用的 `portal-expose` skill 会检查本地应用、打开 Portal 隧道、验证公网 URL，并交接生命周期。
+
+只安装该 skill：
+
+```bash
+npx skills add gosuda/portal-tunnel --skill portal-expose
+```
+
+加上 `-g` 可安装到所有项目。然后让 agent 用 Portal 部署、预览或分享本地应用。Codex、Claude Code 和 Cursor 的宿主 marketplace 安装步骤见 [plugins/portal-deploy/README.md](plugins/portal-deploy/README.md)。
 
 ### 使用 Portal Agent 持续运行隧道
 


### PR DESCRIPTION
## Summary
- Add the `npx skills add gosuda/portal-tunnel --skill portal-expose` install command to Quick Start.
- Keep host-specific Codex, Claude Code, and Cursor marketplace steps in `plugins/portal-deploy/README.md`.

## Test plan
- [ ] Confirm the English and Chinese Quick Start sections show the same install command.
- [ ] Confirm `--skill portal-expose` is required so contributor skills are not installed by default.