### PR TITLE
feat: implement keyless tenant key separation and expose materials en…

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,9 @@ Browser
 3. The Portal tunnel on your side completes the TLS handshake locally. Session
    keys are derived on your machine.
 4. For relay-hosted domains, the tunnel obtains certificate signatures via
-   `/v1/sign`, using the relay only as a keyless signing oracle. The relay signs
-   handshake digests but never receives session keys.
+   `/v1/sign`, using the relay's wildcard-only tenant key. The relay API key is
+   separate and is never exposed to the signer. The relay signs handshake
+   digests but never receives session keys.
 5. After the handshake, the relay continues forwarding ciphertext without access
    to plaintext.
 

--- a/config.toml
+++ b/config.toml
@@ -2,9 +2,9 @@
 # Bump protocol versions only when wire-level behavior changes.
 
 [release]
-version  = "v2.3.6"
+version  = "v2.3.8"
 base_url = "https://github.com/gosuda/portal-tunnel/releases"
 
 [protocol]
-tunnel    = "8"
+tunnel    = "9"
 discovery = "8"

--- a/docs/src/routes/api-reference/+page.md
+++ b/docs/src/routes/api-reference/+page.md
@@ -146,6 +146,7 @@ Casper facilitator.
 |--------|------|------|----------|
 | `GET` | `/discovery` | None | `DiscoveryResponse` |
 | `POST` | `/discovery/announce` | Signed descriptor | `DiscoveryAnnounceResponse` |
+| `GET` | `/v1/keyless/materials` | None | `KeylessMaterials` |
 | `POST` | `/v1/sign` | Lease token header | keyless signer response |
 
 ## Shared Types

--- a/docs/src/routes/architecture/+page.md
+++ b/docs/src/routes/architecture/+page.md
@@ -166,14 +166,14 @@ UDP client
 
 - Relay terminates admin/API TLS on the root host and exposes `/v1/sign` for tenant-side keyless signing.
 - Control-plane HTTP (`/sdk/*`), reverse-session establishment (`/sdk/connect`), and tenant TLS are separate connections with different trust boundaries.
-- Relay API TLS, SDK relay-client TLS, SDK tenant-server TLS, and QUIC tunnel TLS are distinct configs even when they reuse the same relay certificate material.
+- Relay API TLS and tenant keyless TLS use separate certificate keys. The API key is never registered with `/v1/sign`.
 - Relay does not terminate tenant TLS. It peeks ClientHello for SNI and bridges raw encrypted bytes after routing.
 - SDK/tunnel endpoints terminate tenant TLS locally with a keyless-backed signer that calls the relay.
 - In keyless TLS, the relay performs certificate private-key signing through `/v1/sign`, but the SDK/tunnel endpoint still runs the TLS server handshake and derives tenant TLS session keys locally.
 - `/sdk/connect`, `/sdk/renew`, and `/sdk/unregister` are authorized by lease existence plus a relay-issued lease access token.
 - `/sdk/register` is authenticated by a SIWE challenge/response flow using the SDK identity secp256k1 key. On success, the relay issues a lease-scoped ES256K JWT access token signed by the relay identity key and used for the rest of the lease lifecycle.
 - Relay URLs must use `https://`.
-- HTTP/2 stays disabled on the admin/API TLS listener. Keyless TLS certificate sharing and `/sdk/connect` both depend on the current HTTP/1.1-only transport contract.
+- HTTP/2 stays disabled on the admin/API TLS listener. The keyless signer and `/sdk/connect` depend on the current HTTP/1.1-only transport contract.
 - WireGuard, when enabled, is relay-to-relay overlay transport only. It carries multi-hop relay forwarding and overlay discovery, but it is not used for direct tenant TLS termination, public UDP ingress, or `/sdk/*` control-plane traffic.
 
 ### Reverse Session Protocol
@@ -201,7 +201,7 @@ UDP client
 - ENS gasless automation reuses `ACME_DNS_PROVIDER` for DNSSEC and ENS TXT sync when the selected provider supports DNSSEC.
 - Relay stores its state under `IDENTITY_PATH`, including `identity.json`, `policy.json`, and certificate material. Tunnel and demo-app identities still use `IDENTITY_PATH` / `--identity-path` as a direct JSON file path.
 - Managed non-localhost ACME keeps both root and wildcard DNS A records in sync.
-- Relay certificate material lives under `IDENTITY_PATH` as `fullchain.pem` and `privatekey.pem`.
+- Relay API certificate material lives under `IDENTITY_PATH` as `fullchain.pem` and `privatekey.pem`. Tenant wildcard signer material lives under `IDENTITY_PATH/tenant/` with the same filenames.
 - Localhost uses the development certificate path instead of public managed/manual certificate setup.
 
 ## Connection Model

--- a/docs/src/routes/configuration/+page.md
+++ b/docs/src/routes/configuration/+page.md
@@ -58,7 +58,7 @@ The relay server (`relay-server`) reads configuration from environment variables
 
 | Variable | Default | Type | Description |
 |----------|---------|------|-------------|
