### PR TITLE
feat(portal-expose): add game server hosting reference

### DIFF
--- a/docs/src/routes/configuration/+page.md
+++ b/docs/src/routes/configuration/+page.md
@@ -63,6 +63,8 @@ The relay server (`relay-server`) reads configuration from environment variables
 
 ### Embedded DNS
 
+> This section is the canonical reference for embedded DNS configuration. The deployment and self-hosting guides link here rather than restating the details.
+
 Serves the relay base domain from an authoritative DNS server embedded in the relay process, so no DNS provider API credentials are required. It is the default provider when `ACME_DNS_PROVIDER` is unset. Delegate the base domain once at the parent zone (`NS portal.example.com -> ns.portal.example.com` with glue `A` pointing at the relay public IP) and open `53/tcp` + `53/udp`. Containers running without root need `CAP_NET_BIND_SERVICE` to bind the default port. A answers for the apex and every covered name are synthesized from the relay public IPv4; ACME DNS-01 TXT and tunnel ECH HTTPS records are served directly. ENS gasless automation (zone DNSSEC) is not supported yet.
 
 | Variable | Default | Type | Description |

--- a/docs/src/routes/deployment/+page.md
+++ b/docs/src/routes/deployment/+page.md
@@ -31,7 +31,7 @@ SNI router.
 
 - A public Linux server with Docker and Docker Compose.
 - A public hostname such as `portal.example.com`.
