### PR TITLE
fix: separate unverified relay admission from trusted discovery

### DIFF
--- a/portal/api_server.go
+++ b/portal/api_server.go
@@ -429,7 +429,9 @@ func (s *Server) handleHop(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if !s.announceLimiter.Allow(clientIP) {
+	// Only the mutating POST consumes the announce budget: DELETE performs
+	// route and DNS cleanup only and must stay available after a POST burst.
+	if r.Method == http.MethodPost && !s.announceLimiter.Allow(clientIP) {
 		utils.WriteAPIError(w, http.StatusTooManyRequests, types.APIErrorCodeRateLimited, "hop route rate limit exceeded")
 		return
 	}
@@ -480,7 +482,7 @@ func (s *Server) handleHop(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	route.ForwardRelay = forwardRelay
-	if err := s.relaySet.InsertAnnounced(forwardRelay, now); err != nil {
+	if err := s.relaySet.InsertHopRelay(forwardRelay, now); err != nil {
 		utils.InvalidRequestError(fmt.Errorf("forward relay: %w", err)).Write(w)
 		return
 	}

--- a/portal/api_server.go
+++ b/portal/api_server.go
@@ -229,7 +229,7 @@ func (s *Server) handleRelayDiscoveryAnnounce(w http.ResponseWriter, r *http.Req
 	}
 
 	now := time.Now().UTC()
-	if err := s.relaySet.InsertAnnounced(desc, now); err != nil {
+	if err := s.relaySet.InsertCandidate(desc, now); err != nil {
 		utils.WriteAPIError(w, http.StatusBadRequest, types.APIErrorCodeInvalidRequest, err.Error())
 		return
 	}
@@ -482,7 +482,7 @@ func (s *Server) handleHop(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	route.ForwardRelay = forwardRelay
-	if err := s.relaySet.InsertHopRelay(forwardRelay, now); err != nil {
+	if err := s.relaySet.InsertCandidate(forwardRelay, now); err != nil {
 		utils.InvalidRequestError(fmt.Errorf("forward relay: %w", err)).Write(w)
 		return
 	}

--- a/portal/api_server.go
+++ b/portal/api_server.go
@@ -425,11 +425,16 @@ func (s *Server) handleHop(w http.ResponseWriter, r *http.Request) {
 		utils.MethodNotAllowedError().Write(w)
 		return
 	}
-	if s.overlay == nil || s.relaySet == nil {
-		utils.WriteAPIError(w, http.StatusServiceUnavailable, types.APIErrorCodeFeatureUnavailable, errFeatureUnavailable.Error())
+	clientIP, ok := s.extractAllowedClientIP(w, r)
+	if !ok {
 		return
 	}
-	if _, ok := s.extractAllowedClientIP(w, r); !ok {
+	if !s.announceLimiter.Allow(clientIP) {
+		utils.WriteAPIError(w, http.StatusTooManyRequests, types.APIErrorCodeRateLimited, "hop route rate limit exceeded")
+		return
+	}
+	if s.overlay == nil || s.relaySet == nil {
+		utils.WriteAPIError(w, http.StatusServiceUnavailable, types.APIErrorCodeFeatureUnavailable, errFeatureUnavailable.Error())
 		return
 	}
 

--- a/portal/discovery/announce_test.go
+++ b/portal/discovery/announce_test.go
@@ -51,52 +51,52 @@ func mustSignedDescriptor(t *testing.T, signing types.Identity, relayURL string,
 	return signed
 }
 
-func TestInsertAnnouncedAcceptsValidDescriptor(t *testing.T) {
+func TestInsertCandidateAcceptsValidDescriptor(t *testing.T) {
 	set := NewRelaySet(nil)
 	signing := mustSigningIdentity(t)
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	desc := mustSignedDescriptor(t, signing, "https://relay-ann.example", now)
-	if err := set.InsertAnnounced(desc, now); err != nil {
-		t.Fatalf("InsertAnnounced() error = %v", err)
+	if err := set.InsertCandidate(desc, now); err != nil {
+		t.Fatalf("InsertCandidate() error = %v", err)
 	}
 	if got := relayStates(set); len(got) != 1 {
 		t.Fatalf("len(relayStates()) = %d, want 1", len(got))
 	}
 }
 
-func TestInsertAnnouncedRejectsUnsigned(t *testing.T) {
+func TestInsertCandidateRejectsUnsigned(t *testing.T) {
 	set := NewRelaySet(nil)
 	signing := mustSigningIdentity(t)
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	desc := mustUnsignedDescriptor(t, signing, "https://relay-unsigned.example")
-	err := set.InsertAnnounced(desc, now)
+	err := set.InsertCandidate(desc, now)
 	if err == nil || err.Error() != "relay descriptor is not signed" {
-		t.Fatalf("InsertAnnounced() error = %v, want unsigned descriptor error", err)
+		t.Fatalf("InsertCandidate() error = %v, want unsigned descriptor error", err)
 	}
 }
 
-func TestInsertAnnouncedRejectsExpired(t *testing.T) {
+func TestInsertCandidateRejectsExpired(t *testing.T) {
 	set := NewRelaySet(nil)
 	signing := mustSigningIdentity(t)
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	desc := mustSignedDescriptor(t, signing, "https://relay-expired.example", now.Add(-DiscoveryDescriptorTTL-time.Second))
-	err := set.InsertAnnounced(desc, now)
+	err := set.InsertCandidate(desc, now)
 	if err == nil || err.Error() != "relay descriptor already expired" {
-		t.Fatalf("InsertAnnounced() error = %v, want expired descriptor error", err)
+		t.Fatalf("InsertCandidate() error = %v, want expired descriptor error", err)
 	}
 }
 
-func TestInsertAnnouncedIgnoresSupersededRollback(t *testing.T) {
+func TestInsertCandidateIgnoresSupersededRollback(t *testing.T) {
 	set := NewRelaySet(nil)
 	signing := mustSigningIdentity(t)
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	relayURL := "https://relay-roll.example"
 	newer := mustSignedDescriptor(t, signing, relayURL, now)
-	if err := set.InsertAnnounced(newer, now); err != nil {
+	if err := set.InsertCandidate(newer, now); err != nil {
 		t.Fatalf("seed insert error = %v", err)
 	}
 	older := mustSignedDescriptor(t, signing, relayURL, now.Add(-time.Minute))
-	if err := set.InsertAnnounced(older, now); err != nil {
+	if err := set.InsertCandidate(older, now); err != nil {
 		t.Fatalf("superseded insert error = %v", err)
 	}
 
@@ -109,21 +109,21 @@ func TestInsertAnnouncedIgnoresSupersededRollback(t *testing.T) {
 	}
 }
 
-func TestInsertAnnouncedRejectsRollbackAcrossRelayURL(t *testing.T) {
+func TestInsertCandidateRejectsRollbackAcrossRelayURL(t *testing.T) {
 	set := NewRelaySet(nil)
 	signing := mustSigningIdentity(t)
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	newer := mustSignedDescriptor(t, signing, "https://relay-roll-new.example", now)
-	if err := set.InsertAnnounced(newer, now); err != nil {
+	if err := set.InsertCandidate(newer, now); err != nil {
 		t.Fatalf("seed insert error = %v", err)
 	}
 	older := mustSignedDescriptor(t, signing, "https://relay-roll-old.example", now.Add(-time.Minute))
-	if err := set.InsertAnnounced(older, now); err == nil {
+	if err := set.InsertCandidate(older, now); err == nil {
 		t.Fatal("expected rollback reject")
 	}
 }
 
-func TestInsertAnnouncedBlocksCrossIdentityTakeover(t *testing.T) {
+func TestInsertCandidateBlocksCrossIdentityTakeover(t *testing.T) {
 	set := NewRelaySet(nil)
 	owner := mustSigningIdentity(t)
 	attacker := mustSigningIdentity(t)
@@ -131,12 +131,12 @@ func TestInsertAnnouncedBlocksCrossIdentityTakeover(t *testing.T) {
 	relayURL := "https://relay-takeover.example"
 
 	ownerDesc := mustSignedDescriptor(t, owner, relayURL, now)
-	if err := set.InsertAnnounced(ownerDesc, now); err != nil {
+	if err := set.InsertCandidate(ownerDesc, now); err != nil {
 		t.Fatalf("owner insert error = %v", err)
 	}
 
 	attackerDesc := mustSignedDescriptor(t, attacker, relayURL, now.Add(time.Second))
-	if err := set.InsertAnnounced(attackerDesc, now); err == nil {
+	if err := set.InsertCandidate(attackerDesc, now); err == nil {
 		t.Fatal("expected takeover reject")
 	}
 
@@ -164,13 +164,13 @@ func TestAnnounceLimiterAllowsBurstThenThrottles(t *testing.T) {
 	}
 }
 
-func TestInsertAnnouncedCapsFloodPerSigningIdentity(t *testing.T) {
+func TestInsertCandidateCapsFloodPerSigningIdentity(t *testing.T) {
 	set := NewRelaySet(nil)
 	legit := mustSigningIdentity(t)
 	attacker := mustSigningIdentity(t)
 	now := time.Now().UTC().Truncate(time.Microsecond)
 
-	if err := set.InsertAnnounced(mustSignedDescriptor(t, legit, "https://legit.example", now), now); err != nil {
+	if err := set.InsertCandidate(mustSignedDescriptor(t, legit, "https://legit.example", now), now); err != nil {
 		t.Fatalf("legit insert error = %v", err)
 	}
 	// Flood the pool the way the reported abuse does: one signing identity
@@ -178,7 +178,7 @@ func TestInsertAnnouncedCapsFloodPerSigningIdentity(t *testing.T) {
 	for i := range MaxAnnouncedRelays {
 		at := now.Add(time.Duration(i) * time.Second)
 		url := fmt.Sprintf("https://attacker-%04d.example", i)
-		if err := set.InsertAnnounced(mustSignedDescriptor(t, attacker, url, at), at); err != nil {
+		if err := set.InsertCandidate(mustSignedDescriptor(t, attacker, url, at), at); err != nil {
 			t.Fatalf("flood insert %d error = %v", i, err)
 		}
 	}
@@ -200,7 +200,7 @@ func TestInsertAnnouncedCapsFloodPerSigningIdentity(t *testing.T) {
 	}
 }
 
-func TestInsertAnnouncedPerIdentityCapKeepsConfirmedEntries(t *testing.T) {
+func TestInsertCandidatePerIdentityCapKeepsConfirmedEntries(t *testing.T) {
 	set := NewRelaySet(nil)
 	owner := mustSigningIdentity(t)
 	now := time.Now().UTC().Truncate(time.Microsecond)
@@ -214,7 +214,7 @@ func TestInsertAnnouncedPerIdentityCapKeepsConfirmedEntries(t *testing.T) {
 	for i := range MaxAnnouncedRelaysPerIdentity * 2 {
 		at := now.Add(time.Duration(i) * time.Second)
 		url := fmt.Sprintf("https://owner-%02d.example", i)
-		if err := set.InsertAnnounced(mustSignedDescriptor(t, owner, url, at), at); err != nil {
+		if err := set.InsertCandidate(mustSignedDescriptor(t, owner, url, at), at); err != nil {
 			t.Fatalf("insert %d error = %v", i, err)
 		}
 	}
@@ -247,18 +247,19 @@ func mustSignedOverlayDescriptor(t *testing.T, signing types.Identity, relayURL 
 	return signed
 }
 
-func TestInsertHopRelayStagesUntilConfirmed(t *testing.T) {
+func TestInsertCandidateHiddenUntilDirectProbe(t *testing.T) {
 	set := NewRelaySet(nil)
 	signing := mustSigningIdentity(t)
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	relayURL := "https://hop-forward.example"
+	descriptor := mustSignedOverlayDescriptor(t, signing, relayURL, now)
 
-	if err := set.InsertHopRelay(mustSignedOverlayDescriptor(t, signing, relayURL, now), now); err != nil {
-		t.Fatalf("InsertHopRelay() error = %v", err)
+	if err := set.InsertCandidate(descriptor, now); err != nil {
+		t.Fatalf("InsertCandidate() error = %v", err)
 	}
 	for _, desc := range set.Descriptors(types.RelayDescriptor{}) {
 		if desc.APIHTTPSAddr == relayURL {
-			t.Fatal("staged hop relay must stay out of Descriptors() until confirmed")
+			t.Fatal("candidate relay must stay out of Descriptors() until directly probed")
 		}
 	}
 	overlayPeer := false
@@ -268,10 +269,18 @@ func TestInsertHopRelayStagesUntilConfirmed(t *testing.T) {
 		}
 	}
 	if !overlayPeer {
-		t.Fatal("staged hop relay must remain an overlay peer for its hop route")
+		t.Fatal("candidate relay must remain an overlay peer for its hop route")
 	}
 
-	set.ConfirmRelayURL(relayURL)
+	// The real promotion path: the refresher polls the relay itself and
+	// ApplyRelayDiscoveryResponse verifies the target's own descriptor.
+	if _, err := set.ApplyRelayDiscoveryResponse(relayURL, types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion,
+		GeneratedAt:     now,
+		Relays:          []types.RelayDescriptor{descriptor},
+	}, now); err != nil {
+		t.Fatalf("ApplyRelayDiscoveryResponse() error = %v", err)
+	}
 	discovered := false
 	for _, desc := range set.Descriptors(types.RelayDescriptor{}) {
 		if desc.APIHTTPSAddr == relayURL {
@@ -279,28 +288,27 @@ func TestInsertHopRelayStagesUntilConfirmed(t *testing.T) {
 		}
 	}
 	if !discovered {
-		t.Fatal("confirmed hop relay must appear in Descriptors()")
+		t.Fatal("directly probed relay must appear in Descriptors()")
 	}
 }
 
-func TestFilterCandidatePoolExcludesStagedUntilConfirmed(t *testing.T) {
+func TestFilterCandidatePoolExcludesCandidatesUntilVerified(t *testing.T) {
 	signing := mustSigningIdentity(t)
 	other := mustSigningIdentity(t)
 	now := time.Now().UTC().Truncate(time.Microsecond)
-	staged := RelayState{
-		Descriptor: mustSignedOverlayDescriptor(t, signing, "https://staged.example", now),
-		Staged:     true,
+	candidate := RelayState{
+		Descriptor: mustSignedOverlayDescriptor(t, signing, "https://candidate.example", now),
 		LastSeenAt: now,
 	}
-	confirmed := RelayState{
-		Descriptor: mustSignedDescriptor(t, other, "https://confirmed-candidate.example", now),
-		Confirmed:  true,
+	verified := RelayState{
+		Descriptor: mustSignedDescriptor(t, other, "https://verified-candidate.example", now),
+		Trust:      RelayVerified,
 		LastSeenAt: now,
 	}
 
-	pool := filterCandidatePool([]RelayState{staged, confirmed}, RouteState{}, now, false)
-	if len(pool) != 1 || pool[0].Descriptor.APIHTTPSAddr != "https://confirmed-candidate.example" {
-		t.Fatalf("filterCandidatePool() = %v, want only the confirmed entry", pool)
+	pool := filterCandidatePool([]RelayState{candidate, verified}, RouteState{}, now, false)
+	if len(pool) != 1 || pool[0].Descriptor.APIHTTPSAddr != "https://verified-candidate.example" {
+		t.Fatalf("filterCandidatePool() = %v, want only the verified entry", pool)
 	}
 }
 
@@ -330,5 +338,127 @@ func TestApplyRelayDiscoveryResponseAppliesIdentityCap(t *testing.T) {
 	}
 	if ingested > MaxAnnouncedRelaysPerIdentity {
 		t.Fatalf("gossip ingested %d entries for one identity, want <= %d", ingested, MaxAnnouncedRelaysPerIdentity)
+	}
+}
+
+func TestApplyRelayDiscoveryResponsePromotesOnlyTarget(t *testing.T) {
+	set := NewRelaySet(nil)
+	source := mustSigningIdentity(t)
+	gossiped := make([]types.Identity, 3)
+	for i := range gossiped {
+		gossiped[i] = mustSigningIdentity(t)
+	}
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	sourceURL := "https://probed-source.example"
+
+	sourceDescriptor := mustSignedDescriptor(t, source, sourceURL, now)
+	relays := []types.RelayDescriptor{sourceDescriptor}
+	for i, identity := range gossiped {
+		url := fmt.Sprintf("https://laundered-%d.example", i)
+		relays = append(relays, mustSignedDescriptor(t, identity, url, now.Add(time.Duration(i)*time.Second)))
+	}
+	if _, err := set.ApplyRelayDiscoveryResponse(sourceURL, types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion,
+		GeneratedAt:     now,
+		Relays:          relays,
+	}, now); err != nil {
+		t.Fatalf("ApplyRelayDiscoveryResponse() error = %v", err)
+	}
+
+	visible := set.Descriptors(types.RelayDescriptor{})
+	if len(visible) != 1 || visible[0].APIHTTPSAddr != sourceURL {
+		t.Fatalf("Descriptors() = %v, want only the directly probed source", visible)
+	}
+
+	// A relay mentioned by the probed source only becomes visible through
+	// its own direct probe.
+	launderedURL := "https://laundered-0.example"
+	launderedDescriptor := relays[1]
+	if _, err := set.ApplyRelayDiscoveryResponse(launderedURL, types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion,
+		GeneratedAt:     now,
+		Relays:          []types.RelayDescriptor{launderedDescriptor},
+	}, now); err != nil {
+		t.Fatalf("ApplyRelayDiscoveryResponse(laundered) error = %v", err)
+	}
+	visible = set.Descriptors(types.RelayDescriptor{})
+	if len(visible) != 2 {
+		t.Fatalf("len(Descriptors()) = %d, want 2 after the second direct probe", len(visible))
+	}
+}
+
+func TestGossipRefreshKeepsVerifiedTrust(t *testing.T) {
+	set := NewRelaySet(nil)
+	signing := mustSigningIdentity(t)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	relayURL := "https://monotone.example"
+	descriptor := mustSignedDescriptor(t, signing, relayURL, now)
+
+	if _, err := set.ApplyRelayDiscoveryResponse(relayURL, types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion,
+		GeneratedAt:     now,
+		Relays:          []types.RelayDescriptor{descriptor},
+	}, now); err != nil {
+		t.Fatalf("ApplyRelayDiscoveryResponse(target) error = %v", err)
+	}
+	refreshed := mustSignedDescriptor(t, signing, relayURL, now.Add(time.Second))
+	if _, err := set.ApplyRelayDiscoveryResponse("", types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion,
+		GeneratedAt:     now.Add(time.Second),
+		Relays:          []types.RelayDescriptor{refreshed},
+	}, now.Add(time.Second)); err != nil {
+		t.Fatalf("ApplyRelayDiscoveryResponse(gossip) error = %v", err)
+	}
+
+	visible := false
+	for _, desc := range set.Descriptors(types.RelayDescriptor{}) {
+		if desc.APIHTTPSAddr == relayURL {
+			visible = true
+		}
+	}
+	if !visible {
+		t.Fatal("gossip refresh must not demote a verified entry")
+	}
+}
+
+func TestGlobalCapEvictsCandidatesBeforeVerified(t *testing.T) {
+	set := NewRelaySet(nil)
+	verified := mustSigningIdentity(t)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	verifiedDescriptor := mustSignedDescriptor(t, verified, "https://verified.example", now)
+	if _, err := set.ApplyRelayDiscoveryResponse("https://verified.example", types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion,
+		GeneratedAt:     now,
+		Relays:          []types.RelayDescriptor{verifiedDescriptor},
+	}, now); err != nil {
+		t.Fatalf("ApplyRelayDiscoveryResponse(verified) error = %v", err)
+	}
+
+	identitiesNeeded := MaxAnnouncedRelays / MaxAnnouncedRelaysPerIdentity
+	inserted := 0
+	for i := 0; i < identitiesNeeded+1 && inserted <= MaxAnnouncedRelays; i++ {
+		identity := mustSigningIdentity(t)
+		for j := 0; j < MaxAnnouncedRelaysPerIdentity && inserted <= MaxAnnouncedRelays; j++ {
+			at := now.Add(time.Duration(inserted) * time.Millisecond)
+			url := fmt.Sprintf("https://flood-%05d.example", inserted)
+			if err := set.InsertCandidate(mustSignedDescriptor(t, identity, url, at), at); err != nil {
+				t.Fatalf("InsertCandidate(%d) error = %v", inserted, err)
+			}
+			inserted++
+		}
+	}
+
+	visible := false
+	for _, desc := range set.Descriptors(types.RelayDescriptor{}) {
+		if desc.APIHTTPSAddr == "https://verified.example" {
+			visible = true
+		}
+	}
+	if !visible {
+		t.Fatal("verified relay must survive a candidate flood filling the global cap")
+	}
+	if got := len(relayStates(set)); got > MaxAnnouncedRelays {
+		t.Fatalf("pool size = %d, want <= %d", got, MaxAnnouncedRelays)
 	}
 }

--- a/portal/discovery/announce_test.go
+++ b/portal/discovery/announce_test.go
@@ -1,6 +1,8 @@
 package discovery
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -159,5 +161,66 @@ func TestAnnounceLimiterAllowsBurstThenThrottles(t *testing.T) {
 	}
 	if !limiter.Allow("10.0.0.2") {
 		t.Fatal("different IP should have its own bucket")
+	}
+}
+
+func TestInsertAnnouncedCapsFloodPerSigningIdentity(t *testing.T) {
+	set := NewRelaySet(nil)
+	legit := mustSigningIdentity(t)
+	attacker := mustSigningIdentity(t)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	if err := set.InsertAnnounced(mustSignedDescriptor(t, legit, "https://legit.example", now), now); err != nil {
+		t.Fatalf("legit insert error = %v", err)
+	}
+	// Flood the pool the way the reported abuse does: one signing identity
+	// announcing MaxAnnouncedRelays distinct URLs with fresh IssuedAt.
+	for i := range MaxAnnouncedRelays {
+		at := now.Add(time.Duration(i) * time.Second)
+		url := fmt.Sprintf("https://attacker-%04d.example", i)
+		if err := set.InsertAnnounced(mustSignedDescriptor(t, attacker, url, at), at); err != nil {
+			t.Fatalf("flood insert %d error = %v", i, err)
+		}
+	}
+
+	var legitEntries, attackerEntries int
+	for _, state := range relayStates(set) {
+		switch strings.ToLower(state.Descriptor.Address) {
+		case strings.ToLower(legit.Address):
+			legitEntries++
+		case strings.ToLower(attacker.Address):
+			attackerEntries++
+		}
+	}
+	if legitEntries != 1 {
+		t.Fatalf("legit entries = %d, want 1 (identity flood must not displace other relays)", legitEntries)
+	}
+	if attackerEntries != MaxAnnouncedRelaysPerIdentity {
+		t.Fatalf("attacker entries = %d, want %d", attackerEntries, MaxAnnouncedRelaysPerIdentity)
+	}
+}
+
+func TestInsertAnnouncedPerIdentityCapKeepsConfirmedEntries(t *testing.T) {
+	set := NewRelaySet(nil)
+	owner := mustSigningIdentity(t)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	confirmedURL := "https://confirmed.example"
+	set.relays[confirmedURL] = RelayState{
+		Descriptor: mustSignedDescriptor(t, owner, confirmedURL, now),
+		Confirmed:  true,
+		LastSeenAt: now,
+	}
+	for i := range MaxAnnouncedRelaysPerIdentity * 2 {
+		at := now.Add(time.Duration(i) * time.Second)
+		url := fmt.Sprintf("https://owner-%02d.example", i)
+		if err := set.InsertAnnounced(mustSignedDescriptor(t, owner, url, at), at); err != nil {
+			t.Fatalf("insert %d error = %v", i, err)
+		}
+	}
+
+	confirmed, ok := set.relays[confirmedURL]
+	if !ok || !confirmed.Confirmed {
+		t.Fatal("listener-confirmed entry must survive the identity cap")
 	}
 }

--- a/portal/discovery/announce_test.go
+++ b/portal/discovery/announce_test.go
@@ -462,3 +462,77 @@ func TestGlobalCapEvictsCandidatesBeforeVerified(t *testing.T) {
 		t.Fatalf("pool size = %d, want <= %d", got, MaxAnnouncedRelays)
 	}
 }
+
+func TestTrustDoesNotTransferAcrossIdentityTakeover(t *testing.T) {
+	set := NewRelaySet(nil)
+	first := mustSigningIdentity(t)
+	attacker := mustSigningIdentity(t)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	relayURL := "https://takeover.example"
+
+	firstDescriptor := mustSignedDescriptor(t, first, relayURL, now)
+	if _, err := set.ApplyRelayDiscoveryResponse(relayURL, types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion,
+		GeneratedAt:     now,
+		Relays:          []types.RelayDescriptor{firstDescriptor},
+	}, now); err != nil {
+		t.Fatalf("ApplyRelayDiscoveryResponse() error = %v", err)
+	}
+
+	// The verified descriptor expires, which opens the URL slot to a
+	// cross-identity takeover.
+	later := now.Add(DiscoveryDescriptorTTL + time.Minute)
+	if err := set.InsertCandidate(mustSignedDescriptor(t, attacker, relayURL, later), later); err != nil {
+		t.Fatalf("InsertCandidate() error = %v", err)
+	}
+
+	state, ok := set.relays[relayURL]
+	if !ok {
+		t.Fatal("replacement descriptor must be stored")
+	}
+	if state.Trust != RelayCandidate {
+		t.Fatalf("trust = %v, want RelayCandidate after a cross-identity takeover", state.Trust)
+	}
+	for _, desc := range set.Descriptors(types.RelayDescriptor{}) {
+		if desc.APIHTTPSAddr == relayURL {
+			t.Fatal("replacement identity must not inherit visibility from the previous identity")
+		}
+	}
+}
+
+func TestBootstrapCandidateDescriptorStaysHidden(t *testing.T) {
+	bootstrapURL := "https://bootstrap.example"
+	set := NewRelaySet([]string{bootstrapURL})
+	attacker := mustSigningIdentity(t)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	if err := set.InsertCandidate(mustSignedDescriptor(t, attacker, bootstrapURL, now), now); err != nil {
+		t.Fatalf("InsertCandidate() error = %v", err)
+	}
+	state, ok := set.relays[bootstrapURL]
+	if !ok || !state.Bootstrap {
+		t.Fatal("bootstrap pin must survive a candidate insert at the same URL")
+	}
+	if state.Trust != RelayCandidate {
+		t.Fatalf("trust = %v, want RelayCandidate for a squatted bootstrap descriptor", state.Trust)
+	}
+	for _, desc := range set.Descriptors(types.RelayDescriptor{}) {
+		if desc.APIHTTPSAddr == bootstrapURL {
+			t.Fatal("candidate descriptor squatted on a bootstrap URL must stay out of Descriptors()")
+		}
+	}
+	if pool := filterCandidatePool([]RelayState{state}, RouteState{}, now, false); len(pool) != 0 {
+		t.Fatalf("filterCandidatePool() = %v, want the squatted bootstrap excluded", pool)
+	}
+
+	// URL-only bootstrap entries keep their single-hop fallback role, but
+	// never join multi-hop paths.
+	urlOnly := newRelayState("https://bootstrap-fallback.example")
+	urlOnly.Bootstrap = true
+	if pool := filterCandidatePool([]RelayState{urlOnly}, RouteState{}, now, false); len(pool) != 1 {
+		t.Fatal("URL-only bootstrap entry must remain a single-hop fallback candidate")
+	}
+	if pool := filterCandidatePool([]RelayState{urlOnly}, RouteState{}, now, true); len(pool) != 0 {
+		t.Fatal("URL-only bootstrap entry must not join multi-hop paths")
+	}
+}

--- a/portal/discovery/announce_test.go
+++ b/portal/discovery/announce_test.go
@@ -224,3 +224,111 @@ func TestInsertAnnouncedPerIdentityCapKeepsConfirmedEntries(t *testing.T) {
 		t.Fatal("listener-confirmed entry must survive the identity cap")
 	}
 }
+
+func mustSignedOverlayDescriptor(t *testing.T, signing types.Identity, relayURL string, issuedAt time.Time) types.RelayDescriptor {
+	t.Helper()
+	authority, err := identity.NewLocalAuthority(signing)
+	if err != nil {
+		t.Fatalf("identity.NewLocalAuthority() error = %v", err)
+	}
+	signed, err := auth.SignRelayDescriptor(types.RelayDescriptor{
+		Address:            signing.Address,
+		Version:            types.DiscoveryVersion,
+		IssuedAt:           issuedAt,
+		ExpiresAt:          issuedAt.Add(DiscoveryDescriptorTTL),
+		APIHTTPSAddr:       relayURL,
+		WireGuardPublicKey: "3dpOqFgLYqlt/5hKsy653evfDxl7PjHUtTXLzcwkqxo=",
+		WireGuardPort:      51820,
+		SupportsOverlay:    true,
+	}, authority)
+	if err != nil {
+		t.Fatalf("SignRelayDescriptor() error = %v", err)
+	}
+	return signed
+}
+
+func TestInsertHopRelayStagesUntilConfirmed(t *testing.T) {
+	set := NewRelaySet(nil)
+	signing := mustSigningIdentity(t)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	relayURL := "https://hop-forward.example"
+
+	if err := set.InsertHopRelay(mustSignedOverlayDescriptor(t, signing, relayURL, now), now); err != nil {
+		t.Fatalf("InsertHopRelay() error = %v", err)
+	}
+	for _, desc := range set.Descriptors(types.RelayDescriptor{}) {
+		if desc.APIHTTPSAddr == relayURL {
+			t.Fatal("staged hop relay must stay out of Descriptors() until confirmed")
+		}
+	}
+	overlayPeer := false
+	for _, desc := range set.OverlayPeerDescriptor() {
+		if desc.APIHTTPSAddr == relayURL {
+			overlayPeer = true
+		}
+	}
+	if !overlayPeer {
+		t.Fatal("staged hop relay must remain an overlay peer for its hop route")
+	}
+
+	set.ConfirmRelayURL(relayURL)
+	discovered := false
+	for _, desc := range set.Descriptors(types.RelayDescriptor{}) {
+		if desc.APIHTTPSAddr == relayURL {
+			discovered = true
+		}
+	}
+	if !discovered {
+		t.Fatal("confirmed hop relay must appear in Descriptors()")
+	}
+}
+
+func TestFilterCandidatePoolExcludesStagedUntilConfirmed(t *testing.T) {
+	signing := mustSigningIdentity(t)
+	other := mustSigningIdentity(t)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	staged := RelayState{
+		Descriptor: mustSignedOverlayDescriptor(t, signing, "https://staged.example", now),
+		Staged:     true,
+		LastSeenAt: now,
+	}
+	confirmed := RelayState{
+		Descriptor: mustSignedDescriptor(t, other, "https://confirmed-candidate.example", now),
+		Confirmed:  true,
+		LastSeenAt: now,
+	}
+
+	pool := filterCandidatePool([]RelayState{staged, confirmed}, RouteState{}, now, false)
+	if len(pool) != 1 || pool[0].Descriptor.APIHTTPSAddr != "https://confirmed-candidate.example" {
+		t.Fatalf("filterCandidatePool() = %v, want only the confirmed entry", pool)
+	}
+}
+
+func TestApplyRelayDiscoveryResponseAppliesIdentityCap(t *testing.T) {
+	set := NewRelaySet(nil)
+	signing := mustSigningIdentity(t)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	relays := make([]types.RelayDescriptor, 0, MaxAnnouncedRelaysPerIdentity*2)
+	for i := range MaxAnnouncedRelaysPerIdentity * 2 {
+		url := fmt.Sprintf("https://gossip-%02d.example", i)
+		relays = append(relays, mustSignedDescriptor(t, signing, url, now.Add(time.Duration(i)*time.Second)))
+	}
+	if _, err := set.ApplyRelayDiscoveryResponse("", types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion,
+		GeneratedAt:     now,
+		Relays:          relays,
+	}, now); err != nil {
+		t.Fatalf("ApplyRelayDiscoveryResponse() error = %v", err)
+	}
+
+	ingested := 0
+	for _, state := range relayStates(set) {
+		if strings.EqualFold(state.Descriptor.Address, signing.Address) {
+			ingested++
+		}
+	}
+	if ingested > MaxAnnouncedRelaysPerIdentity {
+		t.Fatalf("gossip ingested %d entries for one identity, want <= %d", ingested, MaxAnnouncedRelaysPerIdentity)
+	}
+}

--- a/portal/discovery/relayset.go
+++ b/portal/discovery/relayset.go
@@ -920,6 +920,7 @@ func (s *RelaySet) InsertAnnounced(desc types.RelayDescriptor, now time.Time) er
 
 	switch s.upsertDescriptorLocked(record, now, false) {
 	case upsertAccepted:
+		s.enforceIdentityCapLocked(record.Descriptor.Address)
 		s.enforceCapLocked()
 		return nil
 	case upsertIgnored:
@@ -928,6 +929,41 @@ func (s *RelaySet) InsertAnnounced(desc types.RelayDescriptor, now time.Time) er
 		return errors.New("announced descriptor rejected by rollback or takeover guard")
 	}
 	return nil
+}
+
+// enforceIdentityCapLocked bounds how many unverified announced entries a
+// single signing identity holds in the set. Overflow evicts that identity's
+// own oldest entries by LastSeenAt, so a flooding identity recycles its own
+// slots instead of displacing other relays through the global cap. Bootstrap,
+// banned, and listener-confirmed entries are never evicted here; the keyIndex
+// rollback anchors survive eviction by design. The caller MUST already hold
+// s.mu as a write lock.
+func (s *RelaySet) enforceIdentityCapLocked(address string) {
+	address = strings.ToLower(strings.TrimSpace(address))
+	if address == "" {
+		return
+	}
+	type ownedEntry struct {
+		url    string
+		seenAt time.Time
+	}
+	owned := make([]ownedEntry, 0, MaxAnnouncedRelaysPerIdentity+1)
+	for url, state := range s.relays {
+		if state.Bootstrap || state.Banned || state.Confirmed {
+			continue
+		}
+		if strings.ToLower(strings.TrimSpace(state.Descriptor.Address)) != address {
+			continue
+		}
+		owned = append(owned, ownedEntry{url: url, seenAt: state.LastSeenAt})
+	}
+	if len(owned) <= MaxAnnouncedRelaysPerIdentity {
+		return
+	}
+	sort.Slice(owned, func(i, j int) bool { return owned[i].seenAt.Before(owned[j].seenAt) })
+	for _, entry := range owned[:len(owned)-MaxAnnouncedRelaysPerIdentity] {
+		delete(s.relays, entry.url)
+	}
 }
 
 func verifyFreshRelayDescriptor(desc types.RelayDescriptor, now time.Time) (types.RelayDescriptor, error) {

--- a/portal/discovery/relayset.go
+++ b/portal/discovery/relayset.go
@@ -158,6 +158,7 @@ func mergeLocalRelayState(record, existing RelayState) RelayState {
 	record.Confirmed = record.Confirmed || existing.Confirmed
 	record.Banned = record.Banned || existing.Banned
 	record.Dead = record.Dead || existing.Dead
+	record.Staged = record.Staged || existing.Staged
 	if record.discoveryFailures < existing.discoveryFailures {
 		record.discoveryFailures = existing.discoveryFailures
 	}
@@ -260,6 +261,11 @@ func (s *RelaySet) upsertDescriptorLocked(record RelayState, now time.Time, allo
 			TombstoneUntil: tombstoneUntil,
 		}
 	}
+	// Shared untrusted-ingestion invariant: whichever path admitted the
+	// descriptor (announce, hop route, or gossiped discovery response), a
+	// single signing identity never holds more unverified entries than the
+	// per-identity cap. Confirmed entries are never evicted by this cap.
+	s.enforceIdentityCapLocked(address)
 	return upsertAccepted
 }
 
@@ -483,6 +489,9 @@ func filterCandidatePool(states []RelayState, routeState RouteState, now time.Ti
 	pool := make([]RelayState, 0, len(states))
 	for _, state := range states {
 		relayURL := state.Descriptor.APIHTTPSAddr
+		if state.Staged && !state.Confirmed {
+			continue
+		}
 		if !requireOverlay && slices.Contains(routeState.ExplicitRelayURLs, relayURL) {
 			continue
 		}
@@ -648,6 +657,9 @@ func (s *RelaySet) Descriptors(self types.RelayDescriptor) []types.RelayDescript
 	}
 	for _, state := range s.currentRelayStates(now) {
 		if state.Banned || state.Dead || !state.hasObservedDescriptor() {
+			continue
+		}
+		if state.Staged && !state.Confirmed {
 			continue
 		}
 		add(state.Descriptor)
@@ -890,6 +902,18 @@ func (s *RelaySet) RecordLoadFactor(relayURL string, loadFixed uint32) {
 // Returns nil iff the descriptor was stored, idempotently refreshed, or is an
 // older same-URL/same-identity announce already superseded by local state.
 func (s *RelaySet) InsertAnnounced(desc types.RelayDescriptor, now time.Time) error {
+	return s.insertDescriptor(desc, now, false)
+}
+
+// InsertHopRelay admits a forward relay supplied by an untrusted hop-routing
+// request. The entry is staged: it serves the overlay peer of that hop route
+// but stays out of Descriptors() and automatic route planning until a direct
+// discovery poll marks it Confirmed.
+func (s *RelaySet) InsertHopRelay(desc types.RelayDescriptor, now time.Time) error {
+	return s.insertDescriptor(desc, now, true)
+}
+
+func (s *RelaySet) insertDescriptor(desc types.RelayDescriptor, now time.Time, staged bool) error {
 	if now.IsZero() {
 		now = time.Now().UTC()
 	} else {
@@ -904,6 +928,7 @@ func (s *RelaySet) InsertAnnounced(desc types.RelayDescriptor, now time.Time) er
 	record := RelayState{
 		Descriptor: normalized,
 		LastSeenAt: now,
+		Staged:     staged,
 	}
 
 	s.mu.Lock()
@@ -920,7 +945,6 @@ func (s *RelaySet) InsertAnnounced(desc types.RelayDescriptor, now time.Time) er
 
 	switch s.upsertDescriptorLocked(record, now, false) {
 	case upsertAccepted:
-		s.enforceIdentityCapLocked(record.Descriptor.Address)
 		s.enforceCapLocked()
 		return nil
 	case upsertIgnored:

--- a/portal/discovery/relayset.go
+++ b/portal/discovery/relayset.go
@@ -882,7 +882,8 @@ func (s *RelaySet) RecordLoadFactor(relayURL string, loadFixed uint32) {
 }
 
 // InsertCandidate ingests a single descriptor from untrusted input (/sdk/hop
-// or the announce endpoint). The full validation pipeline runs inline:
+// or the announce endpoint) as a RelayCandidate. The full validation
+// pipeline runs inline:
 //
 //  1. The descriptor signature is verified against the recovered public key
 //     and matched to the descriptor's Address field.
@@ -895,12 +896,13 @@ func (s *RelaySet) RecordLoadFactor(relayURL string, loadFixed uint32) {
 //     pre-existing entry at the same URL.
 //  4. The shared upsertDescriptorLocked method enforces the
 //     monotonic-IssuedAt-per-key rollback guard and the cross-identity
-// InsertCandidate admits a descriptor from untrusted input (/sdk/hop,
-// /discovery/announce) as a RelayCandidate. Candidates serve overlay
-// routing for the hop route that brought them in and remain refresh-poll
-// targets, but they stay out of Descriptors() and automatic route planning
-// until a direct authoritative probe of that exact relay promotes them to
-// RelayVerified via ApplyRelayDiscoveryResponse.
+//     URL-takeover guard, plus the per-identity candidate cap shared by
+//     every untrusted ingestion path.
+//
+// Candidates serve overlay routing for the hop route that brought them in
+// and remain refresh-poll targets, but they stay out of Descriptors() and
+// automatic route planning until a direct authoritative probe of that exact
+// relay promotes them to RelayVerified via ApplyRelayDiscoveryResponse.
 func (s *RelaySet) InsertCandidate(desc types.RelayDescriptor, now time.Time) error {
 	if now.IsZero() {
 		now = time.Now().UTC()

--- a/portal/discovery/relayset.go
+++ b/portal/discovery/relayset.go
@@ -158,7 +158,9 @@ func mergeLocalRelayState(record, existing RelayState) RelayState {
 	record.Confirmed = record.Confirmed || existing.Confirmed
 	record.Banned = record.Banned || existing.Banned
 	record.Dead = record.Dead || existing.Dead
-	record.Staged = record.Staged || existing.Staged
+	if existing.Trust > record.Trust {
+		record.Trust = existing.Trust
+	}
 	if record.discoveryFailures < existing.discoveryFailures {
 		record.discoveryFailures = existing.discoveryFailures
 	}
@@ -176,7 +178,8 @@ func mergeLocalRelayState(record, existing RelayState) RelayState {
 	return record
 }
 
-func markDiscoveryConfirmed(state RelayState) RelayState {
+func markDiscoveryVerified(state RelayState) RelayState {
+	state.Trust = RelayVerified
 	state.Dead = false
 	state.discoveryFailures = 0
 	state.nextDiscoveryRefreshAt = time.Time{}
@@ -489,7 +492,7 @@ func filterCandidatePool(states []RelayState, routeState RouteState, now time.Ti
 	pool := make([]RelayState, 0, len(states))
 	for _, state := range states {
 		relayURL := state.Descriptor.APIHTTPSAddr
-		if state.Staged && !state.Confirmed {
+		if !state.Bootstrap && state.Trust != RelayVerified {
 			continue
 		}
 		if !requireOverlay && slices.Contains(routeState.ExplicitRelayURLs, relayURL) {
@@ -659,7 +662,7 @@ func (s *RelaySet) Descriptors(self types.RelayDescriptor) []types.RelayDescript
 		if state.Banned || state.Dead || !state.hasObservedDescriptor() {
 			continue
 		}
-		if state.Staged && !state.Confirmed {
+		if !state.Bootstrap && state.Trust != RelayVerified {
 			continue
 		}
 		add(state.Descriptor)
@@ -816,7 +819,7 @@ func (s *RelaySet) ApplyRelayDiscoveryResponse(targetURL string, resp types.Disc
 
 		isAuthoritativeTarget := !protocolMismatch && !missingTarget && authoritative && relayURL == targetURL
 		if isAuthoritativeTarget {
-			record = markDiscoveryConfirmed(record)
+			record = markDiscoveryVerified(record)
 		}
 
 		if upsert := s.upsertDescriptorLocked(record, now, isAuthoritativeTarget); upsert != upsertAccepted {
@@ -828,7 +831,7 @@ func (s *RelaySet) ApplyRelayDiscoveryResponse(targetURL string, resp types.Disc
 			// existing URL slot.
 			if isAuthoritativeTarget && hasExistingAtURL {
 				if existingAtURL.discoveryFailures != 0 || !existingAtURL.nextDiscoveryRefreshAt.IsZero() || !existingAtURL.unhealthySince.IsZero() {
-					existingAtURL = markDiscoveryConfirmed(existingAtURL)
+					existingAtURL = markDiscoveryVerified(existingAtURL)
 					s.relays[relayURL] = existingAtURL
 					relaySetChanged = true
 				}
@@ -878,10 +881,8 @@ func (s *RelaySet) RecordLoadFactor(relayURL string, loadFixed uint32) {
 	s.relays[relayURL] = state
 }
 
-// InsertAnnounced ingests a single descriptor submitted via the announce
-// endpoint. It is the only public mutator that is intended to be reachable
-// from external (untrusted) callers. The full validation pipeline runs
-// inline:
+// InsertCandidate ingests a single descriptor from untrusted input (/sdk/hop
+// or the announce endpoint). The full validation pipeline runs inline:
 //
 //  1. The descriptor signature is verified against the recovered public key
 //     and matched to the descriptor's Address field.
@@ -889,31 +890,18 @@ func (s *RelaySet) RecordLoadFactor(relayURL string, loadFixed uint32) {
 //     future) and not significantly clock-skewed (IssuedAt no further into
 //     the future than AnnounceClockSkewTolerance, validity window no longer
 //     than AnnounceMaxValidity).
-//  3. Local merge preserves Bootstrap, Confirmed, Banned, discovery retry
-//     state, active suppression state, and telemetry from any pre-existing
-//     entry at the same URL.
+//  3. Local merge preserves Bootstrap, Confirmed, Banned, Trust, discovery
+//     retry state, active suppression state, and telemetry from any
+//     pre-existing entry at the same URL.
 //  4. The shared upsertDescriptorLocked method enforces the
 //     monotonic-IssuedAt-per-key rollback guard and the cross-identity
-//     URL-takeover guard. Announce never grants takeover authority; only
-//     direct authoritative refresh can do that.
-//  5. After a successful upsert, the LRU cap is enforced; bootstrap and
-//     listener-confirmed entries are pinned.
-//
-// Returns nil iff the descriptor was stored, idempotently refreshed, or is an
-// older same-URL/same-identity announce already superseded by local state.
-func (s *RelaySet) InsertAnnounced(desc types.RelayDescriptor, now time.Time) error {
-	return s.insertDescriptor(desc, now, false)
-}
-
-// InsertHopRelay admits a forward relay supplied by an untrusted hop-routing
-// request. The entry is staged: it serves the overlay peer of that hop route
-// but stays out of Descriptors() and automatic route planning until a direct
-// discovery poll marks it Confirmed.
-func (s *RelaySet) InsertHopRelay(desc types.RelayDescriptor, now time.Time) error {
-	return s.insertDescriptor(desc, now, true)
-}
-
-func (s *RelaySet) insertDescriptor(desc types.RelayDescriptor, now time.Time, staged bool) error {
+// InsertCandidate admits a descriptor from untrusted input (/sdk/hop,
+// /discovery/announce) as a RelayCandidate. Candidates serve overlay
+// routing for the hop route that brought them in and remain refresh-poll
+// targets, but they stay out of Descriptors() and automatic route planning
+// until a direct authoritative probe of that exact relay promotes them to
+// RelayVerified via ApplyRelayDiscoveryResponse.
+func (s *RelaySet) InsertCandidate(desc types.RelayDescriptor, now time.Time) error {
 	if now.IsZero() {
 		now = time.Now().UTC()
 	} else {
@@ -928,7 +916,6 @@ func (s *RelaySet) insertDescriptor(desc types.RelayDescriptor, now time.Time, s
 	record := RelayState{
 		Descriptor: normalized,
 		LastSeenAt: now,
-		Staged:     staged,
 	}
 
 	s.mu.Lock()
@@ -955,13 +942,13 @@ func (s *RelaySet) insertDescriptor(desc types.RelayDescriptor, now time.Time, s
 	return nil
 }
 
-// enforceIdentityCapLocked bounds how many unverified announced entries a
-// single signing identity holds in the set. Overflow evicts that identity's
-// own oldest entries by LastSeenAt, so a flooding identity recycles its own
+// enforceIdentityCapLocked bounds how many candidate entries a single
+// signing identity holds in the set. Overflow evicts that identity's own
+// oldest candidates by LastSeenAt, so a flooding identity recycles its own
 // slots instead of displacing other relays through the global cap. Bootstrap,
-// banned, and listener-confirmed entries are never evicted here; the keyIndex
-// rollback anchors survive eviction by design. The caller MUST already hold
-// s.mu as a write lock.
+// banned, verified, and listener-confirmed entries are never evicted here;
+// the keyIndex rollback anchors survive eviction by design. The caller MUST
+// already hold s.mu as a write lock.
 func (s *RelaySet) enforceIdentityCapLocked(address string) {
 	address = strings.ToLower(strings.TrimSpace(address))
 	if address == "" {
@@ -973,7 +960,7 @@ func (s *RelaySet) enforceIdentityCapLocked(address string) {
 	}
 	owned := make([]ownedEntry, 0, MaxAnnouncedRelaysPerIdentity+1)
 	for url, state := range s.relays {
-		if state.Bootstrap || state.Banned || state.Confirmed {
+		if state.Bootstrap || state.Banned || state.Confirmed || state.Trust == RelayVerified {
 			continue
 		}
 		if strings.ToLower(strings.TrimSpace(state.Descriptor.Address)) != address {
@@ -1039,7 +1026,7 @@ func (s *RelaySet) enforceCapLocked() {
 	}
 	type ageEntry struct {
 		url       string
-		confirmed bool
+		protected bool
 		seenAt    time.Time
 	}
 	candidates := make([]ageEntry, 0, len(s.relays))
@@ -1049,15 +1036,16 @@ func (s *RelaySet) enforceCapLocked() {
 		}
 		candidates = append(candidates, ageEntry{
 			url:       url,
-			confirmed: state.Confirmed,
+			protected: state.Confirmed || state.Trust == RelayVerified,
 			seenAt:    state.LastSeenAt,
 		})
 	}
 	sort.Slice(candidates, func(i, j int) bool {
-		// Non-confirmed entries evict first; confirmed is the last-resort
-		// tier. Within each tier, oldest LastSeenAt evicts first.
-		if candidates[i].confirmed != candidates[j].confirmed {
-			return !candidates[i].confirmed
+		// Candidate entries evict first; verified and listener-confirmed
+		// entries are the last-resort tier. Within each tier, oldest
+		// LastSeenAt evicts first.
+		if candidates[i].protected != candidates[j].protected {
+			return !candidates[i].protected
 		}
 		return candidates[i].seenAt.Before(candidates[j].seenAt)
 	})

--- a/portal/discovery/relayset.go
+++ b/portal/discovery/relayset.go
@@ -158,7 +158,14 @@ func mergeLocalRelayState(record, existing RelayState) RelayState {
 	record.Confirmed = record.Confirmed || existing.Confirmed
 	record.Banned = record.Banned || existing.Banned
 	record.Dead = record.Dead || existing.Dead
-	if existing.Trust > record.Trust {
+	// Trust never transfers across an identity change on the same URL: a
+	// takeover after descriptor expiry must start over as a candidate. A
+	// genuine rotation re-verifies through the authoritative probe path.
+	sameIdentity := strings.EqualFold(
+		strings.TrimSpace(record.Descriptor.Address),
+		strings.TrimSpace(existing.Descriptor.Address),
+	)
+	if sameIdentity && existing.Trust > record.Trust {
 		record.Trust = existing.Trust
 	}
 	if record.discoveryFailures < existing.discoveryFailures {
@@ -492,8 +499,15 @@ func filterCandidatePool(states []RelayState, routeState RouteState, now time.Ti
 	pool := make([]RelayState, 0, len(states))
 	for _, state := range states {
 		relayURL := state.Descriptor.APIHTTPSAddr
-		if !state.Bootstrap && state.Trust != RelayVerified {
-			continue
+		if state.Trust != RelayVerified {
+			// A bootstrap URL configured by the operator stays eligible as
+			// a URL-only single-hop fallback until a direct probe verifies
+			// it, but a descriptor squatted on a bootstrap URL by an
+			// untrusted candidate is not eligible at all, and unverified
+			// bootstrap entries never join multi-hop paths.
+			if requireOverlay || !state.Bootstrap || state.hasObservedDescriptor() {
+				continue
+			}
 		}
 		if !requireOverlay && slices.Contains(routeState.ExplicitRelayURLs, relayURL) {
 			continue
@@ -662,13 +676,10 @@ func (s *RelaySet) Descriptors(self types.RelayDescriptor) []types.RelayDescript
 		if state.Banned || state.Dead || !state.hasObservedDescriptor() {
 			continue
 		}
-		if !state.Bootstrap && state.Trust != RelayVerified {
+		if state.Trust != RelayVerified {
 			continue
 		}
 		add(state.Descriptor)
-	}
-	if len(out) == 0 {
-		return nil
 	}
 	return out
 }

--- a/portal/discovery/relayset_test.go
+++ b/portal/discovery/relayset_test.go
@@ -30,6 +30,7 @@ func confirmedRelayState(t *testing.T, relayURL string) RelayState {
 	t.Helper()
 	return RelayState{
 		Descriptor: mustRelayDescriptor(t, relayURL),
+		Trust:      RelayVerified,
 		Confirmed:  true,
 		LastSeenAt: time.Now().UTC(),
 	}

--- a/portal/discovery/relaystate.go
+++ b/portal/discovery/relaystate.go
@@ -40,6 +40,26 @@ const (
 	AnnounceMaxValidity = 24 * time.Hour
 )
 
+// RelayTrust classifies whether this relay has directly verified a pool
+// entry or only received its descriptor from untrusted input. Verifying a
+// relay never verifies the other relays its discovery response mentions;
+// those are admitted as candidates like any other untrusted descriptor.
+type RelayTrust uint8
+
+const (
+	// RelayCandidate marks a descriptor admitted from untrusted input.
+	// Candidates still serve overlay routing for the hop route that brought
+	// them in and remain refresh-poll targets, but they are excluded from
+	// Descriptors(), automatic route selection, and this relay's own gossip
+	// output until promoted.
+	RelayCandidate RelayTrust = iota
+
+	// RelayVerified marks a relay whose own URL this relay polled directly
+	// and which served a validly signed self-descriptor. Verified entries
+	// are globally discoverable and automatically selectable.
+	RelayVerified
+)
+
 type PercentileTracker struct {
 	samples []float64
 }
@@ -66,15 +86,14 @@ func (pt *PercentileTracker) Get(p float64) time.Duration {
 type RelayState struct {
 	Descriptor types.RelayDescriptor
 	Bootstrap  bool
-	// Staged marks a relay that entered the set through an untrusted
-	// hop-routing request rather than announce or gossip. Staged entries
-	// still serve the overlay peer of the hop route that introduced them,
-	// but they stay out of Descriptors() and route planning until a direct
-	// discovery poll marks the entry Confirmed.
-	Staged    bool
+	// Trust classifies how the entry entered the set. Descriptors from
+	// untrusted input (/sdk/hop, /discovery/announce, or gossiped discovery
+	// content) are admitted as RelayCandidate and stay out of Descriptors()
+	// and automatic route selection until a direct authoritative probe of
+	// that exact relay promotes them to RelayVerified.
+	Trust     RelayTrust
 	Confirmed bool
 	Banned    bool
-	// Dead marks a relay whose consecutive discovery failures exhausted the
 	// recovery budget. Dead relays are excluded from route planning and relay
 	// listings but stay in the set: the refresher keeps probing them and a
 	// successful discovery response clears the mark.

--- a/portal/discovery/relaystate.go
+++ b/portal/discovery/relaystate.go
@@ -21,6 +21,13 @@ const (
 	// listener-confirmed entries are pinned and never evicted by capacity.
 	MaxAnnouncedRelays = 1024
 
+	// MaxAnnouncedRelaysPerIdentity bounds how many unverified announced
+	// entries one signing identity may hold. Overflow recycles that
+	// identity's own oldest entries, so an unauthenticated announce or
+	// hop-route flood cannot use the identity's slots to push other relays
+	// toward the global-cap eviction.
+	MaxAnnouncedRelaysPerIdentity = 4
+
 	// AnnounceClockSkewTolerance bounds how far in the future a descriptor's
 	// IssuedAt may sit relative to local time. Anything beyond this is
 	// rejected as clock-skewed or maliciously post-dated.

--- a/portal/discovery/relaystate.go
+++ b/portal/discovery/relaystate.go
@@ -66,8 +66,14 @@ func (pt *PercentileTracker) Get(p float64) time.Duration {
 type RelayState struct {
 	Descriptor types.RelayDescriptor
 	Bootstrap  bool
-	Confirmed  bool
-	Banned     bool
+	// Staged marks a relay that entered the set through an untrusted
+	// hop-routing request rather than announce or gossip. Staged entries
+	// still serve the overlay peer of the hop route that introduced them,
+	// but they stay out of Descriptors() and route planning until a direct
+	// discovery poll marks the entry Confirmed.
+	Staged    bool
+	Confirmed bool
+	Banned    bool
 	// Dead marks a relay whose consecutive discovery failures exhausted the
 	// recovery budget. Dead relays are excluded from route planning and relay
 	// listings but stay in the set: the refresher keeps probing them and a

--- a/portal/server_test.go
+++ b/portal/server_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-
 	"github.com/gosuda/portal-tunnel/v2/portal/acme"
 	"github.com/gosuda/portal-tunnel/v2/portal/discovery"
 	"github.com/gosuda/portal-tunnel/v2/portal/keyless"

--- a/portal/server_test.go
+++ b/portal/server_test.go
@@ -220,6 +220,13 @@ func TestHandleHopRateLimited(t *testing.T) {
 	if statuses[2] != http.StatusTooManyRequests {
 		t.Fatalf("third status = %d, want %d", statuses[2], http.StatusTooManyRequests)
 	}
+	deleteReq := httptest.NewRequest(http.MethodDelete, types.PathSDKHop, strings.NewReader(`{}`))
+	deleteReq.RemoteAddr = "192.0.2.1:1234"
+	deleteRec := httptest.NewRecorder()
+	server.handleHop(deleteRec, deleteReq)
+	if deleteRec.Code == http.StatusTooManyRequests {
+		t.Fatalf("DELETE after exhausted POST burst = %d, want cleanup to bypass the POST-only limiter", deleteRec.Code)
+	}
 }
 
 func TestServerStartInitializesLocalACMEAndSigner(t *testing.T) {

--- a/portal/server_test.go
+++ b/portal/server_test.go
@@ -23,7 +23,9 @@ import (
 	"testing"
 	"time"
 
+
 	"github.com/gosuda/portal-tunnel/v2/portal/acme"
+	"github.com/gosuda/portal-tunnel/v2/portal/discovery"
 	"github.com/gosuda/portal-tunnel/v2/portal/keyless"
 	"github.com/gosuda/portal-tunnel/v2/types"
 	"github.com/gosuda/portal-tunnel/v2/utils"
@@ -190,6 +192,34 @@ func TestRelayDiscoveryEnabledServesDiscoveryEnvelope(t *testing.T) {
 	}
 	if !envelope.OK || envelope.Data.ProtocolVersion != types.DiscoveryVersion {
 		t.Fatalf("discovery envelope = %+v, want ok discovery response", envelope)
+	}
+}
+
+func TestHandleHopRateLimited(t *testing.T) {
+	t.Parallel()
+
+	server, err := NewServer(ServerConfig{
+		PortalURL:    "https://portal.example.com",
+		IdentityPath: tempIdentityPath(t),
+	})
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	server.announceLimiter = discovery.NewAnnounceLimiter(1, 2)
+
+	statuses := make([]int, 3)
+	for i := range statuses {
+		req := httptest.NewRequest(http.MethodPost, types.PathSDKHop, strings.NewReader(`{}`))
+		req.RemoteAddr = "192.0.2.1:1234"
+		rec := httptest.NewRecorder()
+		server.handleHop(rec, req)
+		statuses[i] = rec.Code
+	}
+	if statuses[0] == http.StatusTooManyRequests || statuses[1] == http.StatusTooManyRequests {
+		t.Fatalf("first statuses = %d/%d, want within burst budget", statuses[0], statuses[1])
+	}
+	if statuses[2] != http.StatusTooManyRequests {
+		t.Fatalf("third status = %d, want %d", statuses[2], http.StatusTooManyRequests)
 	}
 }
 


### PR DESCRIPTION
## Summary

Replaces incremental patching of `/sdk/hop` abuse with an explicit trust model for the relay discovery pool, built on one invariant:

> An untrusted descriptor never becomes globally discoverable, automatically selectable, or gossipable by this relay until that exact relay has been directly verified.

- `RelayTrust` (`RelayCandidate` / `RelayVerified`) replaces the staging boolean. `Bootstrap` remains operator pinning; `Confirmed` remains a listener-usage pin — both affect eviction priority only, never visibility or promotion
- all untrusted input (`/sdk/hop`, `/discovery/announce`, and gossip content from discovery responses) lands as `RelayCandidate` via `InsertCandidate`. Candidates still serve overlay routing for the hop route that brought them in and remain refresh-poll targets, but stay out of `Descriptors()`, automatic route selection, and this relay's own gossip output
- promotion happens only on the real refresher path: `ApplyRelayDiscoveryResponse` promotes the authoritative target via `markDiscoveryVerified`. Descriptors merely mentioned by a probed relay stay candidates — verifying relay A never launders the relays A talks about
- trust is monotone under gossip refresh; the per-identity candidate cap is enforced in `upsertDescriptorLocked` so announce, hop, and gossip ingestion all pass through it; global-cap eviction prefers candidates, then verified/listener-confirmed, never bootstrap
- `POST /sdk/hop` is rate-limited per source IP (announce limiter defaults); `DELETE` keeps performing route/DNS cleanup without consuming the budget

## Security impact

Closes the discovery-admission item of #314. The previously reported paths are structurally closed rather than bounded:

- unauthenticated hop floods: candidates are invisible regardless of volume; identity cap and rate limit remain as defense in depth
- gossip laundering (staged attacker relay serving thousands of descriptors): content from any response is candidate-only; each relay must be individually probed and must actually respond to become visible
- eviction of legitimate relays: verified and listener-confirmed entries are the last-resort eviction tier; a candidate flood filling the global cap cannot displace them

Behavior change to be aware of: announce and gossip entries are no longer immediately visible; a relay now lists a peer only after polling it once itself (one refresh cycle). Mixed-version networks are safe — this is per-relay local admission policy with no protocol change; unpatched relays keep their current behavior.

## Verification

- `go vet ./portal/ ./portal/discovery/`
- `go test ./portal/discovery/ -count=1` and `go test ./portal/ -count=1` (all green, including the new regression tests)
- new tests: hidden-until-probe through `ApplyRelayDiscoveryResponse` (the real promotion path, not a direct `ConfirmRelayURL` call), target-only promotion with laundering follow-up, trust monotonicity under gossip refresh, per-identity caps across ingestion paths, verified survival of a candidate flood filling the global cap
- `golangci-lint` unavailable in the local environment