-| `ACME_DNS_PROVIDER` | `""` | string | DNS provider for managed DNS-01/A-record sync, the relay ECH record, opt-in tunnel ECH records, and ENS gasless DNSSEC/TXT automation (`embedded` \| `cloudflare` \| `gcloud` \| `hetzner` \| `njalla` \| `route53` \| `vultr`); unset defaults to `embedded`; manual `fullchain.pem`/`privatekey.pem` in `IDENTITY_PATH` is used when present |
+| `ACME_DNS_PROVIDER` | `""` | string | DNS provider for managed DNS-01/A-record sync, separate API and tenant-wildcard certificates, the relay ECH record, opt-in tunnel ECH records, and ENS gasless DNSSEC/TXT automation (`embedded` \| `cloudflare` \| `gcloud` \| `hetzner` \| `njalla` \| `route53` \| `vultr`); unset defaults to `embedded`; manual deployments require `fullchain.pem`/`privatekey.pem` and a distinct wildcard pair under `tenant/` |
 | `ENS_GASLESS_ENABLED` | `false` | bool | Enable ENS gasless DNS import automation for the managed DNS zone and lease hostnames; not supported with `ACME_DNS_PROVIDER=embedded` yet |
 
 ### Embedded DNS

--- a/docs/src/routes/deployment/+page.md
+++ b/docs/src/routes/deployment/+page.md
@@ -89,10 +89,13 @@ To override ACME with a manually managed certificate, place these files in
 ```text
 fullchain.pem
 privatekey.pem
+tenant/fullchain.pem
+tenant/privatekey.pem
 ```
 
-The certificate must cover the Portal root hostname. A wildcard certificate is
-also required when wildcard tunnel names terminate TLS at Portal.
+The root certificate must cover the Portal hostname. The tenant certificate must
+cover only the corresponding wildcard name and must use a different key. Managed
+ACME, including the embedded DNS provider, creates and renews both pairs automatically.
 
 ## Deploy
 

--- a/docs/src/routes/security-model/+page.md
+++ b/docs/src/routes/security-model/+page.md
@@ -23,7 +23,7 @@ Tenant TLS terminates on the SDK side. The local service receives the decrypted 
 
 ## Keyless Signing
 
-For relay-hosted names, the SDK builds a tenant-facing TLS server config backed by the relay's `/v1/sign` endpoint. The relay signs handshake digests with its certificate key, but it does not receive the negotiated tenant TLS session keys.
+For relay-hosted names, the SDK builds a tenant-facing TLS server config backed by the relay's `/v1/sign` endpoint. The relay signs handshake digests with a wildcard-only tenant key that is distinct from the relay API key, but it does not receive the negotiated tenant TLS session keys. The SDK obtains the corresponding public certificate chain and key ID from `/v1/keyless/materials`.
 
 Relay API TLS is separate from tenant TLS:
 