-- A one-time NS delegation at the parent zone: `NS portal.example.com -> ns.portal.example.com` with a glue `A` record pointing at the relay public IP.
+- A one-time NS delegation at the parent zone: `NS portal.example.com -> ns.portal.example.com` with a glue `A` record pointing at the relay public IP. See the [Configuration Reference](/configuration#embedded-dns) for the canonical embedded DNS details.
 - Inbound `443/tcp`, `53/tcp` + `53/udp` for the embedded authoritative DNS, and `51820/udp` when the overlay is enabled.
 - Certificates for the root and wildcard names are issued automatically via ACME DNS-01 against the embedded authoritative DNS.
 

--- a/docs/src/routes/game-server-hosting/+page.md
+++ b/docs/src/routes/game-server-hosting/+page.md
@@ -5,6 +5,8 @@ description: Expose self-hosted game servers through Portal without opening port
 
 # Game Server Hosting
 
+> **Maintainer note**: the compatibility table and relay-setup facts on this page are mirrored in the agent skill reference at `plugins/portal-deploy/skills/portal-expose/references/game-hosting.md`. When transport capabilities change, update both files. This page is the human-facing source; the reference is the agent-facing copy.
+
 Portal exposes a game server running on your own machine through a public relay.
 Players connect to the relay's assigned `host:port`; they do not install Portal.
 

--- a/docs/src/routes/self-hosting/+page.md
+++ b/docs/src/routes/self-hosting/+page.md
@@ -132,6 +132,8 @@ portal-relay localhost:3000
 
 ## DNS Configuration
 
+> The [Configuration Reference](/configuration#embedded-dns) is the canonical source for embedded DNS settings. This section summarizes the delegation step only.
+
 The relay serves DNS for its own subdomains from the embedded authoritative
 server (`relay.example.com` and every name under it, including tunnel
 hostnames). Delegate the zone to the relay once from your existing DNS

--- a/plugins/portal-deploy/skills/portal-expose/SKILL.md
+++ b/plugins/portal-deploy/skills/portal-expose/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 
 Portal publishes a service that is already running on the user's machine. It does not build the app or move it to a cloud host. Treat a successful tunnel as dependent on both the local app and the Portal process or agent remaining available.
 
-Read `references/portal-cli.md` when choosing commands or persistent-agent configuration. Read `references/x402.md` whenever the user requests x402 or a paid route. Read `references/safety-and-verification.md` before exposing a nontrivial project, a service with authentication, or any non-HTTP port.
+Read `references/portal-cli.md` when choosing commands or persistent-agent configuration. Read `references/x402.md` whenever the user requests x402 or a paid route. Read `references/safety-and-verification.md` before exposing a nontrivial project, a service with authentication, or any non-HTTP port. Read `references/game-hosting.md` whenever the user asks to host, publish, or share a game server — it covers game-specific ports, protocol identification, relay raw-transport prerequisites, and raw-endpoint verification.
 
 ## Choose the Mode
 
@@ -20,7 +20,7 @@ Use the smallest mode that satisfies the request:
 - Paid HTTP path: routed HTTP with an explicit x402 payment contract; never enable payment implicitly.
 - Durable tunnel that should survive terminal or login restarts: an explicit `portal agent` config and managed service.
 - Session-owned durable tunnel without an OS service: `portal agent run --foreground`.
-- Raw TCP or UDP: only when the user explicitly requests that transport and names the target.
+- Game server (Minecraft, Terraria, Palworld, or any dedicated game server): always start from `references/game-hosting.md` — raw TCP/UDP transport has different prerequisites and verification than HTTP.
 
 Default to a temporary preview when the user says only "share", "preview", or "deploy locally". Do not install an OS service unless the user asks for a persistent, managed, or restart-surviving tunnel and accepts that `portal agent run` without `--foreground` installs a per-user launchd or systemd unit.
 

--- a/plugins/portal-deploy/skills/portal-expose/references/game-hosting.md
+++ b/plugins/portal-deploy/skills/portal-expose/references/game-hosting.md
@@ -1,0 +1,74 @@
+# Game Server Hosting Reference
+
+Read this when the user asks to host, publish, or share a game server (Minecraft, Terraria, Palworld, Valheim, Rust, or any game with a dedicated server). Game hosting uses Portal's raw TCP/UDP transport, not HTTP — the workflow, prerequisites, and verification differ fundamentally from web exposure.
+
+## Game quick-reference
+
+| Game | Transport | Ports | Status | Notes |
+|---|---|---|---|---|
+| Minecraft Java | TCP | 25565 | Tested | Single TCP port. |
+| Minecraft Bedrock | UDP | 19132 | Compatible | Single UDP port. |
+| Terraria | TCP | 7777 | Compatible | Single TCP port. |
+| Palworld | UDP | 8211 | Experimental | Verify real gameplay before sharing. |
+| Valheim | UDP pair | 2456–2457 | Not supported | Requires a base port and the next; Portal allocates one UDP port per lease. |
+| Rust | UDP game + query | separate | Not supported | Requires separate public game and query ports. |
+| Custom | Ask user | user-specified | — | Identify the protocol (TCP or UDP) and every port before exposing. |
+
+## Hard rule: the relay must support raw transport
+
+Game hosting fails silently if the relay does not have TCP/UDP allocation enabled. Most public relays do **not** — check before promising the user anything:
+
+- Relay must set `TCP_ENABLED` and/or `UDP_ENABLED` with a `MIN_PORT`–`MAX_PORT` range.
+- The relay must publish those ports (`MIN_PORT-MAX_PORT:MIN_PORT-MAX_PORT/tcp` and `/udp` in its compose).
+- The relay's cloud firewall must allow the same ports.
+
+If no participating relay has raw transport enabled, tell the user they need a relay that does (self-hosted relay with TCP/UDP enabled, or a community relay that supports it). Do not attempt the tunnel — it will fail without a clear error.
+
+## Workflow
+
+### 1. Identify the game and its requirements
+
+Look up the game in the table above, or ask the user for the protocol and port(s). If the game needs multiple related UDP ports (Valheim, Rust), report that Portal cannot support it yet rather than partially exposing.
+
+### 2. Check relay support
+
+Confirm the chosen relay (or relay pool) has the needed transport enabled. `portal expose` with `--tcp` or `--udp` will fail or hang if the relay cannot allocate a port.
+
+### 3. Start the local game server
+
+The game server must be running and listening on its expected port before the tunnel opens. Verify with a local connection (e.g., `nc -z 127.0.0.1 25565` for TCP, or a protocol-appropriate UDP probe).
+
+### 4. Expose with the correct transport
+
+```sh
+portal expose <game-port> --udp --name <name>
+```
+
+or for TCP:
+
+```sh
+portal expose <game-port> --tcp --name <name>
+```
+
+Game servers are long-lived — recommend the persistent agent config for anything beyond a one-off session.
+
+### 5. Verify the raw transport endpoint
+
+Unlike HTTP tunnels, raw transports log `raw transport endpoints allocated` with `tcp_addr` and/or `udp_addr` — **not** a `service ready at <URL>` line. Do not wait for an HTTPS URL.
+
+Verify by connecting through the public endpoint:
+- TCP: attempt a connection to the `tcp_addr` (e.g., `nc -z <host> <port>`)
+- UDP: send a protocol-appropriate packet and expect a response (game-dependent; a no-response UDP probe proves nothing)
+
+A successful local port check is not sufficient — verify through the public endpoint.
+
+### 6. Hand off
+
+Report: the `tcp_addr` or `udp_addr` for players to connect to, which game and version is hosted, and the tunnel lifecycle (persistent agent or foreground). Players connect directly to `host:port` — they do not install Portal.
+
+## Failure rules
+
+- Game needs a port group Portal cannot allocate: report the limitation, do not partially expose.
+- No relay with raw transport available: report before attempting, suggest a self-hosted relay.
+- Public endpoint unreachable while local game server works: check the relay's port publishing and firewall first.
+- UDP probe gets no response: some game servers do not respond to empty probes — try connecting with the actual game client before declaring failure.

--- a/plugins/portal-deploy/skills/portal-expose/references/game-hosting.md
+++ b/plugins/portal-deploy/skills/portal-expose/references/game-hosting.md
@@ -2,6 +2,8 @@
 
 Read this when the user asks to host, publish, or share a game server (Minecraft, Terraria, Palworld, Valheim, Rust, or any game with a dedicated server). Game hosting uses Portal's raw TCP/UDP transport, not HTTP — the workflow, prerequisites, and verification differ fundamentally from web exposure.
 
+> **Sync notice**: the compatibility table and relay-setup facts in this file mirror `docs/src/routes/game-server-hosting/+page.md`. When Portal's transport capabilities change (new game support, multi-port allocation, etc.), update both files together. The docs page is the human-facing source; this reference is the agent-facing copy.
+
 ## Game quick-reference
 
 | Game | Transport | Ports | Status | Notes |


### PR DESCRIPTION
Game hosting (Minecraft, Terraria, Palwood, etc.) is a top use case for raw TCP/UDP tunneling, but the current skill treats TCP/UDP as a generic afterthought ("only when the user explicitly requests"). When a user says "host my Minecraft server", the agent has no game-specific knowledge to work from.

## What this adds

**`references/game-hosting.md`** — the agent reads this when a game server request is detected:

- **Per-game port/protocol table**: Minecraft Java (TCP 25565), Bedrock (UDP 19132), Terraria (TCP 7777), Palworld (UDP 8211), Valheim/Rust (explicitly not supported — Portal allocates one port per lease, these games need port groups)
- **Relay raw-transport prerequisite**: most public relays do not have `TCP_ENABLED`/`UDP_ENABLED` with a lease range — the agent checks before promising anything, rather than failing silently
- **Raw-endpoint verification**: `tcp_addr`/`udp_addr` in logs (not `service ready at <URL>`), TCP probe via `nc -z`, UDP probe with protocol-appropriate caveats
- **Player handoff**: players connect to `host:port` directly, no Portal install needed
- **Failure rules**: multi-port games screened upfront, relay capacity checked before attempting, UDP no-response caveats

**`SKILL.md`** — two additions:
1. Reference routing line in the docs paragraph (game server → read game-hosting.md)
2. A game-server branch in the mode chooser that routes to the reference before any tunnel command is built

## Design decisions

- **Reference file, not a new skill**: game hosting is still "expose a service" — a separate skill would create description overlap and selection ambiguity with portal-expose. The reference pattern (portal-cli.md, x400.md, safety-and-verification.md) is the established mechanism.
- **Content mirrors the docs page**: `docs/src/routes/game-server-hosting` already has this knowledge for humans; this reference makes it agent-readable and actionable.
- **Compatibility table is explicit about gaps**: Valheim and Rust are listed as "not supported" rather than omitted, so the agent can tell the user *why* instead of partially exposing and failing.

Closes the gap identified in community discussions (game hosting is a recurring topic in relay user communities).