### PR TITLE
chore: adopt Go 1.27 and integrate gojgp linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ formatters:
   enable: [goimports]
   settings:
     goimports:
-      local-prefixes: [github.com/gosuda/portal/v2]
+      local-prefixes: [github.com/gosuda/portal-tunnel/v2]
 
 linters:
   default: none

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ version: "2"
 
 run:
   tests: true
-  go: "1.26"
 
 formatters:
   enable: [goimports]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: fix-byte-order-marker
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.10.1
+    rev: v2.13.1
     hooks:
       - id: golangci-lint-config-verify
         name: golangci-lint-config-verify

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN --mount=type=cache,target=/root/.npm npm ci
 COPY frontend/ ./
 RUN npm run build
 
-FROM --platform=$BUILDPLATFORM golang:1.26.4 AS go-builder
+FROM --platform=$BUILDPLATFORM golang:1.27.0 AS go-builder
 WORKDIR /src
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,20 @@
 
 .DEFAULT_GOAL := help
 
-GO_PACKAGES := ./cmd/... ./portal/... ./sdk/... ./types/... ./utils/...
+GO_PACKAGES := . ./cmd/... ./portal/... ./sdk/... ./types/... ./utils/...
 GO_BUILD_FLAGS := -trimpath -ldflags "-s -w"
 GO_TOOLCHAIN_VERSION := $(shell awk '/^go / { print "go" $$2; exit }' go.mod)
-GOIMPORTS_VERSION := v0.41.0
-GOLANGCI_LINT_VERSION := v2.11.1
+GOIMPORTS_VERSION := v0.49.0
+GOLANGCI_LINT_VERSION := v2.12.2
+GOJGP_VERSION := v1.1.1
+GOIMPORTS_LOCAL := github.com/gosuda/portal-tunnel/v2
 
 export GOTOOLCHAIN := $(GO_TOOLCHAIN_VERSION)
 
 help:
 	@echo "Available targets:"
 	@echo "  make install           - Install Go developer tools used by this repo"
+	@echo "  make lint              - Run golangci-lint and gojgp"
 	@echo "  make fmt               - Apply gofmt/goimports"
 	@echo "  make lint-auto         - Run autofix lint/format pipeline"
 	@echo "  make test              - Run Go and frontend tests"
@@ -27,21 +30,24 @@ help:
 install:
 	go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	go install github.com/gosuda/JustGoodPractices/cmd/gojgp@$(GOJGP_VERSION)
 
 fmt:
 	gofmt -w .
-	goimports -w .
+	goimports -local $(GOIMPORTS_LOCAL) -w .
 
 vet:
 	go vet $(GO_PACKAGES)
 
 lint:
 	golangci-lint run $(GO_PACKAGES)
+	go run ./cmd/gojgp-lint $(GO_PACKAGES)
 
 lint-auto:
 	gofmt -w .
-	goimports -w .
+	goimports -local $(GOIMPORTS_LOCAL) -w .
 	golangci-lint run --fix $(GO_PACKAGES)
+	go run ./cmd/gojgp-lint $(GO_PACKAGES)
 
 test:
 	go test -v -coverprofile=coverage.out $(GO_PACKAGES)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GO_PACKAGES := . ./cmd/... ./portal/... ./sdk/... ./types/... ./utils/...
 GO_BUILD_FLAGS := -trimpath -ldflags "-s -w"
 GO_TOOLCHAIN_VERSION := $(shell awk '/^go / { print "go" $$2; exit }' go.mod)
 GOIMPORTS_VERSION := v0.49.0
-GOLANGCI_LINT_VERSION := v2.12.2
+GOLANGCI_LINT_VERSION := v2.13.1
 GOJGP_VERSION := v1.1.1
 GOIMPORTS_LOCAL := github.com/gosuda/portal-tunnel/v2
 

--- a/cmd/gojgp-lint/main.go
+++ b/cmd/gojgp-lint/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+const ignoredLawOfDemeter = "[Design Principles: Law of Demeter]"
+
+type diagnostic struct {
+	Position string `json:"posn"`
+	Message  string `json:"message"`
+}
+
+func main() {
+	packages := os.Args[1:]
+	if len(packages) == 0 {
+		packages = []string{"./..."}
+	}
+
+	args := append([]string{"lint", "-json"}, packages...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command := exec.CommandContext(context.Background(), "gojgp", args...)
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		_, _ = os.Stderr.Write(stderr.Bytes())
+		fmt.Fprintf(os.Stderr, "run gojgp: %v\n", err)
+		os.Exit(1)
+	}
+
+	var report map[string]map[string][]diagnostic
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		fmt.Fprintf(os.Stderr, "decode gojgp output: %v\n", err)
+		os.Exit(1)
+	}
+
+	seen := make(map[string]struct{})
+	var findings []diagnostic
+	for _, analyzers := range report {
+		for _, finding := range analyzers["gojgp"] {
+			if strings.HasPrefix(finding.Message, ignoredLawOfDemeter) {
+				continue
+			}
+			key := finding.Position + "\x00" + finding.Message
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			findings = append(findings, finding)
+		}
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Position != findings[j].Position {
+			return findings[i].Position < findings[j].Position
+		}
+		return findings[i].Message < findings[j].Message
+	})
+	for _, finding := range findings {
+		fmt.Fprintf(os.Stderr, "%s: %s\n", finding.Position, finding.Message)
+	}
+	if len(findings) != 0 {
+		fmt.Fprintf(os.Stderr, "gojgp: %d issue(s)\n", len(findings))
+		os.Exit(1)
+	}
+}

--- a/cmd/payment-app/handler.go
+++ b/cmd/payment-app/handler.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"cmp"
 	"embed"
 	"encoding/json"
 	"html/template"