--- a/docs/src/routes/self-hosting/+page.md
+++ b/docs/src/routes/self-hosting/+page.md
@@ -25,8 +25,8 @@ Run the relay with a single Docker command:
 
 ```bash
 mkdir -p ./relay-data
-# Optional: place fullchain.pem/privatekey.pem in ./relay-data to use a manual
-# certificate instead of ACME.
+# Optional manual TLS: place the API pair in ./relay-data and a distinct
+# wildcard-only pair in ./relay-data/tenant. Managed ACME creates both.
 docker run -d \
   --name portal-relay \
   --restart unless-stopped \

--- a/portal/acme/acme.go
+++ b/portal/acme/acme.go
@@ -21,6 +21,7 @@ const (
 	keyFileName            = "privatekey.pem"
 	accountKeyFileName     = "acme-account.key"
 	registrationFileName   = "acme-registration.json"
+	tenantKeyDirName       = "tenant"
 	defaultACMEEmailPrefix = "acme@"
 )
 
@@ -187,6 +188,57 @@ func (m *Manager) EnsureTLSMaterial(ctx context.Context) ([]byte, []byte, error)
 	return certPEM, keyPEM, nil
 }
 
+func (m *Manager) EnsureTenantTLSMaterial(ctx context.Context) ([]byte, []byte, error) {
+	certFile, keyFile, err := m.ensureTenantCertificate(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read tenant tls certificate: %w", err)
+	}
+	keyPEM, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read tenant tls private key: %w", err)
+	}
+	return certPEM, keyPEM, nil
+}
+
+func (m *Manager) ensureTenantCertificate(ctx context.Context) (string, string, error) {
+	if m == nil {
+		return "", "", errors.New("acme manager is nil")
+	}
+	tenantDir := filepath.Join(m.cfg.KeyDir, tenantKeyDirName)
+	domains := tenantCertificateDomains(m.cfg.BaseDomain)
+	if utils.IsLocalRelayHost(m.cfg.BaseDomain) {
+		if err := ensureLocalDevelopmentTenantCertificate(tenantDir, m.cfg.BaseDomain); err != nil {
+			return "", "", err
+		}
+		return tlsFiles(tenantDir)
+	}
+
+	certFile, keyFile, err := tlsFiles(tenantDir)
+	if err == nil {
+		covered, coverErr := certCoversDomains(certFile, domains)
+		if coverErr == nil && covered {
+			cert, parseErr := loadCertificate(certFile)
+			wildcard := "*." + m.cfg.BaseDomain
+			if parseErr == nil && !cert.IsCA && cert.VerifyHostname(m.cfg.BaseDomain) != nil &&
+				len(cert.DNSNames) == 1 && strings.EqualFold(strings.TrimSpace(cert.DNSNames[0]), wildcard) && len(cert.IPAddresses) == 0 {
+				return certFile, keyFile, nil
+			}
+		}
+	}
+	if err := m.syncDNS(ctx); err != nil {
+		return "", "", fmt.Errorf("ensure dns records for tenant certificate: %w", err)
+	}
+	if err := m.provisionTenant(ctx); err != nil {
+		return "", "", err
+	}
+	return tlsFiles(tenantDir)
+}
+
 func (m *Manager) Start(ctx context.Context) {
 	if m == nil || utils.IsLocalRelayHost(m.cfg.BaseDomain) {
 		return
@@ -231,12 +283,24 @@ func (m *Manager) TLSFiles() (string, string, error) {
 	if m == nil {
 		return "", "", errors.New("acme manager is nil")
 	}
-	certFile := filepath.Join(m.cfg.KeyDir, fullChainFileName)
-	keyFile := filepath.Join(m.cfg.KeyDir, keyFileName)
+	return tlsFiles(m.cfg.KeyDir)
+}
+
+func tlsFiles(keyDir string) (string, string, error) {
+	certFile := filepath.Join(keyDir, fullChainFileName)
+	keyFile := filepath.Join(keyDir, keyFileName)
 	if !utils.FileExists(certFile) || !utils.FileExists(keyFile) {
-		return "", "", errors.New("relay certificate files do not exist")
+		return "", "", errors.New("certificate files do not exist")
 	}
 	return certFile, keyFile, nil
+}
+
+func certificateMaterialIsManual(keyDir string) bool {
+	if _, _, err := tlsFiles(keyDir); err != nil {
+		return false
+	}
+	return !utils.FileExists(filepath.Join(keyDir, accountKeyFileName)) &&
+		!utils.FileExists(filepath.Join(keyDir, registrationFileName))
 }
 
 func (m *Manager) manualCertificateOverride() (string, string, bool, error) {
@@ -267,11 +331,18 @@ func (m *Manager) manualCertificateOverride() (string, string, bool, error) {
 }
 
 func (m *Manager) provision(ctx context.Context) error {
-	keyFile := filepath.Join(m.cfg.KeyDir, keyFileName)
-	certFile := filepath.Join(m.cfg.KeyDir, fullChainFileName)
-	accountKeyFile := filepath.Join(m.cfg.KeyDir, accountKeyFileName)
-	registrationFile := filepath.Join(m.cfg.KeyDir, registrationFileName)
-	domains := certificateDomains(m.cfg.BaseDomain)
+	return m.provisionMaterial(ctx, m.cfg.KeyDir, certificateDomains(m.cfg.BaseDomain))
+}
+
+func (m *Manager) provisionTenant(ctx context.Context) error {
+	return m.provisionMaterial(ctx, filepath.Join(m.cfg.KeyDir, tenantKeyDirName), tenantCertificateDomains(m.cfg.BaseDomain))
+}
+
+func (m *Manager) provisionMaterial(ctx context.Context, keyDir string, domains []string) error {
+	keyFile := filepath.Join(keyDir, keyFileName)
+	certFile := filepath.Join(keyDir, fullChainFileName)
+	accountKeyFile := filepath.Join(keyDir, accountKeyFileName)
+	registrationFile := filepath.Join(keyDir, registrationFileName)
 
 	for _, path := range []string{keyFile, certFile, accountKeyFile, registrationFile} {
 		if err := utils.EnsureParentDir(path); err != nil {

--- a/portal/acme/acme_test.go
+++ b/portal/acme/acme_test.go
@@ -1,6 +1,7 @@
 package acme
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -159,6 +160,57 @@ func TestEnsureCertificateGeneratesLocalDevelopmentMaterial(t *testing.T) {
 	if !covered {
 		t.Fatal("certCoversDomains() = false, want true")
 	}
+}
+
+func TestEnsureTenantTLSMaterialUsesDistinctWildcardKey(t *testing.T) {
+	t.Parallel()
+
+	manager, err := NewManager(Config{
+		BaseDomain: "localhost",
+		KeyDir:     t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	apiCertPEM, _, err := manager.EnsureTLSMaterial(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureTLSMaterial() error = %v", err)
+	}
+	tenantCertPEM, tenantKeyPEM, err := manager.EnsureTenantTLSMaterial(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureTenantTLSMaterial() error = %v", err)
+	}
+	if len(tenantKeyPEM) == 0 {
+		t.Fatal("EnsureTenantTLSMaterial() returned empty private key")
+	}
+
+	apiCert, err := x509.ParseCertificate(pemBlockBytes(t, apiCertPEM))
+	if err != nil {
+		t.Fatalf("parse api certificate: %v", err)
+	}
+	tenantCert, err := x509.ParseCertificate(pemBlockBytes(t, tenantCertPEM))
+	if err != nil {
+		t.Fatalf("parse tenant certificate: %v", err)
+	}
+	if bytes.Equal(apiCert.RawSubjectPublicKeyInfo, tenantCert.RawSubjectPublicKeyInfo) {
+		t.Fatal("api and tenant certificates use the same public key")
+	}
+	if tenantCert.VerifyHostname("localhost") == nil {
+		t.Fatal("tenant certificate unexpectedly covers relay apex")
+	}
+	if err := tenantCert.VerifyHostname("lease.localhost"); err != nil {
+		t.Fatalf("tenant certificate does not cover lease hostname: %v", err)
+	}
+}
+
+func pemBlockBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	block, _ := pem.Decode(data)
+	if block == nil {
+		t.Fatal("PEM block is missing")
+	}
+	return block.Bytes
 }
 
 func TestEnsureTLSMaterialUsesManualCertificateWithDefaultEmbeddedProvider(t *testing.T) {

--- a/portal/acme/certificate.go
+++ b/portal/acme/certificate.go
@@ -39,8 +39,18 @@ func (m *Manager) shouldRenew() bool {
 	return err == nil && needsRenewal
 }
 
+func (m *Manager) shouldRenewTenant() bool {
+	certFile := filepath.Join(m.cfg.KeyDir, tenantKeyDirName, fullChainFileName)
+	needsRenewal, err := certNeedsRenewal(certFile, tenantCertificateDomains(m.cfg.BaseDomain))
+	return err == nil && needsRenewal
+}
+
 func certificateDomains(baseDomain string) []string {
 	return []string{baseDomain, "*." + baseDomain}
+}
+
+func tenantCertificateDomains(baseDomain string) []string {
+	return []string{"*." + baseDomain}
 }
 
 func certNeedsRenewal(certFile string, domains []string) (bool, error) {
@@ -168,13 +178,22 @@ func loadOrCreateAccountKey(path string) (crypto.PrivateKey, error) {
 }
 
 func ensureLocalDevelopmentCertificate(keyDir, baseHost string) error {
-	domains := localDevelopmentDomains(baseHost)
+	return ensureLocalDevelopmentCertificateForDomains(keyDir, baseHost, localDevelopmentDomains(baseHost), true)
+}
+
+func ensureLocalDevelopmentTenantCertificate(keyDir, baseHost string) error {
+	baseHost = utils.NormalizeBaseDomain(baseHost)
+	return ensureLocalDevelopmentCertificateForDomains(keyDir, "*."+baseHost, tenantCertificateDomains(baseHost), false)
+}
+
+func ensureLocalDevelopmentCertificateForDomains(keyDir, commonName string, domains []string, isCA bool) error {
 	keyFile := filepath.Join(keyDir, keyFileName)
 	certFile := filepath.Join(keyDir, fullChainFileName)
 
 	if utils.FileExists(keyFile) && utils.FileExists(certFile) {
 		covered, err := certCoversDomains(certFile, domains)
-		if err == nil && covered {
+		cert, certErr := loadCertificate(certFile)
+		if err == nil && certErr == nil && covered && cert.IsCA == isCA {
 			return nil
 		}
 	}
@@ -201,15 +220,18 @@ func ensureLocalDevelopmentCertificate(keyDir, baseHost string) error {
 	template := &x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
-			CommonName:   baseHost,
+			CommonName:   commonName,
 			Organization: []string{"Portal Local Development"},
 		},
 		NotBefore:             now.Add(-1 * time.Hour),
 		NotAfter:              now.Add(localDevelopmentCertificateTTL),
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageKeyAgreement | x509.KeyUsageCertSign,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageKeyAgreement,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		IsCA:                  true,
+		IsCA:                  isCA,
+	}
+	if isCA {
+		template.KeyUsage |= x509.KeyUsageCertSign
 	}
 
 	for _, domain := range domains {

--- a/portal/acme/maintenance.go
+++ b/portal/acme/maintenance.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -156,15 +157,19 @@ func (m *Manager) maintenanceLoop(ctx context.Context) {
 				log.Warn().Err(err).Str("base_domain", m.cfg.BaseDomain).Msg("sync dns records")
 			}
 		case <-renewTicker.C:
-			_, _, manual, err := m.manualCertificateOverride()
-			if err != nil || manual || !m.shouldRenew() {
-				continue
-			}
 			renewCtx, cancel := context.WithTimeout(ctx, defaultSyncTimeout)
-			err = m.provision(renewCtx)
+			_, _, apiManual, apiErr := m.manualCertificateOverride()
+			if apiErr == nil && !apiManual && m.shouldRenew() {
+				apiErr = m.provision(renewCtx)
+			}
+			tenantDir := filepath.Join(m.cfg.KeyDir, tenantKeyDirName)
+			var tenantErr error
+			if !certificateMaterialIsManual(tenantDir) && m.shouldRenewTenant() {
+				tenantErr = m.provisionTenant(renewCtx)
+			}
 			cancel()
-			if err != nil {
-				log.Warn().Err(err).Str("base_domain", m.cfg.BaseDomain).Msg("renew acme certificate")
+			if err := errors.Join(apiErr, tenantErr); err != nil {
+				log.Warn().Err(err).Str("base_domain", m.cfg.BaseDomain).Msg("renew acme certificates")
 			}
 		}
 	}

--- a/portal/api_server.go
+++ b/portal/api_server.go
@@ -56,10 +56,10 @@ func writeAPIErrorResponse(w http.ResponseWriter, err error) {
 	utils.InvalidRequestError(err).Write(w)
 }
 
-func (s *Server) newAPIServer(listener net.Listener, apiMux *http.ServeMux, apiTLS keyless.TLSMaterialConfig) (net.Listener, *http.Server, io.Closer, error) {
+func (s *Server) newAPIServer(listener net.Listener, apiMux *http.ServeMux, apiTLS, tenantTLS keyless.TLSMaterialConfig) (net.Listener, *http.Server, io.Closer, error) {
 	var keylessSignerHandler http.Handler
-	if len(apiTLS.KeyPEM) > 0 {
-		signer, err := keyless.NewSigner(apiTLS.KeyPEM)
+	if len(tenantTLS.KeyPEM) > 0 {
+		signer, err := keyless.NewSigner(tenantTLS.CertPEM, tenantTLS.KeyPEM)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("configure api signer: %w", err)
 		}
@@ -119,6 +119,12 @@ func (s *Server) apiHandler(base *http.ServeMux, keylessSignerHandler http.Handl
 				return
 			}
 			s.handleRelayDiscoveryAnnounce(w, r)
+		case types.PathV1KeylessMaterials:
+			if keylessSignerHandler == nil {
+				http.NotFound(w, r)
+				return
+			}
+			keylessSignerHandler.ServeHTTP(w, r)
 		case types.PathV1Sign:
 			if keylessSignerHandler == nil {
 				http.NotFound(w, r)

--- a/portal/keyless/client.go
+++ b/portal/keyless/client.go
@@ -9,11 +9,15 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	keylesstls "github.com/gosuda/keyless_tls/keyless"
 
+	"github.com/gosuda/portal-tunnel/v2/types"
 	"github.com/gosuda/portal-tunnel/v2/utils"
 )
+
+const materialsRequestTimeout = 15 * time.Second
 
 func BuildClientTLSConfig(relayURL, hostname string, echKeys []tls.EncryptedClientHelloKey, headers func() http.Header) (*tls.Config, ioCloser, error) {
 	normalizedRelayURL, err := utils.NormalizeRelayURL(relayURL)
@@ -30,7 +34,7 @@ func BuildClientTLSConfig(relayURL, hostname string, echKeys []tls.EncryptedClie
 		return nil, nil, errors.New("relay hostname is required")
 	}
 
-	certPEM, rootCAPEM, err := ResolveMaterials(context.Background(), normalizedRelayURL, serverName)
+	certPEM, rootCAPEM, keyID, err := ResolveMaterials(context.Background(), normalizedRelayURL, serverName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("prepare keyless materials: %w", err)
 	}
@@ -45,7 +49,7 @@ func BuildClientTLSConfig(relayURL, hostname string, echKeys []tls.EncryptedClie
 	remoteSigner, err := keylesstls.NewRemoteSigner(keylesstls.RemoteSignerConfig{
 		Endpoint:   normalizedRelayURL,
 		ServerName: serverName,
-		KeyID:      RelayKeyID,
+		KeyID:      keyID,
 		RootCAPEM:  rootCAPEM,
 		Headers:    headers,
 	}, certPEM)
@@ -71,15 +75,39 @@ type ioCloser interface {
 	Close() error
 }
 
-func ResolveMaterials(ctx context.Context, endpoint, serverName string) ([]byte, []byte, error) {
+func ResolveMaterials(ctx context.Context, endpoint, serverName string) ([]byte, []byte, string, error) {
 	chainPEM, err := utils.FetchEndpointCertificateChain(ctx, endpoint, serverName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("fetch signer certificate chain: %w", err)
+		return nil, nil, "", fmt.Errorf("fetch signer api certificate chain: %w", err)
 	}
 	if len(chainPEM) == 0 {
-		return nil, nil, errors.New("keyless certificate chain is required")
+		return nil, nil, "", errors.New("keyless api certificate chain is required")
 	}
-	return bytes.Clone(chainPEM), bytes.Clone(chainPEM), nil
+
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("parse signer endpoint: %w", err)
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, materialsRequestTimeout)
+	defer cancel()
+	_, client, transport, err := utils.NewHTTPTLSClient(requestCtx, parsed, materialsRequestTimeout)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("create signer materials client: %w", err)
+	}
+	defer transport.CloseIdleConnections()
+
+	var materials types.KeylessMaterials
+	if err := utils.HTTPDoAPIPath(requestCtx, client, parsed, http.MethodGet, types.PathV1KeylessMaterials, nil, nil, &materials); err != nil {
+		return nil, nil, "", fmt.Errorf("fetch tenant keyless materials: %w", err)
+	}
+	materials.KeyID = strings.TrimSpace(materials.KeyID)
+	if materials.KeyID == "" {
+		return nil, nil, "", errors.New("tenant keyless key id is required")
+	}
+	if len(materials.CertificateChain) == 0 {
+		return nil, nil, "", errors.New("tenant keyless certificate chain is required")
+	}
+	return bytes.Clone(materials.CertificateChain), bytes.Clone(chainPEM), materials.KeyID, nil
 }
 
 func VerifyCertificateHostname(certPEM []byte, hostname string) error {

--- a/portal/keyless/signer.go
+++ b/portal/keyless/signer.go
@@ -1,7 +1,10 @@
 package keyless
 
 import (
+	"bytes"
 	"context"
+	"crypto"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,26 +14,35 @@ import (
 
 	ksigner "github.com/gosuda/keyless_tls/relay/signer"
 	"github.com/gosuda/keyless_tls/relay/signrpc"
+
+	"github.com/gosuda/portal-tunnel/v2/types"
+	"github.com/gosuda/portal-tunnel/v2/utils"
 )
 
 const (
-	RelayKeyID         = "relay-cert"
+	// TenantKeyID is the only private key identifier exposed by the keyless signer.
+	TenantKeyID        = "tenant-wildcard"
 	defaultAllowedSkew = 5 * time.Minute
 )
 
 type Signer struct {
-	service *ksigner.Service
-	keyID   string
+	service          *ksigner.Service
+	keyID            string
+	certificateChain []byte
 }
 
-func NewSigner(keyPEM []byte) (*Signer, error) {
-	signingKey, err := ksigner.ParsePrivateKeyPEM(keyPEM)
+func NewSigner(certPEM, keyPEM []byte) (*Signer, error) {
+	pair, err := tls.X509KeyPair(certPEM, keyPEM)
 	if err != nil {
-		return nil, fmt.Errorf("parse keyless signing key: %w", err)
+		return nil, fmt.Errorf("parse tenant keyless keypair: %w", err)
+	}
+	signingKey, ok := pair.PrivateKey.(crypto.Signer)
+	if !ok {
+		return nil, errors.New("tenant keyless private key does not implement crypto.Signer")
 	}
 
 	store := ksigner.NewStaticKeyStore()
-	if err := store.Put(RelayKeyID, signingKey); err != nil {
+	if err := store.Put(TenantKeyID, signingKey); err != nil {
 		return nil, fmt.Errorf("register keyless signing key: %w", err)
 	}
 
@@ -39,7 +51,8 @@ func NewSigner(keyPEM []byte) (*Signer, error) {
 			Store:       store,
 			AllowedSkew: defaultAllowedSkew,
 		},
-		keyID: RelayKeyID,
+		keyID:            TenantKeyID,
+		certificateChain: bytes.Clone(certPEM),
 	}, nil
 }
 
@@ -57,8 +70,47 @@ func (s *Signer) Sign(ctx context.Context, req *signrpc.SignRequest) (*signrpc.S
 	return s.service.Sign(ctx, req)
 }
 
+// ValidateMaterialSeparation ensures the tenant signer cannot authenticate the relay apex or unrelated names.
+func ValidateMaterialSeparation(hostname string, apiCertPEM, tenantCertPEM []byte) error {
+	hostname = utils.NormalizeHostname(hostname)
+	if hostname == "" {
+		return errors.New("relay hostname is required")
+	}
+	apiCert, err := utils.ParseCertificatePEM(apiCertPEM)
+	if err != nil {
+		return fmt.Errorf("parse api certificate: %w", err)
+	}
+	tenantCert, err := utils.ParseCertificatePEM(tenantCertPEM)
+	if err != nil {
+		return fmt.Errorf("parse tenant certificate: %w", err)
+	}
+	if bytes.Equal(apiCert.RawSubjectPublicKeyInfo, tenantCert.RawSubjectPublicKeyInfo) {
+		return errors.New("api and tenant certificates must use different public keys")
+	}
+	if tenantCert.IsCA {
+		return errors.New("tenant certificate must not be a certificate authority")
+	}
+	if tenantCert.VerifyHostname(hostname) == nil {
+		return fmt.Errorf("tenant certificate must not cover relay hostname %q", hostname)
+	}
+	wildcard := "*." + hostname
+	if len(tenantCert.DNSNames) != 1 || !strings.EqualFold(strings.TrimSpace(tenantCert.DNSNames[0]), wildcard) || len(tenantCert.IPAddresses) != 0 {
+		return fmt.Errorf("tenant certificate must cover only %q", wildcard)
+	}
+	return nil
+}
+
 func (s *Signer) Handler() http.Handler {
 	mux := http.NewServeMux()
+	mux.HandleFunc(types.PathV1KeylessMaterials, func(w http.ResponseWriter, r *http.Request) {
+		if !utils.RequireMethod(w, r, http.MethodGet) {
+			return
+		}
+		utils.WriteAPIData(w, http.StatusOK, types.KeylessMaterials{
+			KeyID:            s.keyID,
+			CertificateChain: bytes.Clone(s.certificateChain),
+		})
+	})
 	mux.HandleFunc(signrpc.SignPath, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.Header().Set("Allow", http.MethodPost)

--- a/portal/server.go
+++ b/portal/server.go
@@ -231,7 +231,7 @@ func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {
 		return errors.New("server already started")
 	}
 	cfg := s.config()
-	apiTLS, acmeManager, err := s.prepareAPITLS(ctx)
+	apiTLS, tenantTLS, acmeManager, err := s.prepareTLSMaterials(ctx)
 	if err != nil {
 		return err
 	}
@@ -286,7 +286,7 @@ func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {
 	}
 
 	group, groupCtx := errgroup.WithContext(serverCtx)
-	wrappedAPIListener, apiServer, apiCloser, err := s.newAPIServer(apiListener, apiMux, apiTLS)
+	wrappedAPIListener, apiServer, apiCloser, err := s.newAPIServer(apiListener, apiMux, apiTLS, tenantTLS)
 	if err != nil {
 		return err
 	}
@@ -475,11 +475,11 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return shutdownErr
 }
 
-func (s *Server) prepareAPITLS(ctx context.Context) (keyless.TLSMaterialConfig, *acme.Manager, error) {
+func (s *Server) prepareTLSMaterials(ctx context.Context) (keyless.TLSMaterialConfig, keyless.TLSMaterialConfig, *acme.Manager, error) {
 	cfg := s.config()
 	acmeCfg := cfg.ACME
 	if baseDomain := utils.NormalizeHostname(acmeCfg.BaseDomain); baseDomain != "" && baseDomain != s.identity.Name {
-		return keyless.TLSMaterialConfig{}, nil, fmt.Errorf("acme base domain %q does not match portal root host %q", acmeCfg.BaseDomain, s.identity.Name)
+		return keyless.TLSMaterialConfig{}, keyless.TLSMaterialConfig{}, nil, fmt.Errorf("acme base domain %q does not match portal root host %q", acmeCfg.BaseDomain, s.identity.Name)
 	}
 	acmeCfg.BaseDomain = s.identity.Name
 	if strings.TrimSpace(acmeCfg.ENSGaslessAddress) == "" {
@@ -488,18 +488,31 @@ func (s *Server) prepareAPITLS(ctx context.Context) (keyless.TLSMaterialConfig, 
 
 	manager, err := acme.NewManager(acmeCfg)
 	if err != nil {
-		return keyless.TLSMaterialConfig{}, nil, fmt.Errorf("create acme manager: %w", err)
+		return keyless.TLSMaterialConfig{}, keyless.TLSMaterialConfig{}, nil, fmt.Errorf("create acme manager: %w", err)
 	}
 
 	certPEM, keyPEM, err := manager.EnsureTLSMaterial(ctx)
 	if err != nil {
 		_ = manager.Stop(ctx)
-		return keyless.TLSMaterialConfig{}, nil, fmt.Errorf("ensure relay certificate: %w", err)
+		return keyless.TLSMaterialConfig{}, keyless.TLSMaterialConfig{}, nil, fmt.Errorf("ensure relay certificate: %w", err)
 	}
 
 	apiTLS := keyless.TLSMaterialConfig{
 		CertPEM: certPEM,
 		KeyPEM:  keyPEM,
+	}
+	tenantCertPEM, tenantKeyPEM, err := manager.EnsureTenantTLSMaterial(ctx)
+	if err != nil {
+		_ = manager.Stop(ctx)
+		return keyless.TLSMaterialConfig{}, keyless.TLSMaterialConfig{}, nil, fmt.Errorf("ensure tenant certificate: %w", err)
+	}
+	if err := keyless.ValidateMaterialSeparation(s.identity.Name, certPEM, tenantCertPEM); err != nil {
+		_ = manager.Stop(ctx)
+		return keyless.TLSMaterialConfig{}, keyless.TLSMaterialConfig{}, nil, fmt.Errorf("validate keyless material separation: %w", err)
+	}
+	tenantTLS := keyless.TLSMaterialConfig{
+		CertPEM: tenantCertPEM,
+		KeyPEM:  tenantKeyPEM,
 	}
 	echSeed, err := identity.DeriveToken(
 		s.identity.Identity,
@@ -509,12 +522,12 @@ func (s *Server) prepareAPITLS(ctx context.Context) (keyless.TLSMaterialConfig, 
 	)
 	if err != nil {
 		_ = manager.Stop(ctx)
-		return keyless.TLSMaterialConfig{}, nil, fmt.Errorf("derive relay ech seed: %w", err)
+		return keyless.TLSMaterialConfig{}, keyless.TLSMaterialConfig{}, nil, fmt.Errorf("derive relay ech seed: %w", err)
 	}
 	echKeys, echConfigList, err := keyless.EncryptedClientHelloMaterials(echSeed, s.identity.Name)
 	if err != nil {
 		_ = manager.Stop(ctx)
-		return keyless.TLSMaterialConfig{}, nil, fmt.Errorf("prepare ech materials: %w", err)
+		return keyless.TLSMaterialConfig{}, keyless.TLSMaterialConfig{}, nil, fmt.Errorf("prepare ech materials: %w", err)
 	}
 	if len(echKeys) > 0 {
 		apiTLS.EncryptedClientHelloKeys = echKeys
@@ -526,7 +539,7 @@ func (s *Server) prepareAPITLS(ctx context.Context) (keyless.TLSMaterialConfig, 
 		}
 	}
 
-	return apiTLS, manager, nil
+	return apiTLS, tenantTLS, manager, nil
 }
 
 func (s *Server) runAPIServer() error {

--- a/portal/server_test.go
+++ b/portal/server_test.go
@@ -125,6 +125,20 @@ func newTestClient(t *testing.T, cancel context.CancelFunc, server *Server) *htt
 
 func writeManualRelayCertificate(t *testing.T, keyDir, baseDomain string) {
 	t.Helper()
+	writeManualCertificate(t, keyDir, baseDomain, []string{baseDomain, "*." + baseDomain})
+}
+
+func writeManualTenantCertificate(t *testing.T, keyDir, baseDomain string) {
+	t.Helper()
+	tenantDir := filepath.Join(keyDir, "tenant")
+	if err := os.MkdirAll(tenantDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(tenant) error = %v", err)
+	}
+	writeManualCertificate(t, tenantDir, "*."+baseDomain, []string{"*." + baseDomain})
+}
+
+func writeManualCertificate(t *testing.T, keyDir, commonName string, dnsNames []string) {
+	t.Helper()
 
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -135,11 +149,11 @@ func writeManualRelayCertificate(t *testing.T, keyDir, baseDomain string) {
 	template := &x509.Certificate{
 		SerialNumber: big.NewInt(now.UnixNano()),
 		Subject: pkix.Name{
-			CommonName: baseDomain,
+			CommonName: commonName,
 		},
 		NotBefore:             now.Add(-time.Hour),
 		NotAfter:              now.Add(90 * 24 * time.Hour),
-		DNSNames:              []string{baseDomain, "*." + baseDomain},
+		DNSNames:              dnsNames,
 		BasicConstraintsValid: true,
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
@@ -342,6 +356,32 @@ func TestServerStartDomainReportsCompatibilityInfo(t *testing.T) {
 	if envelope.Data.X402.Enabled {
 		t.Fatalf("DomainResponse.X402.Enabled = true, want false")
 	}
+
+	materialsResp, err := client.Get("https://" + utils.HostPortOrLoopback(server.apiListener.Addr().String()) + types.PathV1KeylessMaterials)
+	if err != nil {
+		t.Fatalf("GET keyless materials error = %v", err)
+	}
+	defer materialsResp.Body.Close()
+	var materialsEnvelope types.APIEnvelope[types.KeylessMaterials]
+	if err := json.NewDecoder(materialsResp.Body).Decode(&materialsEnvelope); err != nil {
+		t.Fatalf("decode keyless materials response: %v", err)
+	}
+	if materialsResp.StatusCode != http.StatusOK || !materialsEnvelope.OK {
+		t.Fatalf("GET keyless materials status/envelope = %d/%+v, want success", materialsResp.StatusCode, materialsEnvelope)
+	}
+	if materialsEnvelope.Data.KeyID != keyless.TenantKeyID {
+		t.Fatalf("keyless materials key id = %q, want %q", materialsEnvelope.Data.KeyID, keyless.TenantKeyID)
+	}
+	tenantCert, err := utils.ParseCertificatePEM(materialsEnvelope.Data.CertificateChain)
+	if err != nil {
+		t.Fatalf("parse tenant certificate: %v", err)
+	}
+	if tenantCert.VerifyHostname("localhost") == nil {
+		t.Fatal("tenant certificate unexpectedly covers relay apex")
+	}
+	if err := tenantCert.VerifyHostname("lease.localhost"); err != nil {
+		t.Fatalf("tenant certificate does not cover lease hostname: %v", err)
+	}
 }
 
 func TestRegisterLeaseIncludesSNIPortForPublicIngress(t *testing.T) {
@@ -384,6 +424,7 @@ func TestServerStartUsesManualCertificateWithoutACMEProvider(t *testing.T) {
 
 	keyDir := t.TempDir()
 	writeManualRelayCertificate(t, keyDir, "portal.example.com")
+	writeManualTenantCertificate(t, keyDir, "portal.example.com")
 
 	server, err := NewServer(ServerConfig{
 		PortalURL:     "https://portal.example.com",

--- a/types/api.go
+++ b/types/api.go
@@ -93,6 +93,12 @@ type RegisterResponse struct {
 	TCPEnabled  bool      `json:"tcp_enabled,omitempty"`
 }
 
+// KeylessMaterials identifies the certificate chain and key ID exposed by the tenant signer.
+type KeylessMaterials struct {
+	KeyID            string `json:"key_id"`
+	CertificateChain []byte `json:"certificate_chain"`
+}
+
 type DiscoveryResponse struct {
 	ProtocolVersion string            `json:"protocol_version"`
 	GeneratedAt     time.Time         `json:"generated_at"`

--- a/types/paths.go
+++ b/types/paths.go
@@ -28,8 +28,9 @@ const (
 	X402VerifyPath      = PathX402Facilitator + "/verify"
 	X402SettlePath      = PathX402Facilitator + "/settle"
 
-	PathV1Prefix = "/v1"
-	PathV1Sign   = PathV1Prefix + "/sign"
+	PathV1Prefix           = "/v1"
+	PathV1Sign             = PathV1Prefix + "/sign"
+	PathV1KeylessMaterials = PathV1Prefix + "/keyless/materials"
 
 	PathSDKPrefix            = "/sdk"
 	PathSDKDomain            = PathSDKPrefix + "/domain"


### PR DESCRIPTION
…dpoint

- Updated README.md to clarify the use of separate tenant key for keyless signing.
- Bumped version in config.toml to v2.3.8 and updated protocol version.
- Added new API endpoint `/v1/keyless/materials` to retrieve tenant keyless materials.
- Enhanced architecture documentation to reflect changes in keyless signing and TLS configurations.
- Modified deployment instructions for manual certificate management to include tenant certificates.
- Implemented logic in acme package to manage tenant TLS materials separately.
- Added tests to ensure tenant TLS material generation and validation.
- Updated keyless signer to handle tenant-specific signing and validation.