@@ -125,9 +126,7 @@ func (h *paymentHandler) renderPaidPhoto(w http.ResponseWriter, r *http.Request,
 
 func (h *paymentHandler) newPaymentPageData(r *http.Request) paymentPageData {
 	description := strings.TrimSpace(h.metadata.Description)
-	if description == "" {
-		description = "Connect a Sui wallet, settle USDC with x402, and reveal the protected image."
-	}
+	description = cmp.Or(description, "Connect a Sui wallet, settle USDC with x402, and reveal the protected image.")
 	config := map[string]any{
 		"network":       h.network,
 		"networkName":   h.networkName,

--- a/cmd/portal-loadtest/main.go
+++ b/cmd/portal-loadtest/main.go
@@ -142,7 +142,7 @@ func gamSer(s, x float64) float64 {
 	ap := s
 	del := 1.0 / s
 	sum := del
-	for n := 0; n < maxIter; n++ {
+	for range maxIter {
 		ap++
 		del *= x / ap
 		sum += del

--- a/cmd/portal-tunnel/Dockerfile
+++ b/cmd/portal-tunnel/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.27.0 AS builder
 WORKDIR /src
 
 COPY go.mod go.sum ./

--- a/cmd/portal-tunnel/agent.go
+++ b/cmd/portal-tunnel/agent.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"flag"
@@ -230,9 +231,7 @@ func runAgentStopCommand(args []string) error {
 	stateDir = strings.TrimSpace(stateDir)
 	cfg := agent.Config{Agent: agent.AgentConfig{ServiceName: agent.DefaultServiceName}}
 	if configPath != "" || stateDir == "" {
-		if configPath == "" {
-			configPath = service.DefaultConfigPath()
-		}
+		configPath = cmp.Or(configPath, service.DefaultConfigPath())
 		var err error
 		cfg, err = agent.LoadExistingConfig(configPath)
 		if err != nil {
@@ -286,9 +285,7 @@ func runAgentDashboardCommand(args []string) error {
 
 	configPath = strings.TrimSpace(configPath)
 	stateDir = strings.TrimSpace(stateDir)
-	if configPath == "" {
-		configPath = service.DefaultConfigPath()
-	}
+	configPath = cmp.Or(configPath, service.DefaultConfigPath())
 	if stateDir == "" {
 		if _, err := os.Stat(configPath); err == nil {
 			cfg, err := agent.LoadExistingConfig(configPath)
@@ -329,7 +326,10 @@ func waitAgentStopped(ctx context.Context, stateDir string) error {
 	for {
 		_, err := agent.Status(ctx, stateDir)
 		if err != nil {
-			return nil
+			if errors.Is(err, agent.ErrNotRunning) {
+				return nil
+			}
+			return fmt.Errorf("check portal agent status while waiting for shutdown: %w", err)
 		}
 		select {
 		case <-ctx.Done():

--- a/cmd/portal-tunnel/agent/config.go
+++ b/cmd/portal-tunnel/agent/config.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"os"
@@ -77,9 +78,7 @@ type HTTPRouteConfig struct {
 
 func LoadExistingConfig(path string) (Config, error) {
 	path = strings.TrimSpace(path)
-	if path == "" {
-		path = service.DefaultConfigPath()
-	}
+	path = cmp.Or(path, service.DefaultConfigPath())
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return Config{}, err
@@ -99,9 +98,7 @@ func LoadExistingConfig(path string) (Config, error) {
 
 func loadConfigDocument(path string) (Config, string, os.FileMode, error) {
 	path = strings.TrimSpace(path)
-	if path == "" {
-		path = service.DefaultConfigPath()
-	}
+	path = cmp.Or(path, service.DefaultConfigPath())
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return Config{}, "", 0, err
@@ -148,9 +145,7 @@ func writeConfigDocument(path string, mode os.FileMode, cfg Config) error {
 	if err != nil {
 		return err
 	}
-	if mode == 0 {
-		mode = 0o644
-	}
+	mode = cmp.Or(mode, 0o644)
 	return os.WriteFile(path, data, mode)
 }
 
@@ -365,7 +360,9 @@ func (cfg TunnelConfig) Validate() error {
 	if len(cfg.MultiHop) > 0 && cfg.MultiHopDepth > 1 {
 		return fmt.Errorf("tunnel %q cannot combine multi_hop and multi_hop_depth", cfg.ID)
 	}
-	if (len(cfg.MultiHop) > 0 || cfg.MultiHopDepth > 1) && (cfg.UDPEnabled || cfg.TCPEnabled) {
+	multiHopEnabled := len(cfg.MultiHop) > 0 || cfg.MultiHopDepth > 1
+	nonStreamTransport := cfg.UDPEnabled || cfg.TCPEnabled
+	if multiHopEnabled && nonStreamTransport {
 		return fmt.Errorf("tunnel %q multi-hop supports only the default stream transport", cfg.ID)
 	}
 	if len(cfg.MultiHop) > 0 {

--- a/cmd/portal-tunnel/agent/dashboard.go
+++ b/cmd/portal-tunnel/agent/dashboard.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"net/url"
@@ -561,9 +562,7 @@ func (m *agentDashboardModel) clampSidebarScroll() {
 
 func (m agentDashboardModel) sidebarContentWidth() int {
 	configPath := strings.TrimSpace(m.status.ConfigPath)
-	if configPath == "" {
-		configPath = strings.TrimSpace(m.configPath)
-	}
+	configPath = cmp.Or(configPath, strings.TrimSpace(m.configPath))
 	contentWidth := lipgloss.Width("PORTAL")
 	contentWidth = max(contentWidth, agentDashboardMetaWidth(configPath))
 	contentWidth = max(contentWidth, agentDashboardMetaWidth(strings.TrimSpace(m.status.ControlAddr)))
@@ -1031,9 +1030,7 @@ func (m agentDashboardModel) addTunnelRequest() (types.AgentTunnelRequest, error
 		return types.AgentTunnelRequest{}, fmt.Errorf("X402 Pay To requires routes")
 	}
 	x402TestnetRaw := strings.TrimSpace(m.addX402Testnet.Value())
-	if x402TestnetRaw == "" {
-		x402TestnetRaw = "false"
-	}
+	x402TestnetRaw = cmp.Or(x402TestnetRaw, "false")
 	x402Testnet, err := strconv.ParseBool(x402TestnetRaw)
 	if err != nil {
 		return types.AgentTunnelRequest{}, fmt.Errorf("X402 Testnet must be true or false")
@@ -1052,18 +1049,14 @@ func (m agentDashboardModel) addTunnelRequest() (types.AgentTunnelRequest, error
 	}
 
 	discoveryRaw := strings.TrimSpace(m.addDiscovery.Value())
-	if discoveryRaw == "" {
-		discoveryRaw = "true"
-	}
+	discoveryRaw = cmp.Or(discoveryRaw, "true")
 	discovery, err := strconv.ParseBool(discoveryRaw)
 	if err != nil {
 		return types.AgentTunnelRequest{}, fmt.Errorf("discovery must be true or false")
 	}
 
 	maxRelaysRaw := strings.TrimSpace(m.addMaxRelays.Value())
-	if maxRelaysRaw == "" {
-		maxRelaysRaw = "3"
-	}
+	maxRelaysRaw = cmp.Or(maxRelaysRaw, "3")
 	maxRelays, err := strconv.Atoi(maxRelaysRaw)
 	if err != nil || maxRelays <= 0 {
 		return types.AgentTunnelRequest{}, fmt.Errorf("max relays must be a positive integer")
@@ -1092,7 +1085,7 @@ func agentDashboardParseAddHTTPRoutes(value string) ([]types.AgentHTTPRoute, err
 	var routes []types.AgentHTTPRoute
 	seen := make(map[string]struct{})
 
-	for _, rawSegment := range strings.Split(value, ";") {
+	for rawSegment := range strings.SplitSeq(value, ";") {
 		segment := strings.TrimSpace(rawSegment)
 		if segment == "" {
 			continue
@@ -1167,7 +1160,7 @@ func agentDashboardParseAddRoutePayment(value string) ([]string, string, error) 
 	}
 
 	methods := []string(nil)
-	for _, rawMethod := range strings.Split(methodPart, ",") {
+	for rawMethod := range strings.SplitSeq(methodPart, ",") {
 		method := strings.ToUpper(strings.TrimSpace(rawMethod))
 		if method == "" {
 			return nil, "", fmt.Errorf("payment method is required")
@@ -1213,9 +1206,7 @@ func (m agentDashboardModel) applySettingsEdit() (tea.Model, tea.Cmd) {
 	}
 
 	hideRaw := strings.TrimSpace(m.metadataHide.Value())
-	if hideRaw == "" {
-		hideRaw = "false"
-	}
+	hideRaw = cmp.Or(hideRaw, "false")
 	hide, err := strconv.ParseBool(hideRaw)
 	if err != nil {
 		m.err = fmt.Errorf("metadata hidden must be true or false")
@@ -1436,9 +1427,7 @@ func (m agentDashboardModel) renderSidebar(width, height int) agentDashboardView
 	pane.addStyled(width, agentDashboardRuleStyle, strings.Repeat("-", width))
 
 	configPath := strings.TrimSpace(m.status.ConfigPath)
-	if configPath == "" {
-		configPath = strings.TrimSpace(m.configPath)
-	}
+	configPath = cmp.Or(configPath, strings.TrimSpace(m.configPath))
 	pane.addSidebarTitle(width, "Runtime")
 	pane.addMeta(width, m.sidebarScrollX, "Config", configPath)
 	pane.addMeta(width, m.sidebarScrollX, "Control", strings.TrimSpace(m.status.ControlAddr))
@@ -1776,9 +1765,7 @@ func (v *agentDashboardView) addSidebarTitle(width int, title string) {
 
 func (v *agentDashboardView) addMeta(width, offset int, label, value string) {
 	value = strings.TrimSpace(value)
-	if value == "" {
-		value = "-"
-	}
+	value = cmp.Or(value, "-")
 	labelText := agentDashboardLabelStyle.Render(agentDashboardCell(label+":", 9))
 	valueText := agentDashboardMutedStyle.Render(agentDashboardWindow(value, offset, max(1, width-10)))
 	v.addLine(labelText + " " + valueText)
@@ -2012,9 +1999,7 @@ func agentDashboardColumnWidths(width int) (int, int, int) {
 
 func agentDashboardMetaWidth(value string) int {
 	value = strings.TrimSpace(value)
-	if value == "" {
-		value = "-"
-	}
+	value = cmp.Or(value, "-")
 	return 10 + lipgloss.Width(value)
 }
 
@@ -2071,13 +2056,9 @@ func relayDashboardConnected(tunnel types.AgentTunnelStatus, relay types.AgentRe
 
 func agentDashboardHTTPRouteSummary(route types.AgentHTTPRoute) string {
 	prefix := strings.TrimSpace(route.Prefix)
-	if prefix == "" {
-		prefix = "-"
-	}
+	prefix = cmp.Or(prefix, "-")
 	upstream := strings.TrimSpace(route.Upstream)
-	if upstream == "" {
-		upstream = "-"
-	}
+	upstream = cmp.Or(upstream, "-")
 	if amount := strings.TrimSpace(route.Amount); amount != "" {
 		methods := "ALL"
 		if len(route.Methods) > 0 {
@@ -2168,9 +2149,7 @@ func relayDashboardPublicURL(rawURL string) string {
 		return rawURL
 	}
 	host := parsed.Hostname()
-	if host == "" {
-		host = parsed.Host
-	}
+	host = cmp.Or(host, parsed.Host)
 	if strings.Contains(host, ":") && !strings.HasPrefix(host, "[") {
 		host = "[" + host + "]"
 	}
@@ -2289,10 +2268,7 @@ func agentDashboardRelayWindow(selected, total, rows int) (int, int) {
 	if selected >= total {
 		selected = total - 1
 	}
-	start := selected - rows/2
-	if start < 0 {
-		start = 0
-	}
+	start := max(selected-rows/2, 0)
 	if start+rows > total {
 		start = total - rows
 	}
@@ -2331,9 +2307,7 @@ func agentDashboardURLCell(value string, width int) string {
 	parsed, err := url.Parse(value)
 	if err == nil && parsed.Scheme != "" && parsed.Host != "" {
 		host := strings.TrimSpace(parsed.Hostname())
-		if host == "" {
-			host = strings.TrimSpace(parsed.Host)
-		}
+		host = cmp.Or(host, strings.TrimSpace(parsed.Host))
 		if host != "" {
 			return agentDashboardFit("open "+host, width)
 		}

--- a/cmd/portal-tunnel/agent/manager.go
+++ b/cmd/portal-tunnel/agent/manager.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -210,9 +211,7 @@ func (m *manager) AddTunnel(req types.AgentTunnelRequest) error {
 	}
 	id := strings.TrimSpace(req.ID)
 	name := strings.TrimSpace(req.Name)
-	if id == "" {
-		id = agentTunnelID(name)
-	}
+	id = cmp.Or(id, agentTunnelID(name))
 	if id == "" {
 		return errors.New("tunnel name is required")
 	}
@@ -235,9 +234,7 @@ func (m *manager) AddTunnel(req types.AgentTunnelRequest) error {
 	if target == "" && len(httpRoutes) == 0 {
 		target = defaultTargetAddr
 	}
-	if name == "" {
-		name = id
-	}
+	name = cmp.Or(name, id)
 	relayURLs, err := utils.NormalizeRelayURLs(req.RelayURLs...)
 	if err != nil {
 		return err
@@ -706,9 +703,7 @@ func (t *managedTunnel) runOnce(ctx context.Context) error {
 		banMITM = *cfg.BanMITM
 	}
 	x402FacilitatorToken := strings.TrimSpace(cfg.X402FacilitatorToken)
-	if x402FacilitatorToken == "" {
-		x402FacilitatorToken = strings.TrimSpace(os.Getenv("CSPR_CLOUD_API_KEY"))
-	}
+	x402FacilitatorToken = cmp.Or(x402FacilitatorToken, strings.TrimSpace(os.Getenv("CSPR_CLOUD_API_KEY")))
 	exposure, err := sdk.Expose(ctx, sdk.ExposeConfig{
 		RelayURLs:            append([]string(nil), cfg.RelayURLs...),
 		Discovery:            discovery,

--- a/cmd/portal-tunnel/agent/service/service_darwin.go
+++ b/cmd/portal-tunnel/agent/service/service_darwin.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 func Install(ctx context.Context, def Definition) error {
@@ -68,9 +69,9 @@ func launchdPlistPath(name string) (string, string, error) {
 
 func launchdPlist(def Definition) string {
 	args := append([]string{def.Executable}, def.Args...)
-	argXML := ""
+	var argXML strings.Builder
 	for _, arg := range args {
-		argXML += "\n    <string>" + xmlEscape(arg) + "</string>"
+		argXML.WriteString("\n    <string>" + xmlEscape(arg) + "</string>")
 	}
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -89,12 +90,12 @@ func launchdPlist(def Definition) string {
   <true/>
 </dict>
 </plist>
-`, xmlEscape(def.Name), argXML, xmlEscape(def.WorkingDir))
+`, xmlEscape(def.Name), argXML.String(), xmlEscape(def.WorkingDir))
 }
 
 func xmlEscape(value string) string {
 	var out []byte
-	xml.EscapeText((*appendWriter)(&out), []byte(value))
+	_ = xml.EscapeText((*appendWriter)(&out), []byte(value))
 	return string(out)
 }
 

--- a/cmd/portal-tunnel/agent_test.go
+++ b/cmd/portal-tunnel/agent_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWaitAgentStoppedReturnsStatusErrors(t *testing.T) {
+	stateDir := t.TempDir()
+	endpointPath := filepath.Join(stateDir, "agent-endpoint.json")
+	if err := os.WriteFile(endpointPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write incomplete agent endpoint: %v", err)
+	}
+
+	err := waitAgentStopped(t.Context(), stateDir)
+	if err == nil {
+		t.Fatal("waitAgentStopped() error = nil, want incomplete endpoint error")
+	}
+	if !strings.Contains(err.Error(), "agent endpoint state is incomplete") {
+		t.Fatalf("waitAgentStopped() error = %q, want incomplete endpoint error", err)
+	}
+}
+
+func TestWaitAgentStoppedAcceptsMissingEndpoint(t *testing.T) {
+	if err := waitAgentStopped(t.Context(), t.TempDir()); err != nil {
+		t.Fatalf("waitAgentStopped() error = %v, want nil for stopped agent", err)
+	}
+}

--- a/cmd/portal-tunnel/installer/update.go
+++ b/cmd/portal-tunnel/installer/update.go
@@ -39,33 +39,43 @@ func StartUpdateCheck(currentVersion string) {
 
 	go func() {
 		for {
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodHead, binURL, nil)
-			if err == nil {
-				resp, err := updateCheckClient.Do(req)
-				if err == nil {
-					location := resp.Header.Get("Location")
-					_ = resp.Body.Close()
-
-					if parsed, err := url.Parse(location); err == nil {
-						segments := strings.Split(strings.TrimPrefix(parsed.Path, "/"), "/")
-						if len(segments) >= 5 {
-							version := segments[4]
-							current := strings.TrimSpace(currentVersion)
-							if current != "" && !strings.HasPrefix(current, "v") {
-								current = "v" + current
-							}
-							latestValid := strings.HasPrefix(version, "v") && semver.IsValid(version)
-							if latestValid && semver.IsValid(current) && semver.Compare(version, current) > 0 {
-								fmt.Fprintf(os.Stderr, "\nA new version is available: %s. Run 'portal update' to upgrade.\n", version)
-							}
-						}
-					}
-				}
-			}
-
+			checkForAvailableUpdate(currentVersion, binURL)
 			time.Sleep(updateCheckInterval)
 		}
 	}()
+}
+
+func checkForAvailableUpdate(currentVersion, binURL string) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodHead, binURL, nil)
+	if err != nil {
+		return
+	}
+	resp, err := updateCheckClient.Do(req)
+	if err != nil {
+		return
+	}
+	location := resp.Header.Get("Location")
+	_ = resp.Body.Close()
+
+	parsed, err := url.Parse(location)
+	if err != nil {
+		return
+	}
+	segments := strings.Split(strings.TrimPrefix(parsed.Path, "/"), "/")
+	if len(segments) < 5 {
+		return
+	}
+
+	version := segments[4]
+	current := strings.TrimSpace(currentVersion)
+	if current != "" && !strings.HasPrefix(current, "v") {
+		current = "v" + current
+	}
+	latestValid := strings.HasPrefix(version, "v") && semver.IsValid(version)
+	if !latestValid || !semver.IsValid(current) || semver.Compare(version, current) <= 0 {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "\nA new version is available: %s. Run 'portal update' to upgrade.\n", version)
 }
 
 func UpdateCurrentBinary(version string) error {

--- a/cmd/portal-tunnel/main.go
+++ b/cmd/portal-tunnel/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"flag"
@@ -8,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"text/tabwriter"
@@ -279,18 +281,12 @@ func parseHTTPRoutePayment(value string) ([]string, string, error) {
 	}
 	methods := []string(nil)
 	if hasMethods {
-		for _, rawMethod := range strings.Split(methodPart, ",") {
+		for rawMethod := range strings.SplitSeq(methodPart, ",") {
 			method := strings.ToUpper(strings.TrimSpace(rawMethod))
 			if method == "" {
 				return nil, "", errors.New("payment method is required")
 			}
-			exists := false
-			for _, existing := range methods {
-				if existing == method {
-					exists = true
-					break
-				}
-			}
+			exists := slices.Contains(methods, method)
 			if !exists {
 				methods = append(methods, method)
 			}
@@ -379,9 +375,7 @@ func runListCommand(args []string) error {
 	fmt.Fprintln(table, "RELAY\tVERSION")
 	for i, relayURL := range relayURLs {
 		ver := versions[i]
-		if ver == "" {
-			ver = "unknown"
-		}
+		ver = cmp.Or(ver, "unknown")
 		fmt.Fprintf(table, "%s\t%s\n", relayURL, ver)
 	}
 	return table.Flush()

--- a/cmd/relay-server/api.go
+++ b/cmd/relay-server/api.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"cmp"
 	"crypto/sha256"
 	"crypto/subtle"
 	"embed"
@@ -13,6 +14,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog/log"
+
 	portaltunnel "github.com/gosuda/portal-tunnel/v2"
 	"github.com/gosuda/portal-tunnel/v2/cmd/portal-tunnel/installer"
 	"github.com/gosuda/portal-tunnel/v2/portal"
@@ -20,8 +24,6 @@ import (
 	"github.com/gosuda/portal-tunnel/v2/portal/policy"
 	"github.com/gosuda/portal-tunnel/v2/types"
 	"github.com/gosuda/portal-tunnel/v2/utils"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/rs/zerolog/log"
 )
 
 //go:embed dist/*
@@ -128,9 +130,7 @@ func (api *RelayAPI) loadPolicyState() error {
 
 func (api *RelayAPI) serveAdmin(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimSuffix(strings.TrimSpace(r.URL.Path), "/")
-	if path == "" {
-		path = types.PathRoot
-	}
+	path = cmp.Or(path, types.PathRoot)
 
 	switch path {
 	case types.PathAdmin:
@@ -174,9 +174,7 @@ func (api *RelayAPI) serveAdmin(w http.ResponseWriter, r *http.Request) {
 
 func (api *RelayAPI) servePolicy(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimSuffix(strings.TrimSpace(r.URL.Path), "/")
-	if path == "" {
-		path = types.PathRoot
-	}
+	path = cmp.Or(path, types.PathRoot)
 
 	if !api.authenticatedAdmin(r) {
 		utils.WriteAPIError(w, http.StatusUnauthorized, types.APIErrorCodeUnauthorized, "unauthorized")

--- a/cmd/relay-server/frontend.go
+++ b/cmd/relay-server/frontend.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"compress/gzip"
 	"fmt"
 	"io/fs"
@@ -73,9 +74,7 @@ func (api *RelayAPI) serveFrontend(w http.ResponseWriter, r *http.Request) {
 	}
 
 	assetPath := strings.TrimPrefix(requestPath, "/")
-	if assetPath == "" {
-		assetPath = "index.html"
-	}
+	assetPath = cmp.Or(assetPath, "index.html")
 	asset, err := api.loadFrontendAsset(assetPath)
 	if err != nil {
 		// Missing static assets 404; only client-route-looking paths fall back.
@@ -128,9 +127,7 @@ func (api *RelayAPI) loadFrontendAsset(assetPath string) (*frontendAsset, error)
 		return nil, err
 	}
 	contentType := mime.TypeByExtension(path.Ext(assetPath))
-	if contentType == "" {
-		contentType = http.DetectContentType(data)
-	}
+	contentType = cmp.Or(contentType, http.DetectContentType(data))
 	asset := &frontendAsset{contentType: contentType, data: data}
 	compressible := strings.HasPrefix(contentType, "text/") ||
 		strings.HasPrefix(contentType, "application/javascript") ||

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gosuda/portal-tunnel/v2
 
-go 1.26.4
+go 1.27.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/portal/acme/certificate.go
+++ b/portal/acme/certificate.go
@@ -96,9 +96,11 @@ func newClient(ctx context.Context, email, accountKeyFile, registrationFile stri
 
 	var accountReg registration.Resource
 	accountRegPtr := (*registration.Resource)(nil)
-	if ok, err := utils.ReadJSONFileIfExists(registrationFile, &accountReg); err != nil {
+	ok, err := utils.ReadJSONFileIfExists(registrationFile, &accountReg)
+	if err != nil {
 		return nil, fmt.Errorf("load acme registration: %w", err)
-	} else if ok {
+	}
+	if ok {
 		accountRegPtr = &accountReg
 	}
 

--- a/portal/acme/cloudflare/provider.go
+++ b/portal/acme/cloudflare/provider.go
@@ -1,6 +1,7 @@
 package cloudflare
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -449,9 +450,7 @@ func ensureHTTPSRecord(ctx context.Context, token, zoneID, name string, record d
 func sameHTTPSRecord(existing dnsRecord, record dnsrecord.HTTPSRecord) bool {
 	if existing.Data != nil {
 		existingTarget := strings.TrimSpace(existing.Data.Target)
-		if existingTarget == "" {
-			existingTarget = "."
-		}
+		existingTarget = cmp.Or(existingTarget, ".")
 		return existing.Data.Priority == int(record.Priority) &&
 			existingTarget == record.Target &&
 			strings.TrimSpace(existing.Data.Value) == record.SvcParams

--- a/portal/acme/embedded/provider.go
+++ b/portal/acme/embedded/provider.go
@@ -5,6 +5,7 @@
 package embedded
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -84,9 +85,7 @@ func New(cfg Config) (*Provider, error) {
 		return nil, fmt.Errorf("embedded dns base domain %q must be a hostname", baseDomain)
 	}
 	listenAddr := strings.TrimSpace(cfg.ListenAddr)
-	if listenAddr == "" {
-		listenAddr = defaultListenAddr
-	}
+	listenAddr = cmp.Or(listenAddr, defaultListenAddr)
 
 	p := &Provider{
 		baseDomain: baseDomain,

--- a/portal/acme/gcloud/provider.go
+++ b/portal/acme/gcloud/provider.go
@@ -1,6 +1,7 @@
 package gcloud
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -391,9 +392,7 @@ func newRuntimeConfig(ctx context.Context, cfg Config) (runtimeConfig, error) {
 	}
 
 	projectID := strings.TrimSpace(cfg.ProjectID)
-	if projectID == "" {
-		projectID = strings.TrimSpace(creds.ProjectID)
-	}
+	projectID = cmp.Or(projectID, strings.TrimSpace(creds.ProjectID))
 	if projectID == "" && metadata.OnGCE() {
 		if detected, err := metadata.ProjectIDWithContext(ctx); err == nil {
 			projectID = strings.TrimSpace(detected)

--- a/portal/acme/internal/dnsrecord/dnsrecord.go
+++ b/portal/acme/internal/dnsrecord/dnsrecord.go
@@ -1,6 +1,7 @@
 package dnsrecord
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"strconv"
@@ -17,15 +18,12 @@ type HTTPSRecord struct {
 
 func (r HTTPSRecord) Normalized() (HTTPSRecord, error) {
 	target := strings.TrimSpace(r.Target)
-	if target == "" {
-		target = "."
-	} else if target != "." {
+	target = cmp.Or(target, ".")
+	if target != "." {
 		target = strings.TrimSuffix(target, ".") + "."
 	}
 	priority := r.Priority
-	if priority == 0 {
-		priority = 1
-	}
+	priority = cmp.Or(priority, 1)
 	svcParams := strings.TrimSpace(r.SvcParams)
 	if svcParams == "" {
 		return HTTPSRecord{}, errors.New("https record svc params are required")
@@ -73,7 +71,8 @@ func NameMatches(recordName, expected, fqdn, zone string) bool {
 	if recordName == expected {
 		return true
 	}
-	if expected == "@" && (recordName == "" || recordName == zone || recordName == fqdn) {
+	apexRecord := recordName == "" || recordName == zone || recordName == fqdn
+	if expected == "@" && apexRecord {
 		return true
 	}
 	return recordName == fqdn

--- a/portal/acme/njalla/provider.go
+++ b/portal/acme/njalla/provider.go
@@ -2,6 +2,7 @@ package njalla
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -480,9 +481,7 @@ func (c *apiClient) do(ctx context.Context, method string, params any, out any) 
 		return errors.New("njalla client is nil")
 	}
 	endpoint := strings.TrimSpace(c.endpoint)
-	if endpoint == "" {
-		endpoint = apiEndpoint
-	}
+	endpoint = cmp.Or(endpoint, apiEndpoint)
 	body, err := json.Marshal(apiRequest{Method: method, Params: params})
 	if err != nil {
 		return fmt.Errorf("marshal njalla api request: %w", err)

--- a/portal/acme/route53/provider.go
+++ b/portal/acme/route53/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"time"
@@ -403,9 +404,7 @@ func (p *Provider) findHostedZoneID(ctx context.Context, client *awsroute53.Clie
 			if *zones == nil {
 				*zones = make(map[string]string)
 			}
-			for zoneName, zoneID := range zonesByName {
-				(*zones)[zoneName] = zoneID
-			}
+			maps.Copy((*zones), zonesByName)
 		})
 	}
 
@@ -650,8 +649,7 @@ func ensureActiveKeySigningKey(ctx context.Context, client *awsroute53.Client, h
 		Status:                  aws.String("ACTIVE"),
 	})
 	if err != nil {
-		var alreadyExists *route53types.KeySigningKeyAlreadyExists
-		if errors.As(err, &alreadyExists) {
+		if _, ok := errors.AsType[*route53types.KeySigningKeyAlreadyExists](err); ok {
 			return nil
 		}
 		return fmt.Errorf("create route53 key-signing key %q: %w", kskName, err)

--- a/portal/acme/vultr/provider.go
+++ b/portal/acme/vultr/provider.go
@@ -1,6 +1,7 @@
 package vultr
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -440,9 +441,7 @@ func preferredDSRecord(records []string) string {
 		if ds == "" {
 			continue
 		}
-		if first == "" {
-			first = ds
-		}
+		first = cmp.Or(first, ds)
 		fields := strings.Fields(ds)
 		if len(fields) < 4 {
 			continue

--- a/portal/api_server.go
+++ b/portal/api_server.go
@@ -1,6 +1,7 @@
 package portal
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -48,8 +49,7 @@ var (
 )
 
 func writeAPIErrorResponse(w http.ResponseWriter, err error) {
-	var ae *apiError
-	if errors.As(err, &ae) {
+	if ae, ok := errors.AsType[*apiError](err); ok {
 		utils.WriteAPIError(w, ae.status, ae.code, ae.msg)
 		return
 	}
@@ -340,9 +340,7 @@ func (s *Server) handleRegisterChallenge(w http.ResponseWriter, r *http.Request)
 		scheme = "http"
 	}
 	domain := strings.TrimSpace(r.Host)
-	if domain == "" {
-		domain = s.identity.Name
-	}
+	domain = cmp.Or(domain, s.identity.Name)
 	registerURI := (&url.URL{
 		Scheme: scheme,
 		Host:   domain,
@@ -459,7 +457,11 @@ func (s *Server) handleHop(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if r.Method == http.MethodDelete {
-		record := s.registry.DeleteHopRoute(&route)
+		record, err := s.registry.DeleteHopRoute(&route)
+		if err != nil {
+			utils.InvalidRequestError(err).Write(w)
+			return
+		}
 		dnsCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), defaultClaimTimeout)
 		record.deleteDNS(dnsCtx, s.acmeManager, true)
 		cancel()
@@ -499,7 +501,8 @@ func (s *Server) handleHop(w http.ResponseWriter, r *http.Request) {
 	err = record.syncENSGaslessDNS(dnsCtx, s.acmeManager)
 	cancel()
 	if err != nil {
-		removed := s.registry.DeleteHopRoute(&route)
+		removed, deleteErr := s.registry.DeleteHopRoute(&route)
+		err = errors.Join(err, deleteErr)
 		if removed == nil {
 			removed = record
 		}

--- a/portal/auth/register_challenge.go
+++ b/portal/auth/register_challenge.go
@@ -38,7 +38,7 @@ func NewRegisterChallenge(req types.RegisterChallengeRequest, domain, uri string
 	challengeID := utils.RandomID("rch_")
 	nonce := siwe.GenerateNonce()
 	expiresAt := now.UTC().Add(ttl)
-	message, err := siwe.InitMessage(domain, normalizedIdentity.Address, uri, nonce, map[string]interface{}{
+	message, err := siwe.InitMessage(domain, normalizedIdentity.Address, uri, nonce, map[string]any{
 		"statement":      "Register a portal lease",
 		"chainId":        1,
 		"issuedAt":       now.UTC().Format(time.RFC3339),

--- a/portal/auth/wallet_auth.go
+++ b/portal/auth/wallet_auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"strings"
@@ -72,9 +73,7 @@ func NewWalletAuthenticator(cfg WalletAuthConfig) (*WalletAuthenticator, error) 
 	}
 
 	statement := strings.TrimSpace(cfg.Statement)
-	if statement == "" {
-		statement = "Sign in to Portal"
-	}
+	statement = cmp.Or(statement, "Sign in to Portal")
 
 	return &WalletAuthenticator{
 		allowed:    allowed,
@@ -100,7 +99,7 @@ func (a *WalletAuthenticator) IssueChallenge(req types.WalletAuthChallengeReques
 	challengeID := utils.RandomID("wac_")
 	nonce := siwe.GenerateNonce()
 	expiresAt := now.UTC().Add(defaultWalletAuthChallengeTTL)
-	message, err := siwe.InitMessage(domain, address, uri, nonce, map[string]interface{}{
+	message, err := siwe.InitMessage(domain, address, uri, nonce, map[string]any{
 		"statement":      a.statement,
 		"chainId":        1,
 		"issuedAt":       now.UTC().Format(time.RFC3339),

--- a/portal/discovery/mols_test.go
+++ b/portal/discovery/mols_test.go
@@ -668,7 +668,7 @@ func TestMOLSSelectPriorityEWMAStabilityTransposition(t *testing.T) {
 func BenchmarkMOLSRankRelayPool(b *testing.B) {
 	localAddr := "test-client-address"
 	relays := make([]RelayState, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		relays[i] = RelayState{
 			Descriptor:     types.RelayDescriptor{APIHTTPSAddr: "test"},
 			DiscoveryRTT:   100 * time.Millisecond,

--- a/portal/discovery/refresher_test.go
+++ b/portal/discovery/refresher_test.go
@@ -18,6 +18,8 @@ func TestRefresherRefreshHTTPSIsParallel(t *testing.T) {
 	var received atomic.Int32
 	var maxConcurrent atomic.Int32
 	var current atomic.Int32
+	requestStarted := make(chan struct{}, n)
+	releaseRequests := make(chan struct{})
 
 	servers := make([]*httptest.Server, n)
 	urls := make([]string, n)
@@ -29,13 +31,16 @@ func TestRefresherRefreshHTTPSIsParallel(t *testing.T) {
 				return
 			}
 			c := current.Add(1)
+			defer current.Add(-1)
 			if c > maxConcurrent.Load() {
 				maxConcurrent.Store(c)
 			}
-			// Hold the request open so concurrent requests must overlap if
-			// the refresher is truly parallel.
-			time.Sleep(50 * time.Millisecond)
-			current.Add(-1)
+			requestStarted <- struct{}{}
+			select {
+			case <-releaseRequests:
+			case <-r.Context().Done():
+				return
+			}
 			received.Add(1)
 
 			// Each server returns a signed descriptor for itself so the
@@ -67,7 +72,18 @@ func TestRefresherRefreshHTTPSIsParallel(t *testing.T) {
 		Timeout:   defaultRequestTimeout,
 	}
 
-	if err := refresher.refreshHTTPS(testContext(t)); err != nil {
+	ctx := testContext(t)
+	go func() {
+		for range 2 {
+			select {
+			case <-requestStarted:
+			case <-ctx.Done():
+				return
+			}
+		}
+		close(releaseRequests)
+	}()
+	if err := refresher.refreshHTTPS(ctx); err != nil {
 		t.Fatalf("refreshHTTPS() error = %v", err)
 	}
 

--- a/portal/discovery/relayset.go
+++ b/portal/discovery/relayset.go
@@ -194,6 +194,50 @@ func markDiscoveryVerified(state RelayState) RelayState {
 	return state
 }
 
+func (s *RelaySet) descriptorRollbackResultLocked(
+	record RelayState,
+	relayURL string,
+	address string,
+	now time.Time,
+) (upsertResult, bool) {
+	prev, ok := s.keyIndex[address]
+	if !ok {
+		return 0, false
+	}
+	// Stale tombstone: no replayable descriptor could still be within its
+	// validity window, so drop the anchor and accept the fresh descriptor as
+	// if first-seen.
+	if !prev.TombstoneUntil.IsZero() && now.After(prev.TombstoneUntil) {
+		delete(s.keyIndex, address)
+		return 0, false
+	}
+	if !record.Descriptor.IssuedAt.Before(prev.IssuedAt) {
+		return 0, false
+	}
+
+	existing, ok := s.relays[relayURL]
+	if !ok {
+		return upsertRejected, true
+	}
+	existingAddress := strings.ToLower(strings.TrimSpace(existing.Descriptor.Address))
+	existingIsCurrent := !existing.Descriptor.IssuedAt.Before(record.Descriptor.IssuedAt)
+	if existingAddress == address && existing.Descriptor.ExpiresAt.After(now) && existingIsCurrent {
+		return upsertIgnored, true
+	}
+	return upsertRejected, true
+}
+
+func (s *RelaySet) crossIdentityTakeoverBlockedLocked(relayURL, address string, now time.Time) bool {
+	existing, ok := s.relays[relayURL]
+	if !ok {
+		return false
+	}
+	existingAddress := strings.ToLower(strings.TrimSpace(existing.Descriptor.Address))
+	differentIdentity := existingAddress != "" && address != "" && existingAddress != address
+	unexpired := !existing.Descriptor.ExpiresAt.IsZero() && existing.Descriptor.ExpiresAt.After(now)
+	return differentIdentity && unexpired
+}
+
 // upsertDescriptorLocked applies a fully-merged RelayState to s.relays and
 // updates the keyIndex. The caller MUST already hold s.mu as a write lock.
 //
@@ -226,33 +270,12 @@ func (s *RelaySet) upsertDescriptorLocked(record RelayState, now time.Time, allo
 	}
 	address := strings.ToLower(strings.TrimSpace(record.Descriptor.Address))
 	if address != "" {
-		if prev, ok := s.keyIndex[address]; ok {
-			// Stale tombstone: no replayable descriptor could still be
-			// within its validity window, so drop the anchor and accept
-			// the fresh descriptor as if first-seen.
-			if !prev.TombstoneUntil.IsZero() && now.After(prev.TombstoneUntil) {
-				delete(s.keyIndex, address)
-			} else if record.Descriptor.IssuedAt.Before(prev.IssuedAt) {
-				if existing, ok := s.relays[relayURL]; ok {
-					existingAddress := strings.ToLower(strings.TrimSpace(existing.Descriptor.Address))
-					if existingAddress == address && existing.Descriptor.ExpiresAt.After(now) &&
-						!existing.Descriptor.IssuedAt.Before(record.Descriptor.IssuedAt) {
-						return upsertIgnored
-					}
-				}
-				return upsertRejected
-			}
+		if result, found := s.descriptorRollbackResultLocked(record, relayURL, address, now); found {
+			return result
 		}
 	}
-	if !allowCrossIdentityTakeover {
-		if existing, ok := s.relays[relayURL]; ok {
-			existingAddress := strings.ToLower(strings.TrimSpace(existing.Descriptor.Address))
-			if existingAddress != "" && address != "" && existingAddress != address {
-				if !existing.Descriptor.ExpiresAt.IsZero() && existing.Descriptor.ExpiresAt.After(now) {
-					return upsertRejected
-				}
-			}
-		}
+	if !allowCrossIdentityTakeover && s.crossIdentityTakeoverBlockedLocked(relayURL, address, now) {
+		return upsertRejected
 	}
 	s.relays[relayURL] = record
 	if address != "" {
@@ -475,8 +498,11 @@ func (s *RelaySet) PlanRoutes(explicitPath []string, routeState RouteState) ([]R
 	for _, relayURL := range routeState.ExplicitRelayURLs {
 		eligible := true
 		for _, state := range states {
-			if state.Descriptor.APIHTTPSAddr == relayURL &&
-				(state.Banned || state.Dead || !state.supportsRequiredTransports(routeState, now)) {
+			if state.Descriptor.APIHTTPSAddr != relayURL {
+				continue
+			}
+			unavailable := state.Banned || state.Dead || !state.supportsRequiredTransports(routeState, now)
+			if unavailable {
 				eligible = false
 				break
 			}
@@ -552,7 +578,7 @@ func buildMOLSPaths(ranked []string, depth, maxEntries int) ([]Route, error) {
 	routes := make([]Route, 0, maxEntries)
 	for start := 0; start < maxEntries; start++ {
 		path := make([]string, 0, depth)
-		for i := 0; i < depth; i++ {
+		for i := range depth {
 			path = append(path, ranked[(start+i)%n])
 		}
 		routes = append(routes, NewRoute(path, false))
@@ -773,6 +799,26 @@ func (s *RelaySet) DeactivateRelayURL(relayURL string) {
 	s.relays[relayURL] = state
 }
 
+// discoveryRelayStateLocked is the cryptographic gate for every gossiped
+// descriptor. The caller must hold s.mu for reading the URL ban state.
+func (s *RelaySet) discoveryRelayStateLocked(
+	descriptor types.RelayDescriptor,
+	now time.Time,
+) (RelayState, string, bool) {
+	verified, err := verifyFreshRelayDescriptor(descriptor, now)
+	if err != nil {
+		return RelayState{}, "", false
+	}
+	relayURL := verified.APIHTTPSAddr
+	if relayURL == "" {
+		return RelayState{}, "", false
+	}
+	if existing, ok := s.relays[relayURL]; ok && existing.Banned {
+		return RelayState{}, "", false
+	}
+	return RelayState{Descriptor: verified, LastSeenAt: now}, relayURL, true
+}
+
 func (s *RelaySet) ApplyRelayDiscoveryResponse(targetURL string, resp types.DiscoveryResponse, now time.Time) (relaySetChanged bool, err error) {
 	if now.IsZero() {
 		now = time.Now().UTC()
@@ -789,26 +835,10 @@ func (s *RelaySet) ApplyRelayDiscoveryResponse(targetURL string, resp types.Disc
 	discoveredByURL := make(map[string]RelayState, len(resp.Relays))
 	discoveredOrder := make([]string, 0, len(resp.Relays)+1)
 	targetFound := false
-	add := func(descriptor types.RelayDescriptor) {
-		// Cryptographic gate: every gossiped descriptor must carry a valid
-		// signature. Unsigned or invalid-signature descriptors are dropped
-		// silently; they cannot poison the local relay set, and other peers
-		// will reach the same verdict independently. This is the sole global
-		// trust gate under unconditional propagation, so it is mandatory.
-		verified, verifyErr := verifyFreshRelayDescriptor(descriptor, now)
-		if verifyErr != nil {
-			return
-		}
-		relayState := RelayState{
-			Descriptor: verified,
-			LastSeenAt: now,
-		}
-		relayURL := verified.APIHTTPSAddr
-		if relayURL == "" {
-			return
-		}
-		if existing, ok := s.relays[relayURL]; ok && existing.Banned {
-			return
+	for _, descriptor := range resp.Relays {
+		relayState, relayURL, ok := s.discoveryRelayStateLocked(descriptor, now)
+		if !ok {
+			continue
 		}
 		if authoritative && relayURL == targetURL {
 			targetFound = true
@@ -817,9 +847,6 @@ func (s *RelaySet) ApplyRelayDiscoveryResponse(targetURL string, resp types.Disc
 			discoveredOrder = append(discoveredOrder, relayURL)
 		}
 		discoveredByURL[relayURL] = relayState
-	}
-	for _, descriptor := range resp.Relays {
-		add(descriptor)
 	}
 	missingTarget := authoritative && !targetFound
 
@@ -1094,10 +1121,7 @@ func (s *RelaySet) RecordDiscoveryFailure(relayURL string, recoveryFailures int)
 		return false, "retry", state.discoveryFailures
 	}
 	failuresOverBudget := state.discoveryFailures - recoveryFailures
-	backoff := defaultDirectRecoveryBackoff << min(failuresOverBudget, 3)
-	if backoff > maxDirectRecoveryBackoff {
-		backoff = maxDirectRecoveryBackoff
-	}
+	backoff := min(defaultDirectRecoveryBackoff<<min(failuresOverBudget, 3), maxDirectRecoveryBackoff)
 	state.Dead = true
 	state.nextDiscoveryRefreshAt = now.Add(backoff)
 	s.relays[relayURL] = state
@@ -1121,10 +1145,7 @@ func (s *RelaySet) RecordActiveFailure(relayURL string, recoveryFailures int) (b
 		return false, "retry", state.activeFailures
 	}
 	failuresOverBudget := state.activeFailures - recoveryFailures
-	backoff := defaultDirectRecoveryBackoff << min(failuresOverBudget, 3)
-	if backoff > maxDirectRecoveryBackoff {
-		backoff = maxDirectRecoveryBackoff
-	}
+	backoff := min(defaultDirectRecoveryBackoff<<min(failuresOverBudget, 3), maxDirectRecoveryBackoff)
 	state.suppressActiveUntil = now.Add(backoff)
 	s.relays[relayURL] = state
 	return true, "active", state.activeFailures

--- a/portal/discovery/relayset_test.go
+++ b/portal/discovery/relayset_test.go
@@ -347,7 +347,7 @@ func TestRecordDiscoveryFailureBackoff(t *testing.T) {
 	budget := 3
 
 	start := time.Now()
-	for i := 0; i < budget; i++ {
+	for i := range budget {
 		backedOff, _, _ := set.RecordDiscoveryFailure(relayURL, budget)
 		if i < budget-1 && backedOff {
 			t.Fatal("discovery failure backed off before budget")
@@ -382,7 +382,7 @@ func TestRecordDiscoveryFailureMarksDeadAndRevivesOnAuthoritativeSuccess(t *test
 	set.mu.Unlock()
 
 	budget := 3
-	for i := 0; i < budget; i++ {
+	for range budget {
 		set.RecordDiscoveryFailure(deadURL, budget)
 	}
 

--- a/portal/discovery/relaystate.go
+++ b/portal/discovery/relaystate.go
@@ -4,8 +4,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gosuda/portal-tunnel/v2/types"
 	"github.com/montanaflynn/stats"
+
+	"github.com/gosuda/portal-tunnel/v2/types"
 )
 
 const (

--- a/portal/identity/mnemonic.go
+++ b/portal/identity/mnemonic.go
@@ -1,6 +1,7 @@
 package identity
 
 import (
+	"cmp"
 	"crypto/hmac"
 	"crypto/sha512"
 	"encoding/binary"
@@ -37,9 +38,7 @@ func deriveSecp256k1PrivateKeyFromMnemonic(rawMnemonic, rawDerivationPath string
 	}
 
 	derivationPath := strings.TrimSpace(rawDerivationPath)
-	if derivationPath == "" {
-		derivationPath = DefaultEVMIdentityDerivationPath
-	}
+	derivationPath = cmp.Or(derivationPath, DefaultEVMIdentityDerivationPath)
 	path, err := parseDerivationPath(derivationPath)
 	if err != nil {
 		return "", "", fmt.Errorf("parse identity derivation path: %w", err)

--- a/portal/identity/secp256k1.go
+++ b/portal/identity/secp256k1.go
@@ -371,7 +371,8 @@ func parseSecp256k1PrivateKeyHex(raw string, requireNonZero bool) (*secp256k1.Pr
 }
 
 func trimHexPrefix(raw string) string {
-	if len(raw) >= 2 && raw[0] == '0' && (raw[1] == 'x' || raw[1] == 'X') {
+	hasHexPrefix := len(raw) >= 2 && raw[0] == '0'
+	if hasHexPrefix && (raw[1] == 'x' || raw[1] == 'X') {
 		return raw[2:]
 	}
 	return raw

--- a/portal/lease.go
+++ b/portal/lease.go
@@ -2,6 +2,7 @@ package portal
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -326,7 +327,9 @@ func (r *leaseRegistry) Register(req types.RegisterChallengeRequest, clientIP, r
 			record.Close()
 			return nil, types.RegisterResponse{}, errHostnameConflict
 		}
-		if hopToken != "" && (existing.isHopMiddle() || existing.isHopExit()) && existing.hopToken == hopToken && existingKey != identityKey {
+		isHopRecord := existing.isHopMiddle() || existing.isHopExit()
+		sameHopToken := hopToken != "" && existing.hopToken == hopToken
+		if isHopRecord && sameHopToken && existingKey != identityKey {
 			r.mu.Unlock()
 			record.Close()
 			return nil, types.RegisterResponse{}, errors.New("hop token conflict")
@@ -611,13 +614,13 @@ func (r *leaseRegistry) RegisterHopRoute(route *types.HopRoute, now time.Time) (
 	}
 }
 
-func (r *leaseRegistry) DeleteHopRoute(route *types.HopRoute) *leaseRecord {
+func (r *leaseRegistry) DeleteHopRoute(route *types.HopRoute) (*leaseRecord, error) {
 	if r == nil || route == nil {
-		return nil
+		return nil, nil
 	}
 	ownerKey, err := identity.AddressFromCompressedPublicKeyHex(route.OwnerPublicKey)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("delete hop route owner key: %w", err)
 	}
 	routeHostname := route.RouteHostname
 	hostnameHash := route.HostnameHash
@@ -653,7 +656,7 @@ func (r *leaseRegistry) DeleteHopRoute(route *types.HopRoute) *leaseRecord {
 	}
 	r.mu.Unlock()
 	deleted.Close()
-	return deleted
+	return deleted, nil
 }
 
 func (r *leaseRegistry) promoteECHDNS(record *leaseRecord, manager *acme.Manager, sniPort int) {
@@ -725,9 +728,7 @@ func (r *leaseRegistry) issueRegisterChallenge(req types.RegisterChallengeReques
 		return types.RegisterChallengeResponse{}, err
 	}
 	clientIP = strings.ToLower(strings.TrimSpace(clientIP))
-	if clientIP == "" {
-		clientIP = "<unknown>"
-	}
+	clientIP = cmp.Or(clientIP, "<unknown>")
 
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/portal/lease_test.go
+++ b/portal/lease_test.go
@@ -373,7 +373,7 @@ func TestIssueRegisterChallengeBoundsPendingPerIP(t *testing.T) {
 
 	registry := newTestRegistry(t)
 	clientIP := "203.0.113.50"
-	for i := 0; i < defaultRegisterChallengeOutstandingPerIP; i++ {
+	for i := range defaultRegisterChallengeOutstandingPerIP {
 		_, err := registry.issueRegisterChallenge(types.RegisterChallengeRequest{
 			Identity: newTestLeaseIdentity(t, fmt.Sprintf("demo-%d", i)),
 		}, "example.com", "https://example.com"+types.PathSDKRegister, clientIP)

--- a/portal/policy/bps_manager.go
+++ b/portal/policy/bps_manager.go
@@ -156,10 +156,7 @@ func bpsChunkSize(length int, bps int64) int {
 	if bps <= 0 {
 		return length
 	}
-	chunk := bps / 10
-	if chunk < 1 {
-		chunk = 1
-	}
+	chunk := max(bps/10, 1)
 	if chunk > int64(length) {
 		chunk = int64(length)
 	}

--- a/portal/record.go
+++ b/portal/record.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"time"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/gosuda/portal-tunnel/v2/portal/acme"
 	"github.com/gosuda/portal-tunnel/v2/portal/auth"
 	"github.com/gosuda/portal-tunnel/v2/portal/transport"
 	"github.com/gosuda/portal-tunnel/v2/types"
 	"github.com/gosuda/portal-tunnel/v2/utils"
-	"github.com/rs/zerolog/log"
 )
 
 type leaseRecord struct {

--- a/portal/server_test.go
+++ b/portal/server_test.go
@@ -43,7 +43,7 @@ func tempIdentityPath(t *testing.T) string {
 func tempLeasePort(t *testing.T) int {
 	t.Helper()
 
-	for attempt := 0; attempt < 100; attempt++ {
+	for range 100 {
 		probe, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
 			t.Fatalf("allocate probe port: %v", err)

--- a/portal/telemetry/metrics_test.go
+++ b/portal/telemetry/metrics_test.go
@@ -8,8 +8,9 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 
-	"github.com/gosuda/portal-tunnel/v2/portal/telemetry"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gosuda/portal-tunnel/v2/portal/telemetry"
 )
 
 // metricFamilyByName gathers all metric families and returns the one with the
@@ -205,7 +206,7 @@ func TestEmitFromTrace_CardinalityCap(t *testing.T) {
 
 	// Build the set of our namespace URLs.
 	ourURLs := make(map[string]struct{}, total)
-	for i := 0; i < total; i++ {
+	for i := range total {
 		ourURLs[fmt.Sprintf("t-cap-%03d", i)] = struct{}{}
 	}
 
@@ -235,7 +236,7 @@ func TestEmitFromTrace_CardinalityCap(t *testing.T) {
 	// Our traces are all non-congested non-nonlinear → reason="auto".
 	baseOther := relayReasonCounter("other", "auto")
 
-	for i := 0; i < total; i++ {
+	for i := range total {
 		url := fmt.Sprintf("t-cap-%03d", i)
 		telemetry.EmitFromTrace(telemetry.SelectionTrace{
 			OutputURLs:    []string{url},

--- a/portal/transport/quic_backhaul.go
+++ b/portal/transport/quic_backhaul.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -75,9 +76,7 @@ func DialQUICBackhaul(ctx context.Context, addr string, tlsConfig *tls.Config, a
 
 	if !resp.OK {
 		errText := strings.TrimSpace(resp.Error)
-		if errText == "" {
-			errText = "rejected"
-		}
+		errText = cmp.Or(errText, "rejected")
 		_ = conn.CloseWithError(1, errText)
 		return nil, fmt.Errorf("quic backhaul rejected: %s", errText)
 	}
@@ -122,13 +121,9 @@ func (c *QUICBackhaulControl) Reject(code, reason string) error {
 		return nil
 	}
 	code = strings.TrimSpace(code)
-	if code == "" {
-		code = "rejected"
-	}
+	code = cmp.Or(code, "rejected")
 	reason = strings.TrimSpace(reason)
-	if reason == "" {
-		reason = code
-	}
+	reason = cmp.Or(reason, code)
 
 	var err error
 	if c.stream != nil {

--- a/portal/x402/casper.go
+++ b/portal/x402/casper.go
@@ -1,6 +1,7 @@
 package x402
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -108,9 +109,7 @@ type casperFacilitator struct {
 
 func newCasperFacilitator(network, token string, endpoints ...string) (facilitatorcore.Facilitator, error) {
 	network = strings.ToLower(strings.TrimSpace(network))
-	if network == "" {
-		network = CasperMainnetNetwork
-	}
+	network = cmp.Or(network, CasperMainnetNetwork)
 	if _, ok := casperNetworkDisplayNames[network]; !ok {
 		return nil, fmt.Errorf("unsupported Casper network %q", network)
 	}
@@ -171,9 +170,7 @@ func (f *casperFacilitator) Supported() *facilitatortypes.SupportedResponse {
 // payment.Asset because it differs per network deployment.
 func NewCasperPayment(payment types.X402Payment) (*Payment, error) {
 	network := strings.TrimSpace(payment.Network)
-	if network == "" {
-		network = CasperNetwork(payment.Testnet)
-	}
+	network = cmp.Or(network, CasperNetwork(payment.Testnet))
 	network = strings.ToLower(network)
 	if _, ok := casperNetworkDisplayNames[network]; !ok {
 		return nil, fmt.Errorf("unsupported Casper network %q", network)
@@ -201,7 +198,7 @@ func NewCasperPayment(payment types.X402Payment) (*Payment, error) {
 		Amount:            amount,
 		PayTo:             payTo,
 		MaxTimeoutSeconds: maxTimeoutSeconds,
-		Extra: map[string]interface{}{
+		Extra: map[string]any{
 			"asset":               "wCSPR",
 			"assetTransferMethod": "casper-cep18-transfer",
 			"decimals":            csprDecimals,

--- a/portal/x402/casper_test.go
+++ b/portal/x402/casper_test.go
@@ -260,7 +260,7 @@ func TestCasperFacilitatorSettle(t *testing.T) {
 
 	settled, err := payment.facilitator.Settle(context.Background(), &facilitatortypes.PaymentPayload{
 		X402Version: int(facilitatortypes.X402VersionV2),
-		Payload:     map[string]interface{}{"signature": "deadbeef"},
+		Payload:     map[string]any{"signature": "deadbeef"},
 		Accepted:    payment.requirements,
 	}, &payment.requirements)
 	if err != nil {

--- a/portal/x402/handler.go
+++ b/portal/x402/handler.go
@@ -1,6 +1,7 @@
 package x402
 
 import (
+	"cmp"
 	"context"
 	_ "embed"
 	"errors"
@@ -48,9 +49,7 @@ func NewUSDCPaymentHandler(payment types.X402Payment, protectedPath, protectedMe
 	payment = paid.payment
 
 	protectedPath = strings.TrimSpace(protectedPath)
-	if protectedPath == "" {
-		protectedPath = payment.ResourcePath
-	}
+	protectedPath = cmp.Or(protectedPath, payment.ResourcePath)
 	if protectedPath == "" {
 		return nil, errors.New("USDC payment protected path is required")
 	}

--- a/portal/x402/payment.go
+++ b/portal/x402/payment.go
@@ -1,6 +1,7 @@
 package x402
 
 import (
+	"cmp"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -44,9 +45,7 @@ func NewPayment(payment types.X402Payment) (*Payment, error) {
 
 func NewUSDCPayment(payment types.X402Payment) (*Payment, error) {
 	network := strings.TrimSpace(payment.Network)
-	if network == "" {
-		network = Network(payment.Testnet)
-	}
+	network = cmp.Or(network, Network(payment.Testnet))
 	network = strings.ToLower(network)
 	asset, err := usdcAsset(network)
 	if err != nil {
@@ -71,7 +70,7 @@ func NewUSDCPayment(payment types.X402Payment) (*Payment, error) {
 		Amount:            amount,
 		PayTo:             payTo,
 		MaxTimeoutSeconds: maxTimeoutSeconds,
-		Extra: map[string]interface{}{
+		Extra: map[string]any{
 			"asset":               "USDC",
 			"assetTransferMethod": "sui-gasless-stablecoin-address-balance",
 		},
@@ -82,9 +81,7 @@ func NewUSDCPayment(payment types.X402Payment) (*Payment, error) {
 		return nil, err
 	}
 	networkName := NetworkDisplayName(requirements.Network)
-	if networkName == "" {
-		networkName = requirements.Network
-	}
+	networkName = cmp.Or(networkName, requirements.Network)
 	payment.Testnet = strings.EqualFold(requirements.Network, TestnetNetwork)
 	payment.Network = requirements.Network
 	payment.NetworkName = networkName
@@ -221,9 +218,7 @@ func (p *Payment) Settle(ctx context.Context, w http.ResponseWriter, r *http.Req
 			Str("asset", p.requirements.Asset)
 		if settled != nil {
 			errorMessage := strings.TrimSpace(settled.ErrorMessage)
-			if errorMessage == "" {
-				errorMessage = "<empty>"
-			}
+			errorMessage = cmp.Or(errorMessage, "<empty>")
 			event = event.
 				Str("reason", strings.TrimSpace(settled.ErrorReason)).
 				Str("error_message", errorMessage).
@@ -289,9 +284,7 @@ func (p *Payment) WritePrepare(w http.ResponseWriter, r *http.Request, sender, r
 		// Casper payments are signed by the wallet against the published
 		// requirements, so there is no server-built transaction to prepare.
 		resourcePath = strings.TrimSpace(resourcePath)
-		if resourcePath == "" {
-			resourcePath = strings.TrimSpace(p.payment.ResourcePath)
-		}
+		resourcePath = cmp.Or(resourcePath, strings.TrimSpace(p.payment.ResourcePath))
 		p.writePaymentRequired(w, r, "payment required", resourcePath)
 		return
 	}
@@ -354,19 +347,13 @@ func (p *Payment) WritePrepare(w http.ResponseWriter, r *http.Request, sender, r
 	}
 
 	resourcePath = strings.TrimSpace(resourcePath)
-	if resourcePath == "" {
-		resourcePath = strings.TrimSpace(p.payment.ResourcePath)
-	}
+	resourcePath = cmp.Or(resourcePath, strings.TrimSpace(p.payment.ResourcePath))
 	if resourcePath == "" && r.URL != nil {
 		resourcePath = r.URL.Path
 	}
-	if resourcePath == "" {
-		resourcePath = "/"
-	}
+	resourcePath = cmp.Or(resourcePath, "/")
 	resourceMimeType := strings.TrimSpace(p.payment.ResourceMimeType)
-	if resourceMimeType == "" {
-		resourceMimeType = "text/html"
-	}
+	resourceMimeType = cmp.Or(resourceMimeType, "text/html")
 	utils.WritePaymentJSON(w, http.StatusOK, types.X402PreparePaymentResponse{
 		X402Version:         int(facilitatortypes.X402VersionV2),
 		PaymentRequirements: p.requirements,

--- a/portal/x402/x402.go
+++ b/portal/x402/x402.go
@@ -1,6 +1,7 @@
 package x402
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"net/http"
@@ -63,9 +64,7 @@ func usdcAsset(network string) (string, error) {
 
 func newUSDCFacilitator(network, asset string, endpoints ...string) (facilitatorcore.Facilitator, error) {
 	network = strings.ToLower(strings.TrimSpace(network))
-	if network == "" {
-		network = MainnetNetwork
-	}
+	network = cmp.Or(network, MainnetNetwork)
 	if asset == "" {
 		var err error
 		asset, err = usdcAsset(network)

--- a/sdk/api_client.go
+++ b/sdk/api_client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -290,8 +291,8 @@ func (l *listener) registerHopRoutes(ctx context.Context, expiresAt time.Time, r
 	}
 
 	now := time.Now().UTC()
-	for i := len(routes) - 1; i >= 0; i-- {
-		route := routes[i]
+	for i, route := range slices.Backward(routes) {
+
 		desc, ok := l.relaySet.OverlayRelayDescriptor(route.ForwardRelay.APIHTTPSAddr, now)
 		if !ok {
 			return "", 0, fmt.Errorf("multi-hop forward relay %d descriptor is unavailable", i)

--- a/sdk/api_client_test.go
+++ b/sdk/api_client_test.go
@@ -32,7 +32,11 @@ func TestNewRenewRequestIncludesMetadata(t *testing.T) {
 	if req.ReportedIP != "203.0.113.10" {
 		t.Fatalf("ReportedIP = %q, want 203.0.113.10", req.ReportedIP)
 	}
-	if got := req.Metadata; got.Description != metadata.Description || got.Owner != metadata.Owner || got.Thumbnail != metadata.Thumbnail || got.Hide != metadata.Hide || len(got.Tags) != 2 || got.Tags[0] != "demo" || got.Tags[1] != "live" {
+	got := req.Metadata
+	metadataMatches := got.Description == metadata.Description && got.Owner == metadata.Owner &&
+		got.Thumbnail == metadata.Thumbnail && got.Hide == metadata.Hide && len(got.Tags) == 2 &&
+		got.Tags[0] == "demo" && got.Tags[1] == "live"
+	if !metadataMatches {
 		t.Fatalf("Metadata = %#v, want %#v", got, metadata)
 	}
 

--- a/sdk/expose.go
+++ b/sdk/expose.go
@@ -105,7 +105,9 @@ func Expose(ctx context.Context, cfg ExposeConfig) (*Exposure, error) {
 	if len(multiHop) > 0 && cfg.MultiHopDepth > 1 {
 		return nil, errors.New("explicit --multi-hop cannot be combined with automatic --multi-hop-depth")
 	}
-	if (len(multiHop) > 0 || cfg.MultiHopDepth > 1) && (cfg.UDPEnabled || cfg.TCPEnabled) {
+	multiHopEnabled := len(multiHop) > 0 || cfg.MultiHopDepth > 1
+	nonStreamTransport := cfg.UDPEnabled || cfg.TCPEnabled
+	if multiHopEnabled && nonStreamTransport {
 		return nil, errors.New("multi-hop currently supports only the default SNI TLS stream transport")
 	}
 	x402PayTo := strings.TrimSpace(cfg.X402PayTo)

--- a/sdk/expose_test.go
+++ b/sdk/expose_test.go
@@ -388,7 +388,7 @@ func TestExposureSnapshotExcludesDeadRelayListener(t *testing.T) {
 		},
 	}
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		relaySet.RecordDiscoveryFailure(relayA, 3)
 	}
 	snap := exposure.Snapshot()

--- a/sdk/http.go
+++ b/sdk/http.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -268,9 +269,7 @@ func newHTTPRoute(routeConfig HTTPRouteConfig, x402Payment types.X402Payment) (*
 	var route *httpRoute
 	if staticRoot := strings.TrimSpace(routeConfig.StaticRoot); staticRoot != "" {
 		staticIndex := strings.TrimSpace(routeConfig.StaticIndex)
-		if staticIndex == "" {
-			staticIndex = utils.DefaultStaticIndex
-		}
+		staticIndex = cmp.Or(staticIndex, utils.DefaultStaticIndex)
 		route = &httpRoute{
 			prefix:      prefix,
 			staticRoot:  staticRoot,
@@ -386,9 +385,7 @@ func (r *httpRoute) rewriteProxyRequest(pr *httputil.ProxyRequest) {
 			path = "/"
 		default:
 			path = strings.TrimPrefix(path, r.prefix)
-			if path == "" {
-				path = "/"
-			}
+			path = cmp.Or(path, "/")
 		}
 
 		if rawPath != "" {
@@ -425,6 +422,11 @@ func (r *httpRoute) rewriteProxyRequest(pr *httputil.ProxyRequest) {
 	if r.prefix != "/" {
 		pr.Out.Header.Set("X-Forwarded-Prefix", r.prefix)
 	}
+}
+
+func isSafeAbsoluteURLPath(value string) bool {
+	return strings.HasPrefix(value, "/") &&
+		(len(value) == 1 || (value[1] != '/' && value[1] != '\\'))
 }
 
 func (r *httpRoute) rewriteProxyResponse(resp *http.Response) error {
@@ -479,14 +481,14 @@ func (r *httpRoute) rewriteProxyResponse(resp *http.Response) error {
 				} else {
 					parsed = nil
 				}
-			case strings.HasPrefix(location, "/") && parsed.Host == "" && (len(location) == 1 || (location[1] != '\\' && location[1] != '/')):
+			case parsed.Host == "" && isSafeAbsoluteURLPath(location):
 			default:
 				parsed = nil
 			}
 
 			if parsed != nil {
 				mapped := publicPath(parsed.Path)
-				if strings.HasPrefix(mapped, "/") && (len(mapped) == 1 || (mapped[1] != '/' && mapped[1] != '\\')) {
+				if isSafeAbsoluteURLPath(mapped) {
 					parsed.Path = mapped
 					parsed.RawPath = ""
 					header.Set("Location", parsed.String())
@@ -523,8 +525,9 @@ func (r *httpRoute) rewriteProxyResponse(resp *http.Response) error {
 		}
 
 		domain := utils.NormalizeHostname(strings.TrimPrefix(cookie.Domain, "."))
-		if domain != "" && domain != publicDomain &&
-			(domain == r.upstreamDomain || utils.IsLocalRelayHost(domain)) {
+		rewriteDomain := domain != "" && domain != publicDomain &&
+			(domain == r.upstreamDomain || utils.IsLocalRelayHost(domain))
+		if rewriteDomain {
 			cookie.Domain = ""
 			changed = true
 		}

--- a/sdk/listener.go
+++ b/sdk/listener.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"context"
 	"crypto/tls"
 	"encoding/base64"
@@ -464,7 +465,8 @@ func (l *listener) publicURLForLease(lease listenerSnapshot) string {
 	host := lease.hostname
 	sniPort := lease.sniPort
 	scheme := strings.ToLower(strings.TrimSpace(baseURL.Scheme))
-	if (scheme == "https" && sniPort == 443) || (scheme == "http" && sniPort == 80) {
+	usesDefaultPort := scheme == "https" && sniPort == 443 || scheme == "http" && sniPort == 80
+	if usesDefaultPort {
 		sniPort = 0
 	}
 	if sniPort > 0 {
@@ -690,9 +692,7 @@ func (l *listener) openQUICBackhaulSession(ctx context.Context) (*quic.Conn, err
 		return nil, errors.New("relay tls config is unavailable")
 	}
 	host := strings.TrimSpace(l.relayURL.Hostname())
-	if host == "" {
-		host = strings.TrimSpace(l.relayURL.Host)
-	}
+	host = cmp.Or(host, strings.TrimSpace(l.relayURL.Host))
 	dialAddr := net.JoinHostPort(host, fmt.Sprintf("%d", lease.sniPort))
 	return transport.DialQUICBackhaul(ctx, dialAddr, l.tlsConfig, lease.accessToken)
 }

--- a/sdk/mitm.go
+++ b/sdk/mitm.go
@@ -308,10 +308,10 @@ func (m *mitmManager) maybeHandleConn(conn net.Conn) (net.Conn, bool, error) {
 	frameSize := 16
 	reader := bufio.NewReaderSize(conn, frameSize)
 	_ = conn.SetReadDeadline(time.Now().Add(mitmProbePeekTimeout))
-	peeked, err := reader.Peek(frameSize)
+	peeked, _ := reader.Peek(frameSize)
 	defer conn.SetReadDeadline(time.Time{})
-	if err != nil {
-		return wrapBufferedConn(conn, reader), false, fmt.Errorf("peek mitm probe frame: %w", err)
+	if len(peeked) != frameSize {
+		return wrapBufferedConn(conn, reader), false, nil
 	}
 
 	nonceHex := hex.EncodeToString(peeked[:frameSize])

--- a/sdk/mitm.go
+++ b/sdk/mitm.go
@@ -311,7 +311,7 @@ func (m *mitmManager) maybeHandleConn(conn net.Conn) (net.Conn, bool, error) {
 	peeked, err := reader.Peek(frameSize)
 	defer conn.SetReadDeadline(time.Time{})
 	if err != nil {
-		return wrapBufferedConn(conn, reader), false, nil
+		return wrapBufferedConn(conn, reader), false, fmt.Errorf("peek mitm probe frame: %w", err)
 	}
 
 	nonceHex := hex.EncodeToString(peeked[:frameSize])

--- a/types/agent.go
+++ b/types/agent.go
@@ -17,7 +17,7 @@ type AgentTunnelStatus struct {
 	Discovery       bool               `json:"discovery"`
 	MaxActiveRelays int                `json:"max_active_relays,omitempty"`
 	ECH             bool               `json:"ech,omitempty"`
-	Metadata        LeaseMetadata      `json:"metadata,omitempty"`
+	Metadata        LeaseMetadata      `json:"metadata"`
 	MultiHop        []string           `json:"multi_hop,omitempty"`
 	X402PayTo       string             `json:"x402_pay_to,omitempty"`
 	X402Testnet     bool               `json:"x402_testnet,omitempty"`

--- a/types/api.go
+++ b/types/api.go
@@ -113,7 +113,7 @@ type RenewRequest struct {
 	AccessToken string        `json:"access_token"`
 	TTL         int           `json:"ttl,omitempty"`
 	ReportedIP  string        `json:"reported_ip,omitempty"`
-	Metadata    LeaseMetadata `json:"metadata,omitempty"`
+	Metadata    LeaseMetadata `json:"metadata"`
 }
 
 type RenewResponse struct {
@@ -133,11 +133,11 @@ type HopRoute struct {
 	HostnameHash   string          `json:"hostname_hash,omitempty"`
 	ECHConfigList  []byte          `json:"ech_config_list,omitempty"`
 	MatchToken     string          `json:"match_token,omitempty"`
-	Metadata       LeaseMetadata   `json:"metadata,omitempty"`
+	Metadata       LeaseMetadata   `json:"metadata"`
 	ForwardRelay   RelayDescriptor `json:"forward_relay"`
 	ForwardToken   string          `json:"forward_token"`
-	FirstSeenAt    time.Time       `json:"first_seen_at,omitempty"`
-	ExpiresAt      time.Time       `json:"expires_at,omitempty"`
+	FirstSeenAt    time.Time       `json:"first_seen_at"`
+	ExpiresAt      time.Time       `json:"expires_at"`
 	Signature      string          `json:"signature,omitempty"`
 }
 

--- a/utils/api.go
+++ b/utils/api.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -12,8 +13,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/gosuda/portal-tunnel/v2/types"
 	facilitatortypes "github.com/gosuda/x402-facilitator/types"
+
+	"github.com/gosuda/portal-tunnel/v2/types"
 )
 
 type APIErrorResponse struct {
@@ -123,9 +125,7 @@ func PublicURLForPath(r *http.Request, path string) string {
 	}
 	host, _, _ := strings.Cut(r.Header.Get("X-Forwarded-Host"), ",")
 	host = strings.TrimSpace(host)
-	if host == "" {
-		host = strings.TrimSpace(r.Host)
-	}
+	host = cmp.Or(host, strings.TrimSpace(r.Host))
 	if host == "" {
 		return path
 	}
@@ -294,8 +294,7 @@ func decodeJSONRequestBody[T any](w http.ResponseWriter, r *http.Request, maxByt
 }
 
 func writeRequestBodyTooLarge(w http.ResponseWriter, err error) bool {
-	var maxBytesError *http.MaxBytesError
-	if !errors.As(err, &maxBytesError) {
+	if _, ok := errors.AsType[*http.MaxBytesError](err); !ok {
 		return false
 	}
 	WriteAPIError(w, http.StatusRequestEntityTooLarge, types.APIErrorCodeInvalidRequest, "request body too large")

--- a/utils/cmd.go
+++ b/utils/cmd.go
@@ -242,7 +242,8 @@ func NewFlagSet(name string, usage func(io.Writer)) *flag.FlagSet {
 
 func ParseFlagSet(fs *flag.FlagSet, args []string, usage func(io.Writer)) error {
 	args = normalizeFlagArgs(fs, args)
-	if len(args) == 1 && (args[0] == "help" || args[0] == "-h" || args[0] == "--help") {
+	helpRequested := len(args) == 1 && (args[0] == "help" || args[0] == "-h" || args[0] == "--help")
+	if helpRequested {
 		if usage != nil {
 			usage(os.Stdout)
 		}

--- a/utils/file.go
+++ b/utils/file.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"cmp"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -27,9 +28,7 @@ func FileExists(path string) bool {
 func WriteFileAtomic(path string, data []byte, mode os.FileMode) error {
 	path = strings.TrimSpace(path)
 	dir := filepath.Dir(path)
-	if dir == "" {
-		dir = "."
-	}
+	dir = cmp.Or(dir, ".")
 	tmp, err := os.CreateTemp(dir, ".tmp-*")
 	if err != nil {
 		return err

--- a/utils/filepath.go
+++ b/utils/filepath.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -91,12 +92,7 @@ func containsDotDot(v string) bool {
 	if !strings.Contains(v, "..") {
 		return false
 	}
-	for _, ent := range strings.FieldsFunc(v, func(r rune) bool { return r == '/' || r == '\\' }) {
-		if ent == ".." {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(strings.FieldsFunc(v, func(r rune) bool { return r == '/' || r == '\\' }), "..")
 }
 
 func serveStaticFile(w http.ResponseWriter, req *http.Request, dir http.FileSystem, rel string) bool {

--- a/utils/name.go
+++ b/utils/name.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"cmp"
 	"net"
 	"net/url"
 	"strings"
@@ -49,9 +50,7 @@ func DefaultExposeName(target, rawSeed string) (string, error) {
 	if cut, ok := strings.CutPrefix(seed, "cli_"); ok {
 		seed = cut
 	}
-	if seed == "" {
-		seed = "portal"
-	}
+	seed = cmp.Or(seed, "portal")
 
 	input := []byte(seed + "|" + normalizeExposeTarget(target))
 	first := fnv1a32(input, 0x811c9dc5)
@@ -72,9 +71,7 @@ func DefaultExposeName(target, rawSeed string) (string, error) {
 func normalizeExposeTarget(raw string) string {
 	trimmed := strings.TrimSpace(raw)
 	candidate := trimmed
-	if candidate == "" {
-		candidate = defaultExposeTargetPort
-	}
+	candidate = cmp.Or(candidate, defaultExposeTargetPort)
 
 	if isAllDigits(candidate) {
 		return defaultExposeTargetHost + ":" + candidate
@@ -85,11 +82,10 @@ func normalizeExposeTarget(raw string) string {
 		if err != nil {
 			return candidate
 		}
-		if (u.Scheme == "http" || u.Scheme == "https") &&
-			u.Host != "" &&
-			(u.Path == "" || u.Path == "/") &&
-			u.RawQuery == "" &&
-			u.Fragment == "" {
+		isHTTPURL := u.Scheme == "http" || u.Scheme == "https"
+		hasRootPath := u.Path == "" || u.Path == "/"
+		hasNoSuffix := u.RawQuery == "" && u.Fragment == ""
+		if isHTTPURL && u.Host != "" && hasRootPath && hasNoSuffix {
 			return u.Host
 		}
 		return candidate
@@ -100,9 +96,7 @@ func normalizeExposeTarget(raw string) string {
 		return candidate
 	}
 	port := u.Port()
-	if port == "" {
-		port = "80"
-	}
+	port = cmp.Or(port, "80")
 	return net.JoinHostPort(u.Hostname(), port)
 }
 

--- a/utils/tls.go
+++ b/utils/tls.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"cmp"
 	"context"
 	"crypto"
 	"crypto/ecdsa"
@@ -75,12 +76,8 @@ func FetchEndpointCertificateChain(ctx context.Context, endpoint, serverName str
 		return nil, errors.New("endpoint hostname is empty")
 	}
 	port := u.Port()
-	if port == "" {
-		port = "443"
-	}
-	if serverName == "" {
-		serverName = host
-	}
+	port = cmp.Or(port, "443")
+	serverName = cmp.Or(serverName, host)
 
 	dialer := &net.Dialer{Timeout: 5 * time.Second}
 	rawConn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, port))

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -37,7 +37,8 @@ func SplitCSV(raw string) []string {
 }
 
 func TrimHexPrefix(raw string) string {
-	if len(raw) >= 2 && raw[0] == '0' && (raw[1] == 'x' || raw[1] == 'X') {
+	hasHexPrefix := len(raw) >= 2 && raw[0] == '0'
+	if hasHexPrefix && (raw[1] == 'x' || raw[1] == 'X') {
 		return raw[2:]
 	}
 	return raw
@@ -89,7 +90,8 @@ func NormalizeDNSLabel(raw string) (string, error) {
 		return "", errors.New("name must not start or end with hyphen")
 	}
 	for _, r := range label {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+		validRune := r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '-'
+		if validRune {
 			continue
 		}
 		return "", errors.New("name must contain only letters, numbers, or hyphen")
@@ -125,7 +127,8 @@ func sanitizeDNSLabelInput(raw string) string {
 
 func isPlainDNSLabel(label string) bool {
 	for _, r := range label {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+		validRune := r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '-'
+		if validRune {
 			continue
 		}
 		return false


### PR DESCRIPTION
- raise the minimum supported Go version to 1.27.0
- align the Makefile and both Docker build images with Go 1.27.0
- add `gojgp` to the repository lint workflow
- fix the local import prefix used by `goimports`
- apply lint-driven control-flow and standard-library simplifications
- flatten MITM probe frame handling without introducing a wrapper
- propagate agent shutdown status errors instead of treating every status failure as a successful shutdown
- make the parallel relay refresher test deterministic by replacing timing-based synchronization with channels

## Notable changes

### Go toolchain

The module now declares Go 1.27.0 as its minimum required version.

The Makefile derives `GOTOOLCHAIN` from the `go` directive, and both Docker builders use `golang:1.27.0`.

### Lint workflow

`make install` now installs `gojgp`, and `make lint` runs it through a small adapter that:

- consumes JSON diagnostics
- filters the intentionally excluded Law of Demeter rule
- removes duplicate findings
- emits findings in deterministic order

The repository root package is also included in the shared Go package list.

### Runtime correctness

Agent shutdown polling now accepts only `agent.ErrNotRunning` as confirmation that the agent stopped. Corrupt endpoint state and other status errors are returned to the
caller instead of being silently treated as success.

Hop-route deletion now propagates owner-key parsing errors, and all internal callers have been migrated to the new error-returning contract.

### Refactoring

The remaining changes simplify equivalent control flow using Go standard-library APIs such as:

- `cmp.Or`
- `errors.AsType`
- `maps.Copy`
- `slices.Contains`
- `slices.Backward`
- `strings.SplitSeq`
- integer ranges

Relay descriptor rollback, identity takeover, and discovery verification logic were extracted into focused methods while preserving the existing lock scope and selection
behavior.

## Compatibility

- Go 1.27.0 is now required to build or consume this module.
- The preferred and Docker build toolchains are aligned with that minimum.
- Several non-pointer struct fields no longer carry `omitempty`. Their standard `encoding/json` output was already always present, but reflection-based schema generators
may observe the struct-tag change.

## Validation

- all existing tests were reported passing before the final Go and Docker version alignment
- `go mod tidy -diff`
- Go language-server diagnostics for the flattened MITM implementation