### PR TITLE
Add an AI feedback loop for Portal friction

### DIFF
--- a/plugins/portal-deploy/README.md
+++ b/plugins/portal-deploy/README.md
@@ -1,12 +1,12 @@
 # Portal Deploy plugin
 
-`portal-deploy` is a skills-only plugin for Codex, Claude Code, and Cursor. It teaches an agent to inspect a local app, choose the appropriate Portal tunnel mode, configure explicitly requested x402 paid routes, verify the public endpoint and payment challenge, and hand off the tunnel lifecycle safely.
+`portal-deploy` is a skills-only plugin for Codex, Claude Code, and Cursor. It teaches an agent to inspect a local app, choose the appropriate Portal tunnel mode, configure explicitly requested x402 paid routes, verify the public endpoint and payment challenge, and hand off the tunnel lifecycle safely. When a real Portal task encounters friction, it can retain sanitized local evidence and route an approved low-risk improvement through an upstream issue and PR.
 
 Portal exposes a service that remains on the local machine. This plugin does not turn Portal into a cloud build or hosting platform.
 
 ## Layout
 
-One shared skill, three host manifests. Do not copy `SKILL.md` per host.
+Shared skills, three host manifests. Do not copy `SKILL.md` per host.
 
 ```text
 plugins/portal-deploy/
@@ -14,13 +14,22 @@ plugins/portal-deploy/
 ├── .claude-plugin/plugin.json     # Claude Code plugin manifest
 ├── .cursor-plugin/plugin.json     # Cursor plugin manifest
 ├── skills/portal-expose/
-│   ├── SKILL.md                   # Shared Open Agent Skill
+│   ├── SKILL.md                   # Expose and verify Portal services
 │   ├── agents/openai.yaml         # Codex skill UI metadata
 │   └── references/
+│       ├── feedback-evidence.md
 │       ├── portal-cli.md
 │       ├── game-hosting.md
 │       ├── safety-and-verification.md
 │       └── x402.md
+├── skills/portal-feedback/
+│   ├── SKILL.md                   # Turn approved friction into issues and PRs
+│   ├── agents/openai.yaml
+│   └── references/
+│       ├── evidence-packet.schema.json
+│       ├── finding.schema.json
+│       ├── verification-attempt.schema.json
+│       └── issue-and-pr-loop.md
 ├── skills/portal-relay/
 │   └── SKILL.md                   # Run a public Portal relay
 └── README.md
@@ -34,7 +43,7 @@ Repository-root catalogs, each pointing at this same plugin directory:
 | Claude Code | `.claude-plugin/marketplace.json` | `portal-tunnel` |
 | Cursor | `.cursor-plugin/marketplace.json` | `portal-tunnel` |
 
-Install unit is the plugin `portal-deploy`. Agent invocation units are the skills `portal-expose` and `portal-relay`.
+Install unit is the plugin `portal-deploy`. Agent invocation units are the skills `portal-expose`, `portal-feedback`, and `portal-relay`.
 
 ## Local Codex setup
 
@@ -99,8 +108,11 @@ Public listing is a Git repository submitted at [cursor.com/marketplace/publish]
 - `Create a temporary Portal preview for the frontend on port 5173.`
 - `Keep this service available through a persistent Portal agent tunnel.`
 - `Serve this trusted static site through Portal.`
+- `Review the Portal friction recorded by my last tunnel attempt.`
+- `Show the Portal feedback inbox and prepare the next issue brief.`
+- `Approve this Portal feedback finding and carry the low-risk fix through a PR.`
 
-The skill should not trigger for deploying a Portal relay, normal cloud hosting, or publishing the plugin itself.
+`portal-expose` should not trigger for deploying a Portal relay, normal cloud hosting, or publishing the plugin. `portal-feedback` should trigger only for stored Portal friction or explicit feedback operations, not for an ordinary exposure request.
 
 ## Marketplace review cases
 
@@ -112,12 +124,17 @@ Positive:
 - Run this app as a persistent Portal tunnel.
 - Serve this trusted static site through Portal.
 - Create a temporary Portal preview for the frontend on port 5173.
+- Review the friction packet from the last failed Portal Agent setup.
+- Show pending Portal feedback findings.
+- Retry the blocked publication for this Portal feedback finding.
 
 Negative:
 
 - Deploy a Portal relay with this plugin.
 - Publish this plugin to a marketplace.
 - Host this app on generic cloud hosting.
+- Expose this app through Portal. (`portal-expose`, not `portal-feedback`.)
+- Explain a Portal error without creating upstream artifacts.
 
 ## Development validation
 
@@ -126,6 +143,8 @@ From the repository root:
 ```sh
 python3 /path/to/skill-creator/scripts/quick_validate.py \
   plugins/portal-deploy/skills/portal-expose
+python3 /path/to/skill-creator/scripts/quick_validate.py \
+  plugins/portal-deploy/skills/portal-feedback
 python3 /path/to/plugin-creator/scripts/validate_plugin.py \
   plugins/portal-deploy
 claude plugin validate ./plugins/portal-deploy --strict

--- a/plugins/portal-deploy/skills/portal-expose/SKILL.md
+++ b/plugins/portal-deploy/skills/portal-expose/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 
 Portal publishes a service that is already running on the user's machine. It does not build the app or move it to a cloud host. Treat a successful tunnel as dependent on both the local app and the Portal process or agent remaining available.
 
-Read `references/portal-cli.md` when choosing commands or persistent-agent configuration. Read `references/x402.md` whenever the user requests x402 or a paid route. Read `references/safety-and-verification.md` before exposing a nontrivial project, a service with authentication, or any non-HTTP port. Read `references/game-hosting.md` whenever the user asks to host, publish, or share a game server — it covers game-specific ports, protocol identification, relay raw-transport prerequisites, and raw-endpoint verification.
+Read `references/portal-cli.md` when choosing commands or persistent-agent configuration. Read `references/x402.md` whenever the user requests x402 or a paid route. Read `references/safety-and-verification.md` before exposing a nontrivial project, a service with authentication, or any non-HTTP port. Read `references/game-hosting.md` whenever the user asks to host, publish, or share a game server; it covers game-specific ports, protocol identification, relay raw-transport prerequisites, and raw-endpoint verification. Read `references/feedback-evidence.md` at the start of every Portal operation so one user task shares one run identity and friction can be captured without retaining ordinary successful runs.
 
 ## Choose the Mode
 
@@ -25,6 +25,8 @@ Use the smallest mode that satisfies the request:
 Default to a temporary preview when the user says only "share", "preview", or "deploy locally". Do not install an OS service unless the user asks for a persistent, managed, or restart-surviving tunnel and accepts that `portal agent run` without `--foreground` installs a per-user launchd or systemd unit.
 
 ## Workflow
+
+Start the in-memory experience trace before step 1. Feedback capture must never delay, change, or weaken the requested Portal result.
 
 ### 1. Inspect the Project
 
@@ -81,6 +83,7 @@ Before executing, show the exact public target and any important exposure conseq
 - For raw TCP or UDP, protocol-probe the allocated `tcp_addr`/`udp_addr` without mutating application data. A successful local port open is not enough.
 - When a browser-capable tool is available and the app has UI, load the primary page and check for an obvious render or runtime failure. Do not log in or submit data unless the user requested it.
 - Re-check the local health endpoint if the public request fails so the handoff distinguishes app failure from tunnel or relay failure.
+- Treat Portal readiness and the public probe as separate validations. A reported-ready URL that fails externally is a feedback `state_mismatch`, not a successful deployment.
 
 ### 7. Hand Off the Result
 
@@ -97,6 +100,8 @@ Report:
 - Anything that remains temporary, unavailable, or unverified.
 
 Do not call the result permanent when the local machine, app process, or foreground tunnel must remain running.
+
+Before discarding the trace, apply `references/feedback-evidence.md`: persist sanitized friction packets, correlate them through `portal-feedback`, or evaluate a matching post-release closure candidate. A normal successful run with no closure candidate leaves no feedback artifact.
 
 ## Failure Rules
 

--- a/plugins/portal-deploy/skills/portal-expose/references/feedback-evidence.md
+++ b/plugins/portal-deploy/skills/portal-expose/references/feedback-evidence.md
@@ -1,0 +1,82 @@
+# Feedback evidence
+
+Use this reference only for Portal operations performed through `portal-expose`. It records friction locally without adding telemetry to Portal or retaining normal successful runs.
+
+## Start an experience run
+
+At the first Portal-specific action in the user task, generate one lowercase UUIDv4 `run_id`. Keep one in-memory trace through the final public verification or terminal failure. Retries and diagnostics in the same user task keep the same run ID.
+
+Record only Portal-related top-level actions:
+
+- sanitized argv;
+- UTC start and end time;
+- duration;
+- termination: `exited`, `timeout`, `signal`, or `not_started`;
+- nullable exit code and signal;
+- the shortest stdout/stderr summaries that prove an observation;
+- expected and observed validation results.
+
+Never record private reasoning, environment-variable values, identity contents, signed payloads, credentials, cookies, payment secrets, or unrelated repository and browser data.
+
+## Detect friction
+
+Create evidence only when at least one signal applies.
+
+- `objective_failure`: a documented Portal command fails, times out, is killed, never starts, leaves a required service inactive, or fails the requested public validation.
+- `state_mismatch`: Portal reports a ready tenant URL but its external check fails, or a stable restart changes the URL despite reusing the requested name, identity, and relay root.
+- `user_correction`: the user says a delivered result or an assumption already acted on was wrong. A new requirement after a correct handoff is a new task, not a correction.
+- `excess_diagnosis`: after the first failed validation, at least three unplanned top-level diagnostic invocations are needed. Do not count the selected branch's local probe, Portal command, public probe, or prescribed source reads. One pipeline or internally retried command counts once.
+
+HTTP validation contracts:
+
+| Situation | Contract code | Pass condition |
+| --- | --- | --- |
+| Ordinary public app | `http_200_399` | `200..399` |
+| App known locally to require authentication | `http_auth_401` or `http_auth_403` | matching status |
+| Unpaid protected x402 method | `http_x402_402` | `402` and matching challenge fields |
+| Managed service | `service_active` | service manager reports active |
+| Stable restart | `hostname_stable` and `identity_reused` | same expected URL and identity |
+| Raw transport | `protocol_nonmutating` | selected protocol probe succeeds |
+
+## Split and classify
+
+One run may produce several packets only when observations have different causal mechanisms. Give each packet a new UUIDv4 `packet_id`; one run can vote once per finding.
+
+Classify as `defect` only when the minimal command reproduces twice in the run, or a static artifact deterministically violates its consumer's contract, and an immutable Portal source reference identifies the cause. The reference includes `gosuda/portal-tunnel`, commit SHA, path or contract section, line range when applicable, and commit-pinned URL. Store `defect_qualification.method` as `reproduced_command` with a count of at least two, or `static_contract_violation` with a count of one.
+
+Classify reproducible ambiguity, poor defaults, extra-step cost, and user correction without a deterministic source mechanism as `ux-friction`. Otherwise use `needs-review`. When Portal could not run, store `portal_version: null`; never invent a version.
+
+## Sanitize and persist
+
+Resolve the state root:
+
+```text
+Linux:   $XDG_STATE_HOME/portal-feedback, else ~/.local/state/portal-feedback
+macOS:   ~/Library/Application Support/Portal Feedback
+Windows: %LOCALAPPDATA%\Portal Feedback
+```
+
+Write packets to `runs/<run-id>/<packet-id>.json` using the repository-relative schema `plugins/portal-deploy/skills/portal-feedback/references/evidence-packet.schema.json`.
+
+Before writing:
+
+1. Collapse summary whitespace and enforce schema bounds.
+2. Replace the current home prefix with `$HOME`.
+3. Remove URL query strings and authorization/cookie header values.
+4. Redact values following names containing `token`, `secret`, `password`, `private-key`, `identity-json`, `api-key`, or `facilitator-token`, including environment assignment and `--flag=value` forms.
+5. Run the host secret scanner when available, then always scan case-insensitively for `-----BEGIN .* PRIVATE KEY-----`, `Authorization: Bearer`, `github_pat_`, `ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`, `AKIA[0-9A-Z]{16}`, and the acceptance fixture `github_pat_TEST_SECRET`.
+6. Reject the packet if any possible secret remains. Keep no rejected artifact.
+7. Reject symlinks below the state root. On POSIX, create directories as `0700` and files as `0600`.
+8. Write a sibling temporary file, flush it, and atomically rename it.
+
+After persistence, run the `portal-feedback` correlation procedure in the same conversation. If the task is ending, leave the packet for the next `portal-feedback inbox` invocation.
+
+## Successful runs and closure
+
+A successful run normally persists nothing. Before discarding it, inspect local findings for `waiting_real_use` records with the same requested-outcome class. If candidates exist, invoke the internal `portal-feedback evaluate-closure` procedure with the sanitized in-memory trace. It writes one `real_use` verification attempt per qualifying finding. A replay or ordinary success never casts a promotion vote.
+
+When no closure candidate exists, retain the sanitized trace only in the active conversation until the user's next response. If that response corrects the delivered Portal result or an assumption already acted on, create a `user_correction` packet under the same run ID. If the response accepts the result, changes requirements, or starts unrelated work, discard the trace without writing.
+
+## Feedback failure
+
+Feedback capture is secondary to the requested Portal operation. If redaction, schema validation, locking, or writing fails, preserve the user's Portal result and report the feedback failure separately. Never weaken redaction to save a packet.

--- a/plugins/portal-deploy/skills/portal-feedback/SKILL.md
+++ b/plugins/portal-deploy/skills/portal-feedback/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: portal-feedback
+description: Correlate sanitized friction from Portal agent usage, review pending findings, approve or defer issue briefs, publish source-grounded Portal issues, implement approved low-risk fixes, open PRs, and verify improvements after release. Use when portal-expose stored a friction packet, or when the user asks to inspect, review, approve, reject, defer, retry, replay, or check Portal feedback findings. Do not use for ordinary Portal exposure with no recorded friction.
+license: MIT
+---
+
+# Improve Portal from agent experience
+
+Turn real Portal friction into one bounded upstream improvement. Evidence stays local until the user approves a persisted brief. Maintainers own merge.
+
+Read `references/evidence-packet.schema.json`, `references/finding.schema.json`, and `references/verification-attempt.schema.json` before creating or changing their records. Read `references/issue-and-pr-loop.md` before correlation, approval, GitHub mutation, implementation, replay, or closure.
+
+## Operating rules
+
+- Target only `gosuda/portal-tunnel`.
+- Treat `findings/<finding-id>.json` as the sole state authority.
+- Acquire the finding lock before every mutation; release it after the atomic write.
+- Perform no public GitHub mutation before explicit approval of the current scope digest.
+- Re-run duplicate search immediately before issue creation.
+- Use the remote feedback marker to recover partial issue and PR publication.
+- Implement only the closed low-risk allowlist. Route restricted work to an implementation checkpoint.
+- Never auto-merge.
+- Never close on tests or replay alone. Require a containing release and a later matching real use.
+- Keep raw logs, secrets, identity material, credentials, cookies, payment data, and private reasoning out of local records and GitHub artifacts.
+
+## Operations
+
+Interpret explicit user phrasing as one of these operations.
+
+| Operation | Action |
+| --- | --- |
+| `inbox` | Clean expired state, ingest packets, advance due findings, refresh PR/release metadata, and list due work. No approval or GitHub mutation. |
+| `status <finding-id>` | Read state, evidence count, digests, URLs, blocker, and next action without mutation. |
+| `review <finding-id>` | Investigate a `needs_review` finding and store an evidence-backed assessment. |
+| `approve <finding-id>` | Approve the persisted issue or contribution brief when its revision and scope digests match. |
+| `reject <finding-id> <reason>` | Reject an awaiting issue brief and retain bounded rejection history. |
+| `defer <finding-id> [date]` | Defer, defaulting to seven days. |
+| `retry <finding-id>` | Recover a remote marker or retry the blocked transition once. |
+| `replay <finding-id>` | Run a new synthetic scenario and store a new verification attempt. |
+| `approve-implementation <finding-id>` | Approve a restricted implementation brief and its new scope digest. |
+| `reject-implementation <finding-id> <reason>` | Decline autonomous restricted work and move it to the maintainer queue. |
+| `handoff-implementation <finding-id>` | Move restricted work to the maintainer queue without rejection. |
+| `purge-expired` | Apply retention once. |
+
+Invalid-state mutations leave state unchanged and report allowed next operations. Repeating an approval or public publication returns the existing URLs.
+
+## Default run
+
+When invoked after `portal-expose` wrote evidence:
+
+1. Resolve the platform state root.
+2. Validate and ingest every uncorrelated packet.
+3. Normalize its mechanism and update one finding per mechanism.
+4. Apply promotion thresholds and complete duplicate search.
+5. Persist the brief before presenting it.
+6. Ask `Approve`, `Reject`, or `Defer` only when a finding reaches `awaiting_approval`.
+7. After approval, continue through issue publication and eligible low-risk PR work without a second issue-to-PR checkpoint.
+8. Stop at maintainer merge. On later invocations, track merge, release, replay, and real-use closure.
+
+## Completion
+
+Report the finding ID, current state, issue and PR URLs when present, exact verification performed, and the next actor. A run that changes no state says so. Never round `maintainer_queue`, `blocked`, `merged_waiting_release`, or `waiting_real_use` up to complete.

--- a/plugins/portal-deploy/skills/portal-feedback/agents/openai.yaml
+++ b/plugins/portal-deploy/skills/portal-feedback/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Improve Portal from Agent Feedback"
+  short_description: "Turn Portal friction into issues and PRs"
+  default_prompt: "Use $portal-feedback to review sanitized Portal friction, prepare the approval brief, and carry approved low-risk work through a verified PR."

--- a/plugins/portal-deploy/skills/portal-feedback/references/evidence-packet.schema.json
+++ b/plugins/portal-deploy/skills/portal-feedback/references/evidence-packet.schema.json
@@ -1,0 +1,868 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Portal feedback evidence packet",
+  "description": "One sanitized friction packet written by portal-expose to runs/<run-id>/<packet-id>.json. This schema asserts every structurally expressible constraint. Before persistence the skill also checks UTF-8 byte lengths, collapsed-whitespace lengths, timestamp ordering, UUID version, the defect source condition, immutable URL revisions, and cross-record consistency.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "packet_id",
+    "run_id",
+    "origin",
+    "started_at",
+    "ended_at",
+    "operation",
+    "mode",
+    "requested_outcome",
+    "environment",
+    "commands",
+    "validations",
+    "signals",
+    "diagnostic_command_count",
+    "classification",
+    "mechanism",
+    "source_refs",
+    "redactions",
+    "defect_qualification"
+  ],
+  "properties": {
+    "schema_version": {
+      "description": "Evidence packet schema version. Unknown future versions are never read and never promote.",
+      "type": "integer",
+      "const": 1
+    },
+    "packet_id": {
+      "description": "Canonical lowercase UUIDv4, distinct per packet within one run.",
+      "$ref": "#/$defs/uuid_v4"
+    },
+    "run_id": {
+      "description": "Canonical lowercase UUIDv4 shared by every packet and command of one experience run.",
+      "$ref": "#/$defs/uuid_v4"
+    },
+    "origin": {
+      "description": "Whether the run was real Portal use or a synthetic replay. A replay never casts a promotion vote.",
+      "enum": [
+        "real",
+        "replay"
+      ]
+    },
+    "started_at": {
+      "$ref": "#/$defs/utc_rfc3339"
+    },
+    "ended_at": {
+      "description": "Not before started_at; ordering is checked by the skill.",
+      "$ref": "#/$defs/utc_rfc3339"
+    },
+    "operation": {
+      "enum": [
+        "install",
+        "expose",
+        "agent_run",
+        "restart",
+        "stop",
+        "inspect",
+        "update"
+      ]
+    },
+    "mode": {
+      "enum": [
+        "foreground",
+        "managed",
+        "not_applicable"
+      ]
+    },
+    "requested_outcome": {
+      "description": "One line, 1 to 512 UTF-8 bytes after whitespace collapse.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^[^\\r\\n]*$"
+    },
+    "environment": {
+      "$ref": "#/$defs/environment"
+    },
+    "commands": {
+      "description": "Sanitized command records for Portal-related top-level actions.",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 64,
+      "items": {
+        "$ref": "#/$defs/command_record"
+      }
+    },
+    "validations": {
+      "type": "array",
+      "minItems": 0,
+      "maxItems": 32,
+      "items": {
+        "$ref": "#/$defs/validation_record"
+      }
+    },
+    "signals": {
+      "description": "Unique nonempty subset of the four friction signals.",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 4,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/friction_signal"
+      }
+    },
+    "diagnostic_command_count": {
+      "description": "Excess diagnostic invocations only.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 64
+    },
+    "classification": {
+      "enum": [
+        "defect",
+        "ux-friction",
+        "needs-review"
+      ]
+    },
+    "mechanism": {
+      "$ref": "#/$defs/mechanism"
+    },
+    "source_refs": {
+      "description": "Immutable source references; a defect requires at least one.",
+      "type": "array",
+      "minItems": 0,
+      "maxItems": 32,
+      "items": {
+        "$ref": "#/$defs/source_ref"
+      }
+    },
+    "redactions": {
+      "description": "Unique set of redaction categories applied to this packet.",
+      "type": "array",
+      "maxItems": 7,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/redaction_category"
+      }
+    },
+    "user_correction": {
+      "description": "Optional summary of the user correction; never verbatim conversation text.",
+      "type": "string",
+      "maxLength": 512
+    },
+    "defect_qualification": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "method",
+            "reproduction_count"
+          ],
+          "properties": {
+            "method": {
+              "enum": [
+                "reproduced_command",
+                "static_contract_violation"
+              ]
+            },
+            "reproduction_count": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 64
+            }
+          }
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "A defect requires at least one immutable source reference.",
+      "if": {
+        "properties": {
+          "classification": {
+            "const": "defect"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "source_refs": {
+            "minItems": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "classification": {
+            "const": "defect"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "defect_qualification": {
+            "not": {
+              "type": "null"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "defect_qualification": {
+            "properties": {
+              "method": {
+                "const": "reproduced_command"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "defect_qualification": {
+            "properties": {
+              "reproduction_count": {
+                "minimum": 2
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "signals": {
+            "contains": {
+              "const": "excess_diagnosis"
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "diagnostic_command_count": {
+            "minimum": 3
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "signals": {
+            "contains": {
+              "const": "user_correction"
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "user_correction"
+        ],
+        "properties": {
+          "user_correction": {
+            "minLength": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "signals": {
+            "contains": {
+              "const": "state_mismatch"
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "validations": {
+            "contains": {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "http",
+                    "hostname",
+                    "identity"
+                  ]
+                },
+                "passed": {
+                  "const": false
+                }
+              }
+            },
+            "minContains": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "signals": {
+            "contains": {
+              "const": "objective_failure"
+            }
+          }
+        }
+      },
+      "then": {
+        "anyOf": [
+          {
+            "properties": {
+              "commands": {
+                "contains": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "termination": {
+                          "enum": [
+                            "timeout",
+                            "signal",
+                            "not_started"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "termination": {
+                          "const": "exited"
+                        },
+                        "exit_code": {
+                          "not": {
+                            "const": 0
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "minContains": 1
+              }
+            }
+          },
+          {
+            "properties": {
+              "validations": {
+                "contains": {
+                  "properties": {
+                    "passed": {
+                      "const": false
+                    }
+                  }
+                },
+                "minContains": 1
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "$defs": {
+    "uuid_v4": {
+      "description": "Canonical lowercase UUIDv4.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "sha256_hex": {
+      "description": "Full lowercase SHA-256 hex digest.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "commit_sha": {
+      "description": "Lowercase 40-hex Git commit SHA-1.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "utc_rfc3339": {
+      "description": "RFC 3339 timestamp in UTC (Z offset only).",
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$"
+    },
+    "url": {
+      "description": "Absolute http(s) URL without whitespace.",
+      "type": "string",
+      "pattern": "^https?://\\S+$"
+    },
+    "friction_signal": {
+      "enum": [
+        "objective_failure",
+        "state_mismatch",
+        "user_correction",
+        "excess_diagnosis"
+      ]
+    },
+    "redaction_category": {
+      "enum": [
+        "home_path",
+        "authorization",
+        "cookie",
+        "query_string",
+        "named_secret",
+        "identity_material",
+        "scanner_match"
+      ]
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "portal_version",
+        "os",
+        "arch",
+        "service_manager",
+        "source_revision"
+      ],
+      "properties": {
+        "portal_version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 32,
+          "description": "Installed Portal version, or null when Portal could not run."
+        },
+        "os": {
+          "enum": [
+            "linux",
+            "darwin",
+            "windows"
+          ]
+        },
+        "arch": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32
+        },
+        "service_manager": {
+          "enum": [
+            "systemd",
+            "launchd",
+            "windows_service",
+            "none"
+          ]
+        },
+        "source_revision": {
+          "description": "Portal source commit when known.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[0-9a-f]{40}$"
+        }
+      }
+    },
+    "command_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "argv",
+        "duration_ms",
+        "termination",
+        "exit_code",
+        "signal",
+        "stdout_summary",
+        "stderr_summary"
+      ],
+      "properties": {
+        "argv": {
+          "description": "Sanitized argument vector.",
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "items": {
+            "type": "string",
+            "maxLength": 256
+          }
+        },
+        "duration_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "termination": {
+          "enum": [
+            "exited",
+            "timeout",
+            "signal",
+            "not_started"
+          ]
+        },
+        "exit_code": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "signal": {
+          "description": "Signal number when termination is signal.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "stdout_summary": {
+          "description": "Collapsed-whitespace excerpt that proves the signal.",
+          "type": "string",
+          "maxLength": 1024
+        },
+        "stderr_summary": {
+          "description": "Collapsed-whitespace excerpt that proves the signal.",
+          "type": "string",
+          "maxLength": 1024
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "termination": {
+                "const": "exited"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "exit_code": {
+                "type": "integer"
+              },
+              "signal": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "termination": {
+                "const": "signal"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "exit_code": {
+                "type": "null"
+              },
+              "signal": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "termination": {
+                "enum": [
+                  "timeout",
+                  "not_started"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "exit_code": {
+                "type": "null"
+              },
+              "signal": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "validation_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "contract_code",
+        "expected",
+        "observed",
+        "passed"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "service",
+            "http",
+            "hostname",
+            "identity",
+            "process",
+            "protocol"
+          ]
+        },
+        "contract_code": {
+          "enum": [
+            "service_active",
+            "process_running",
+            "process_stopped",
+            "http_200_399",
+            "http_auth_401",
+            "http_auth_403",
+            "http_x402_402",
+            "hostname_stable",
+            "identity_reused",
+            "protocol_nonmutating"
+          ]
+        },
+        "expected": {
+          "type": "string",
+          "maxLength": 512
+        },
+        "observed": {
+          "type": "string",
+          "maxLength": 512
+        },
+        "passed": {
+          "type": "boolean"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "service"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "contract_code": {
+                "enum": [
+                  "service_active"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "http"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "contract_code": {
+                "enum": [
+                  "http_200_399",
+                  "http_auth_401",
+                  "http_auth_403",
+                  "http_x402_402"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "hostname"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "contract_code": {
+                "enum": [
+                  "hostname_stable"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "identity"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "contract_code": {
+                "enum": [
+                  "identity_reused"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "process"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "contract_code": {
+                "enum": [
+                  "process_running",
+                  "process_stopped"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "protocol"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "contract_code": {
+                "enum": [
+                  "protocol_nonmutating"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "mechanism": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "component",
+        "error_or_expectation",
+        "corrective_action",
+        "source_symbol_or_contract"
+      ],
+      "properties": {
+        "component": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "error_or_expectation": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "corrective_action": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "source_symbol_or_contract": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 256
+        }
+      }
+    },
+    "source_ref": {
+      "description": "Immutable source reference: a code location in gosuda/portal-tunnel, or a documented contract at an immutable revision.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "repository",
+            "commit",
+            "path",
+            "line_range",
+            "url"
+          ],
+          "properties": {
+            "repository": {
+              "const": "gosuda/portal-tunnel"
+            },
+            "commit": {
+              "$ref": "#/$defs/commit_sha"
+            },
+            "path": {
+              "description": "Repository-relative path.",
+              "type": "string",
+              "minLength": 1
+            },
+            "line_range": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "start_line",
+                "end_line"
+              ],
+              "properties": {
+                "start_line": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "end_line": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "url": {
+              "description": "Commit-pinned URL.",
+              "$ref": "#/$defs/url"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "repository",
+            "commit",
+            "url",
+            "section"
+          ],
+          "properties": {
+            "repository": {
+              "const": "gosuda/portal-tunnel"
+            },
+            "commit": {
+              "$ref": "#/$defs/commit_sha"
+            },
+            "url": {
+              "description": "Commit-pinned URL.",
+              "$ref": "#/$defs/url"
+            },
+            "section": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/plugins/portal-deploy/skills/portal-feedback/references/finding.schema.json
+++ b/plugins/portal-deploy/skills/portal-feedback/references/finding.schema.json
@@ -1,0 +1,2004 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Portal feedback finding record",
+  "description": "The authoritative record stored at findings/<finding-id>.json. Every field is always present; a field unavailable in the current state is explicitly null. Evidence packets are immutable after persistence; reclassification updates assessment fields only.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "finding_id",
+    "mechanism_digest",
+    "canonical_signature",
+    "state",
+    "effective_classification",
+    "assessment_at",
+    "assessment_reason",
+    "impact_category",
+    "created_at",
+    "updated_at",
+    "next_action",
+    "requested_outcome_class",
+    "resume_state",
+    "due_at",
+    "brief",
+    "brief_revision_digest",
+    "scope_digest",
+    "existing_issue_url",
+    "new_issue_url",
+    "pr_url",
+    "branch",
+    "base_revision",
+    "head_sha",
+    "merge_sha",
+    "release_tag",
+    "blocker_code",
+    "blocker_summary",
+    "evidence",
+    "assessment_source_refs",
+    "approval_history",
+    "duplicate_result",
+    "rejection_history",
+    "replaced_lock_nonces",
+    "patched_replay_attempt_id",
+    "patched_replay_record_digest",
+    "real_use_attempt_id",
+    "real_use_record_digest",
+    "patched_replay_metrics",
+    "real_use_metrics"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "finding_id": {
+      "description": "Full 64-character lowercase SHA-256 digest of the UTF-8 canonical signature; no truncated identifier exists.",
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "mechanism_digest": {
+      "description": "Full SHA-256 digest of the normalized mechanism; ux-friction promotion and reopen decisions compare it.",
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "canonical_signature": {
+      "description": "Component, operation, error-or-expectation, corrective-action, and source-symbol-or-contract joined by single newlines after normalization.",
+      "type": "string",
+      "minLength": 1
+    },
+    "state": {
+      "$ref": "#/$defs/finding_state"
+    },
+    "effective_classification": {
+      "description": "Classification after any evidence-backed reclassification; the original run counts under the new classification.",
+      "enum": [
+        "defect",
+        "ux-friction",
+        "needs-review"
+      ]
+    },
+    "assessment_at": {
+      "$ref": "#/$defs/utc_rfc3339"
+    },
+    "assessment_reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "impact_category": {
+      "description": "Order: efficiency < usability < availability < correctness < security.",
+      "enum": [
+        "efficiency",
+        "usability",
+        "availability",
+        "correctness",
+        "security"
+      ]
+    },
+    "created_at": {
+      "$ref": "#/$defs/utc_rfc3339"
+    },
+    "updated_at": {
+      "$ref": "#/$defs/utc_rfc3339"
+    },
+    "next_action": {
+      "type": "string",
+      "minLength": 1
+    },
+    "requested_outcome_class": {
+      "description": "SHA-256 of the RFC 8785 requested-outcome object over operation, mode, and deduplicated contracts sorted by kind then contract_code.",
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "resume_state": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "enum": [
+            "candidate",
+            "needs_review",
+            "awaiting_approval",
+            "deferred",
+            "rejected",
+            "approved",
+            "publication_pending",
+            "linked_existing",
+            "issue_filed",
+            "implementation_checkpoint",
+            "maintainer_queue",
+            "implementing",
+            "pr_publication_pending",
+            "pr_filed",
+            "merged_waiting_release",
+            "waiting_real_use",
+            "closed",
+            "regressed"
+          ]
+        }
+      ]
+    },
+    "due_at": {
+      "description": "Defer due time; inbox skips the finding until then.",
+      "$ref": "#/$defs/nullable_utc_rfc3339"
+    },
+    "brief": {
+      "description": "Persisted decision-ready brief; non-null from awaiting_approval onward.",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/brief_object"
+        }
+      ]
+    },
+    "brief_revision_digest": {
+      "description": "SHA-256 of the RFC 8785 brief object; non-null from awaiting_approval onward.",
+      "$ref": "#/$defs/nullable_sha256_hex"
+    },
+    "scope_digest": {
+      "description": "SHA-256 of the RFC 8785 authorization object; non-null from awaiting_approval onward.",
+      "$ref": "#/$defs/nullable_sha256_hex"
+    },
+    "existing_issue_url": {
+      "description": "Open or unresolved duplicate match.",
+      "$ref": "#/$defs/nullable_url"
+    },
+    "new_issue_url": {
+      "description": "Issue created for this finding.",
+      "$ref": "#/$defs/nullable_url"
+    },
+    "pr_url": {
+      "description": "Pull request filed for this finding.",
+      "$ref": "#/$defs/nullable_url"
+    },
+    "branch": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1
+    },
+    "base_revision": {
+      "$ref": "#/$defs/nullable_commit_sha"
+    },
+    "head_sha": {
+      "$ref": "#/$defs/nullable_commit_sha"
+    },
+    "merge_sha": {
+      "description": "Maintainer merge commit.",
+      "$ref": "#/$defs/nullable_commit_sha"
+    },
+    "release_tag": {
+      "description": "Release tag whose commit contains the merge SHA.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1
+    },
+    "blocker_code": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1
+    },
+    "blocker_summary": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1,
+      "maxLength": 512
+    },
+    "evidence": {
+      "description": "Packets correlated into this finding; immutable after persistence.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "packet_path",
+          "packet_digest",
+          "run_id",
+          "votes"
+        ],
+        "properties": {
+          "packet_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "packet_digest": {
+            "$ref": "#/$defs/sha256_hex"
+          },
+          "run_id": {
+            "$ref": "#/$defs/uuid_v4"
+          },
+          "votes": {
+            "description": "Whether that run casts a promotion vote for this finding.",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "assessment_source_refs": {
+      "description": "Immutable source references backing the current assessment.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/source_ref"
+      }
+    },
+    "approval_history": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/approval_record"
+      }
+    },
+    "duplicate_result": {
+      "$ref": "#/$defs/duplicate_result"
+    },
+    "rejection_history": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/rejection_record"
+      }
+    },
+    "replaced_lock_nonces": {
+      "description": "Nonces of stale locks replaced before a mutation.",
+      "type": "array",
+      "maxItems": 16,
+      "items": {
+        "$ref": "#/$defs/uuid_v4"
+      }
+    },
+    "patched_replay_attempt_id": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/uuid_v4"
+        }
+      ]
+    },
+    "patched_replay_record_digest": {
+      "$ref": "#/$defs/nullable_sha256_hex"
+    },
+    "real_use_attempt_id": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/uuid_v4"
+        }
+      ]
+    },
+    "real_use_record_digest": {
+      "$ref": "#/$defs/nullable_sha256_hex"
+    },
+    "patched_replay_metrics": {
+      "description": "Required once the finding waits for real use.",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/metric_object"
+        }
+      ]
+    },
+    "real_use_metrics": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/metric_object"
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "Brief and both digests must be non-null from awaiting_approval onward.",
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "awaiting_approval",
+              "approved",
+              "deferred",
+              "rejected",
+              "publication_pending",
+              "linked_existing",
+              "issue_filed",
+              "implementation_checkpoint",
+              "maintainer_queue",
+              "implementing",
+              "pr_publication_pending",
+              "pr_filed",
+              "merged_waiting_release",
+              "waiting_real_use",
+              "closed",
+              "regressed"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "brief": {
+            "not": {
+              "type": "null"
+            }
+          },
+          "brief_revision_digest": {
+            "type": "string"
+          },
+          "scope_digest": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "$comment": "blocked needs blocker code, blocker summary, and resume state.",
+      "if": {
+        "properties": {
+          "state": {
+            "const": "blocked"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "blocker_code": {
+            "type": "string"
+          },
+          "blocker_summary": {
+            "type": "string"
+          },
+          "resume_state": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "$comment": "pr_filed needs the PR URL and head SHA.",
+      "if": {
+        "properties": {
+          "state": {
+            "const": "pr_filed"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "pr_url": {
+            "type": "string"
+          },
+          "head_sha": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "$comment": "waiting_real_use needs merge SHA, containing release tag, and patched replay metrics.",
+      "if": {
+        "properties": {
+          "state": {
+            "const": "waiting_real_use"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "merge_sha": {
+            "type": "string"
+          },
+          "release_tag": {
+            "type": "string"
+          },
+          "patched_replay_metrics": {
+            "not": {
+              "type": "null"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "publication_pending",
+              "linked_existing",
+              "issue_filed",
+              "implementation_checkpoint",
+              "maintainer_queue",
+              "implementing",
+              "pr_publication_pending",
+              "pr_filed",
+              "merged_waiting_release",
+              "waiting_real_use",
+              "closed",
+              "regressed"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "approval_history": {
+            "contains": {
+              "properties": {
+                "action": {
+                  "const": "approve"
+                }
+              }
+            },
+            "minContains": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "deferred"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "due_at": {
+            "not": {
+              "type": "null"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "linked_existing"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "existing_issue_url": {
+            "not": {
+              "type": "null"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "issue_filed",
+              "implementation_checkpoint",
+              "maintainer_queue",
+              "implementing",
+              "pr_publication_pending",
+              "pr_filed",
+              "merged_waiting_release",
+              "waiting_real_use",
+              "closed",
+              "regressed"
+            ]
+          }
+        }
+      },
+      "then": {
+        "anyOf": [
+          {
+            "properties": {
+              "existing_issue_url": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "new_issue_url": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "implementing",
+              "pr_publication_pending",
+              "pr_filed",
+              "merged_waiting_release",
+              "waiting_real_use",
+              "closed"
+            ]
+          }
+        }
+      },
+      "then": {
+        "allOf": [
+          {
+            "properties": {
+              "branch": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "base_revision": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "pr_publication_pending",
+              "pr_filed",
+              "merged_waiting_release",
+              "waiting_real_use",
+              "closed"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "head_sha": {
+            "not": {
+              "type": "null"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "merged_waiting_release",
+              "waiting_real_use",
+              "closed"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "merge_sha": {
+            "not": {
+              "type": "null"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "waiting_real_use",
+              "closed"
+            ]
+          }
+        }
+      },
+      "then": {
+        "allOf": [
+          {
+            "properties": {
+              "release_tag": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "patched_replay_attempt_id": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "patched_replay_record_digest": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "patched_replay_metrics": {
+                "allOf": [
+                  {
+                    "not": {
+                      "type": "null"
+                    }
+                  },
+                  {
+                    "properties": {
+                      "requested_outcome_reached": {
+                        "const": true
+                      },
+                      "original_signal_absent": {
+                        "const": true
+                      },
+                      "human_correction_count": {
+                        "const": 0
+                      },
+                      "state_mismatch_count": {
+                        "const": 0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "closed"
+          }
+        }
+      },
+      "then": {
+        "allOf": [
+          {
+            "properties": {
+              "real_use_attempt_id": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "real_use_record_digest": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "real_use_metrics": {
+                "allOf": [
+                  {
+                    "not": {
+                      "type": "null"
+                    }
+                  },
+                  {
+                    "properties": {
+                      "requested_outcome_reached": {
+                        "const": true
+                      },
+                      "original_signal_absent": {
+                        "const": true
+                      },
+                      "human_correction_count": {
+                        "const": 0
+                      },
+                      "state_mismatch_count": {
+                        "const": 0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "anyOf": [
+          {
+            "properties": {
+              "state": {
+                "enum": [
+                  "publication_pending",
+                  "linked_existing",
+                  "issue_filed",
+                  "implementation_checkpoint",
+                  "maintainer_queue",
+                  "implementing",
+                  "pr_publication_pending",
+                  "pr_filed",
+                  "merged_waiting_release",
+                  "waiting_real_use",
+                  "closed",
+                  "regressed"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "state": {
+                "const": "blocked"
+              },
+              "resume_state": {
+                "enum": [
+                  "publication_pending",
+                  "linked_existing",
+                  "issue_filed",
+                  "implementation_checkpoint",
+                  "maintainer_queue",
+                  "implementing",
+                  "pr_publication_pending",
+                  "pr_filed",
+                  "merged_waiting_release",
+                  "waiting_real_use",
+                  "closed",
+                  "regressed"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "approval_history": {
+            "contains": {
+              "required": [
+                "action"
+              ],
+              "properties": {
+                "action": {
+                  "const": "approve"
+                }
+              }
+            },
+            "minContains": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "anyOf": [
+          {
+            "properties": {
+              "state": {
+                "enum": [
+                  "linked_existing"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "state": {
+                "const": "blocked"
+              },
+              "resume_state": {
+                "enum": [
+                  "linked_existing"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "existing_issue_url": {
+            "not": {
+              "type": "null"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "anyOf": [
+          {
+            "properties": {
+              "state": {
+                "enum": [
+                  "issue_filed",
+                  "implementation_checkpoint",
+                  "maintainer_queue",
+                  "implementing",
+                  "pr_publication_pending",
+                  "pr_filed",
+                  "merged_waiting_release",
+                  "waiting_real_use",
+                  "closed",
+                  "regressed"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "state": {
+                "const": "blocked"
+              },
+              "resume_state": {
+                "enum": [
+                  "issue_filed",
+                  "implementation_checkpoint",
+                  "maintainer_queue",
+                  "implementing",
+                  "pr_publication_pending",
+                  "pr_filed",
+                  "merged_waiting_release",
+                  "waiting_real_use",
+                  "closed",
+                  "regressed"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "anyOf": [
+          {
+            "properties": {
+              "existing_issue_url": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "new_issue_url": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "anyOf": [
+          {
+            "properties": {
+              "state": {
+                "enum": [
+                  "implementing",
+                  "pr_publication_pending",
+                  "pr_filed",
+                  "merged_waiting_release",
+                  "waiting_real_use",
+                  "closed"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "state": {
+                "const": "blocked"
+              },
+              "resume_state": {
+                "enum": [
+                  "implementing",
+                  "pr_publication_pending",
+                  "pr_filed",
+                  "merged_waiting_release",
+                  "waiting_real_use",
+                  "closed"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "allOf": [
+          {
+            "properties": {
+              "branch": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "base_revision": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "anyOf": [
+          {
+            "properties": {
+              "state": {
+                "enum": [
+                  "pr_publication_pending",
+                  "pr_filed",
+                  "merged_waiting_release",
+                  "waiting_real_use",
+                  "closed"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "state": {
+                "const": "blocked"
+              },
+              "resume_state": {
+                "enum": [
+                  "pr_publication_pending",
+                  "pr_filed",
+                  "merged_waiting_release",
+                  "waiting_real_use",
+                  "closed"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "head_sha": {
+            "not": {
+              "type": "null"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "anyOf": [
+          {
+            "properties": {
+              "state": {
+                "enum": [
+                  "merged_waiting_release",
+                  "waiting_real_use",
+                  "closed"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "state": {
+                "const": "blocked"
+              },
+              "resume_state": {
+                "enum": [
+                  "merged_waiting_release",
+                  "waiting_real_use",
+                  "closed"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "merge_sha": {
+            "not": {
+              "type": "null"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "anyOf": [
+          {
+            "properties": {
+              "state": {
+                "enum": [
+                  "waiting_real_use",
+                  "closed"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "state": {
+                "const": "blocked"
+              },
+              "resume_state": {
+                "enum": [
+                  "waiting_real_use",
+                  "closed"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "allOf": [
+          {
+            "properties": {
+              "release_tag": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "patched_replay_attempt_id": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "patched_replay_record_digest": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "patched_replay_metrics": {
+                "allOf": [
+                  {
+                    "not": {
+                      "type": "null"
+                    }
+                  },
+                  {
+                    "properties": {
+                      "requested_outcome_reached": {
+                        "const": true
+                      },
+                      "original_signal_absent": {
+                        "const": true
+                      },
+                      "human_correction_count": {
+                        "const": 0
+                      },
+                      "state_mismatch_count": {
+                        "const": 0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "anyOf": [
+          {
+            "properties": {
+              "state": {
+                "enum": [
+                  "closed"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "state": {
+                "const": "blocked"
+              },
+              "resume_state": {
+                "enum": [
+                  "closed"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "allOf": [
+          {
+            "properties": {
+              "real_use_attempt_id": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "real_use_record_digest": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "real_use_metrics": {
+                "allOf": [
+                  {
+                    "not": {
+                      "type": "null"
+                    }
+                  },
+                  {
+                    "properties": {
+                      "requested_outcome_reached": {
+                        "const": true
+                      },
+                      "original_signal_absent": {
+                        "const": true
+                      },
+                      "human_correction_count": {
+                        "const": 0
+                      },
+                      "state_mismatch_count": {
+                        "const": 0
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "awaiting_approval",
+              "approved",
+              "deferred",
+              "rejected",
+              "publication_pending",
+              "linked_existing",
+              "issue_filed",
+              "implementation_checkpoint",
+              "maintainer_queue",
+              "implementing",
+              "pr_publication_pending",
+              "pr_filed",
+              "merged_waiting_release",
+              "waiting_real_use",
+              "closed",
+              "regressed"
+            ]
+          },
+          "effective_classification": {
+            "const": "defect"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence": {
+            "contains": {
+              "required": [
+                "votes"
+              ],
+              "properties": {
+                "votes": {
+                  "const": true
+                }
+              }
+            },
+            "minContains": 1
+          },
+          "assessment_source_refs": {
+            "minItems": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "awaiting_approval",
+              "approved",
+              "deferred",
+              "rejected",
+              "publication_pending",
+              "linked_existing",
+              "issue_filed",
+              "implementation_checkpoint",
+              "maintainer_queue",
+              "implementing",
+              "pr_publication_pending",
+              "pr_filed",
+              "merged_waiting_release",
+              "waiting_real_use",
+              "closed",
+              "regressed"
+            ]
+          },
+          "effective_classification": {
+            "const": "ux-friction"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence": {
+            "contains": {
+              "required": [
+                "votes"
+              ],
+              "properties": {
+                "votes": {
+                  "const": true
+                }
+              }
+            },
+            "minContains": 2
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "effective_classification": {
+            "const": "needs-review"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "state": {
+            "enum": [
+              "candidate",
+              "needs_review",
+              "blocked"
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "uuid_v4": {
+      "description": "Canonical lowercase UUIDv4.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "sha256_hex": {
+      "description": "Full lowercase SHA-256 hex digest.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "nullable_sha256_hex": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/sha256_hex"
+        }
+      ]
+    },
+    "commit_sha": {
+      "description": "Lowercase 40-hex Git commit SHA-1.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "nullable_commit_sha": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/commit_sha"
+        }
+      ]
+    },
+    "utc_rfc3339": {
+      "description": "RFC 3339 timestamp in UTC (Z offset only).",
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$"
+    },
+    "nullable_utc_rfc3339": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/utc_rfc3339"
+        }
+      ]
+    },
+    "url": {
+      "description": "Absolute http(s) URL without whitespace.",
+      "type": "string",
+      "pattern": "^https?://\\S+$"
+    },
+    "nullable_url": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/url"
+        }
+      ]
+    },
+    "finding_state": {
+      "enum": [
+        "candidate",
+        "needs_review",
+        "awaiting_approval",
+        "deferred",
+        "rejected",
+        "approved",
+        "publication_pending",
+        "linked_existing",
+        "issue_filed",
+        "implementation_checkpoint",
+        "maintainer_queue",
+        "implementing",
+        "pr_publication_pending",
+        "pr_filed",
+        "merged_waiting_release",
+        "waiting_real_use",
+        "closed",
+        "regressed",
+        "blocked"
+      ]
+    },
+    "brief_object": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "summary",
+        "expected_behavior",
+        "actual_behavior",
+        "acceptance_boundary",
+        "implementation_scope",
+        "evidence_packet_digests",
+        "source_refs",
+        "duplicate_status",
+        "risk_classification",
+        "proposed_public_actions"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "expected_behavior": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "actual_behavior": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "acceptance_boundary": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "implementation_scope": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          }
+        },
+        "evidence_packet_digests": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/sha256_hex"
+          }
+        },
+        "source_refs": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/source_ref"
+          }
+        },
+        "duplicate_status": {
+          "enum": [
+            "no_match",
+            "matched"
+          ]
+        },
+        "risk_classification": {
+          "enum": [
+            "low_risk",
+            "restricted"
+          ]
+        },
+        "proposed_public_actions": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/public_action"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "duplicate_status": {
+                "const": "matched"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "proposed_public_actions": {
+                "items": {
+                  "enum": [
+                    "create_pr_linked_existing",
+                    "reopen_issue",
+                    "comment_issue"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "duplicate_status": {
+                "const": "no_match"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "proposed_public_actions": {
+                "items": {
+                  "enum": [
+                    "create_issue",
+                    "create_pr"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "risk_classification": {
+                "const": "restricted"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "proposed_public_actions": {
+                "not": {
+                  "contains": {
+                    "enum": ["create_pr", "create_pr_linked_existing"]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "source_ref": {
+      "description": "Immutable source reference: a code location in gosuda/portal-tunnel, or a documented contract at an immutable revision.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "repository",
+            "commit",
+            "path",
+            "line_range",
+            "url"
+          ],
+          "properties": {
+            "repository": {
+              "const": "gosuda/portal-tunnel"
+            },
+            "commit": {
+              "$ref": "#/$defs/commit_sha"
+            },
+            "path": {
+              "description": "Repository-relative path.",
+              "type": "string",
+              "minLength": 1
+            },
+            "line_range": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "start_line",
+                "end_line"
+              ],
+              "properties": {
+                "start_line": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "end_line": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "url": {
+              "description": "Commit-pinned URL.",
+              "$ref": "#/$defs/url"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "repository",
+            "commit",
+            "url",
+            "section"
+          ],
+          "properties": {
+            "repository": {
+              "const": "gosuda/portal-tunnel"
+            },
+            "commit": {
+              "$ref": "#/$defs/commit_sha"
+            },
+            "url": {
+              "description": "Commit-pinned URL.",
+              "$ref": "#/$defs/url"
+            },
+            "section": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      ]
+    },
+    "metric_object": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requested_outcome_reached",
+        "original_signal_absent",
+        "human_correction_count",
+        "diagnostic_command_count",
+        "state_mismatch_count",
+        "elapsed_ms"
+      ],
+      "properties": {
+        "requested_outcome_reached": {
+          "type": "boolean"
+        },
+        "original_signal_absent": {
+          "type": "boolean"
+        },
+        "human_correction_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "diagnostic_command_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "state_mismatch_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "elapsed_ms": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "approval_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "timestamp",
+        "brief_revision_digest",
+        "scope_digest",
+        "approved_public_actions"
+      ],
+      "properties": {
+        "action": {
+          "description": "Action selected at a checkpoint.",
+          "enum": [
+            "approve",
+            "reject",
+            "defer",
+            "approve_implementation",
+            "hand_off",
+            "reject_implementation"
+          ]
+        },
+        "timestamp": {
+          "$ref": "#/$defs/utc_rfc3339"
+        },
+        "host_session_id": {
+          "description": "Host session ID when available.",
+          "type": "string",
+          "minLength": 1
+        },
+        "brief_revision_digest": {
+          "$ref": "#/$defs/sha256_hex"
+        },
+        "scope_digest": {
+          "$ref": "#/$defs/sha256_hex"
+        },
+        "approved_public_actions": {
+          "description": "Public actions authorized by this approval.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/public_action"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "action": {
+                "enum": [
+                  "approve",
+                  "approve_implementation"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "approved_public_actions": {
+                "minItems": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "action": {
+                "enum": [
+                  "reject",
+                  "defer",
+                  "hand_off",
+                  "reject_implementation"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "approved_public_actions": {
+                "maxItems": 0
+              }
+            }
+          }
+        }
+      ]
+    },
+    "rejection_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "timestamp",
+        "reason",
+        "brief_revision_digest"
+      ],
+      "properties": {
+        "timestamp": {
+          "$ref": "#/$defs/utc_rfc3339"
+        },
+        "reason": {
+          "description": "Bounded rejection reason.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "brief_revision_digest": {
+          "$ref": "#/$defs/sha256_hex"
+        }
+      }
+    },
+    "duplicate_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "searched_at",
+        "queries",
+        "matched_url",
+        "matched_artifact_state",
+        "reason"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "not_searched",
+            "no_match",
+            "matched",
+            "incomplete"
+          ]
+        },
+        "searched_at": {
+          "$ref": "#/$defs/nullable_utc_rfc3339"
+        },
+        "queries": {
+          "description": "Up to three search query strings.",
+          "type": "array",
+          "maxItems": 3,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "matched_url": {
+          "$ref": "#/$defs/nullable_url"
+        },
+        "matched_artifact_state": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "open",
+            "closed",
+            "merged",
+            "unresolved",
+            null
+          ]
+        },
+        "reason": {
+          "description": "Bounded reason, for example an incomplete search explanation.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 512
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "not_searched"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "searched_at": {
+                "type": "null"
+              },
+              "queries": {
+                "maxItems": 0
+              },
+              "matched_url": {
+                "type": "null"
+              },
+              "matched_artifact_state": {
+                "type": "null"
+              },
+              "reason": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "no_match"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "searched_at": {
+                "type": "string"
+              },
+              "queries": {
+                "minItems": 3
+              },
+              "matched_url": {
+                "type": "null"
+              },
+              "matched_artifact_state": {
+                "type": "null"
+              },
+              "reason": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "matched"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "searched_at": {
+                "type": "string"
+              },
+              "queries": {
+                "minItems": 1
+              },
+              "matched_url": {
+                "type": "string"
+              },
+              "matched_artifact_state": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "incomplete"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "searched_at": {
+                "type": "string"
+              },
+              "queries": {
+                "minItems": 1
+              },
+              "reason": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      ]
+    },
+    "public_action": {
+      "enum": [
+        "create_issue",
+        "create_pr",
+        "create_pr_linked_existing",
+        "reopen_issue",
+        "comment_issue"
+      ]
+    }
+  }
+}

--- a/plugins/portal-deploy/skills/portal-feedback/references/issue-and-pr-loop.md
+++ b/plugins/portal-deploy/skills/portal-feedback/references/issue-and-pr-loop.md
@@ -1,0 +1,205 @@
+# Issue and PR loop
+
+This reference owns Portal feedback state transitions, approval, publication, implementation, and closure. Evidence packet construction stays in `plugins/portal-deploy/skills/portal-expose/references/feedback-evidence.md`.
+
+## State root and locks
+
+Resolve the state root by platform:
+
+```text
+Linux:   $XDG_STATE_HOME/portal-feedback, else ~/.local/state/portal-feedback
+macOS:   ~/Library/Application Support/Portal Feedback
+Windows: %LOCALAPPDATA%\Portal Feedback
+```
+
+Use `runs/<run-id>/<packet-id>.json`, `findings/<finding-id>.json`, `verifications/<finding-id>/<attempt-id>.json`, and `locks/<finding-id>.lock`. Reject symlinks below the root. On POSIX, use `0700` directories and `0600` files. Write JSON through a flushed sibling temporary file and atomic rename.
+
+Before mutating a finding, exclusively create its lock with `pid`, `hostname`, `acquired_at`, UUIDv4 `nonce`, and nullable `host_session_id`. Replace a same-host lock older than 15 minutes only when its PID is absent. Replace a different-host lock after 15 minutes because this implementation has no remote worker. Record replaced nonces.
+
+## Retention
+
+Run cleanup at the beginning and end of `inbox` and `purge-expired`.
+
+- Delete unpromoted packets 30 days after `ended_at`.
+- Delete rejected findings and packets 30 days after rejection.
+- Delete deferred findings 30 days after `due_at`.
+- Retain every sanitized packet for at most 30 days after `ended_at`, regardless of finding state.
+- After packet expiry, retain only finding metadata, packet digests, public GitHub URLs, release data, and closure metrics for one year after closure.
+- Keep regressed finding metadata under the same one-year rule until resolved again.
+
+Invalid or future timestamps block deletion and move the finding to `needs_review`. Retained evidence packets stay immutable; cleanup deletes whole expired packets.
+
+## Correlate packets
+
+Validate each packet against `evidence-packet.schema.json` plus byte-length, timestamp-order, UUID-version, immutable-source, and secret checks. Invalid packets do not correlate.
+
+Normalize mechanism fields in this order:
+
+1. home prefix to `<home>`;
+2. canonical UUID to `<uuid>`;
+3. semantic version to `<version>`;
+4. long hexadecimal identifiers to `<hex>`;
+5. URL and dotted DNS hostnames to `<host>`;
+6. ports to `<port>`;
+7. lowercase ASCII, collapse whitespace, and trim surrounding punctuation.
+
+Keep named error codes and source symbols. Join component, operation, error or expectation, corrective action, and source symbol or contract with newlines. SHA-256 the UTF-8 signature; the full lowercase digest is `finding_id`.
+
+Keep votes only in `evidence[]` and derive unique voting run IDs at read time. One real run votes once per finding. Replay attempts never vote. Promote:
+
+- `defect`: one voting real packet with immutable source cause and valid deterministic qualification;
+- `ux-friction`: two voting real packets with different run IDs from different user tasks;
+- `needs-review`: never automatically.
+
+Reclassification updates finding assessment fields. Evidence packets remain immutable.
+
+## Duplicate search
+
+Search `gosuda/portal-tunnel` issues in all states and PRs in open, closed, and merged states. Run three independent query classes: normalized error text, command plus violated expectation, and source symbol plus component. Follow pagination to exhaustion. A provider cap, truncation, authentication error, rate limit, or outage makes the result incomplete and blocks promotion.
+
+A duplicate shares the causal mechanism, not only the symptom. An unresolved match prepares a contribution brief. For a closed issue claiming a fix, identify its merge and containing release. A recurrence on a later containing version is a regression; otherwise link the existing result and stop.
+
+## Persist and present the brief
+
+Serialize digests with RFC 8785 JSON Canonicalization Scheme and SHA-256.
+
+The complete brief contains title, summary, expected and actual behavior, acceptance boundary, implementation scope, packet digests, immutable sources, duplicate result, risk, and proposed public actions. Its hash is `brief_revision_digest`.
+
+The authorization object contains mechanism digest, expected behavior, acceptance boundary, code or documentation scope, risk, duplicate target, and proposed public actions. Its hash is `scope_digest`. Citation and prose repairs do not change scope. A changed target, behavior, boundary, risk, scope, or public action does.
+
+Persist before asking. Present:
+
+```text
+Finding
+Impact
+Evidence
+Duplicate search
+Expected vs actual
+Proposed scope
+Autonomous fix eligibility
+Public actions
+
+Approve | Reject | Defer
+```
+
+Use the host single-select question UI. Plain text counts only when it names the finding and action. Approval authorizes the listed issue or contribution, one low-risk implementation and PR inside scope, and review fixes inside scope. It does not authorize merge, comments, reopening, or scope expansion.
+
+Before any public mutation, require an `approve` history entry whose `scope_digest` equals the current finding scope. Its `brief_revision_digest` must match the brief presented at approval time. Later citation- or prose-only revisions may differ only after an audit proves the scope digest unchanged. Restricted implementation additionally requires a matching `approve_implementation` entry with the current implementation scope digest.
+
+For no-match restricted findings, the initial brief may authorize only issue creation. A later implementation checkpoint authorizes the PR as a separate public action after the restricted diff is reviewed.
+
+## Issue gate and recovery
+
+Before issue creation, rerun duplicate search and open every cited source at its immutable revision. The body uses `Summary`, `Reproduction`, `Evidence`, `Expected vs actual`, and `Scope`.
+
+All six gates must pass:
+
+1. Every factual claim has an immutable citation or is labeled as an observed reproduction.
+2. The report describes a concrete defect or repeatable UX contract failure, not a preference.
+3. A defect names its causal source mechanism; UX friction names the violated expectation and repeated corrective action.
+4. Duplicate search completed with no match.
+5. The title states the observed problem, not a proposed fix.
+6. Every cited source was opened at the cited revision.
+
+Add this marker to issue and PR bodies:
+
+```html
+<!-- portal-feedback:finding=<finding-id>;scope=<scope-digest> -->
+```
+
+Before retrying issue publication, search by repository and marker. Before retrying PR publication, search by marker and exact branch. Read back repository, artifact type, marker, title, scope digest, and URL. Recover an existing artifact instead of creating another.
+
+## Implementation boundary
+
+Autonomous work is limited to CLI output, documentation and skills, installer and OS-service generation, bounded configuration parsing and validation, and read-only status reporting.
+
+Security, authentication, identity, signing, TLS, ECH, MITM policy, secrets, relay protocol, leases, x402, payments, persistent data formats, migrations, backward incompatibility, and every other category require an implementation checkpoint.
+
+The checkpoint shows changed authorization scope, restricted areas, proposed tests, and public action. Approval authorizes implementation and PR under the new digest. Hand off or rejection moves to `maintainer_queue`.
+
+A supported regression seam is an existing public CLI, config parser, generated artifact, skill trigger case, or documented API contract. Documentation and skill-only work uses positive and negative fixtures plus the skill validator. Without a supported seam, stop at `maintainer_queue`.
+
+On Windows without a POSIX Portal checkout, stop at `maintainer_queue` with `posix_handoff_required`. Do not transfer local state automatically.
+
+## Implement and publish the PR
+
+Use a clean `gosuda/portal-tunnel` checkout and its current remote default branch. Create an isolated worktree and branch `portal-feedback/<finding-id>-<short-slug>`.
+
+1. Pin issue URL, base revision, scope digest, and acceptance boundary.
+2. Add the regression and observe red.
+3. Apply the smallest fix and observe green.
+4. Run affected checks and applicable current-OS CI commands that need no secret, privileged runner, or hosted service.
+5. Replay the original scenario and write a `patched_replay` verification attempt.
+6. Store attempt ID, record digest, and successful replay metrics before moving to `waiting_real_use`.
+7. Push only after local gates pass; set `pr_publication_pending`.
+8. Create and read back the PR before setting `pr_filed`.
+9. Apply review feedback inside scope. Rerun checks and write `post_review` verification after relevant edits.
+
+Hosted-only CI remains required. One clean rerun may classify a flaky failure. Restricted review changes return to the checkpoint. Maintainers merge.
+
+## Track release and close
+
+At `inbox`, inspect filed PRs and merged findings. Record maintainer merge SHA. Peel annotated release tags and prove containment with merge ancestry. A runner qualifies only when `portal version` maps unambiguously to a containing release tag.
+
+The requested-outcome class is the RFC 8785 SHA-256 digest of `{"operation":"<enum>","mode":"<enum>","contracts":[{"kind":"<validation kind>","contract_code":"<contract code>"}]}`. Deduplicate contracts and sort by kind then contract code. Free-text summaries do not enter it.
+
+A matching real use requires the same class, containing runner release, every validation passing, the original signal absent, no correction, no state mismatch, and no more diagnostic commands than patched replay.
+
+### Internal `evaluate-closure`
+
+`portal-expose` calls this procedure with a sanitized successful in-memory trace. Compute its requested-outcome class, find `waiting_real_use` records with that class, and sort by finding ID. For each finding, prove release containment and every closure condition. If any check fails, write nothing for that finding. Otherwise write one `real_use` verification attempt, validate its finding ID, kind, outcome class, digest, successful metrics, and tag ancestry, store attempt ID and record digest, then atomically move the finding to `closed`.
+
+Patched replay cannot close. A recurrence moves to `regressed`. Reopening or commenting requires a new brief with `reopen_issue` or `comment_issue`, a new scope digest, and explicit approval.
+
+## State transitions
+
+| Current state | Operation | Required guard | Next state |
+| --- | --- | --- | --- |
+| `candidate` | correlate | promotion and duplicate search complete | `awaiting_approval` |
+| `needs_review` | review | new source or contract evidence | `candidate` or `needs_review` |
+| `awaiting_approval` | approve | current brief and scope digest | `approved` |
+| `awaiting_approval` | reject | bounded reason | `rejected` |
+| `awaiting_approval` | defer | future `due_at` | `deferred` |
+| `deferred` | due | current time at or after `due_at` | `awaiting_approval` |
+| `approved` | stage issue publication | approval and duplicate guard | `publication_pending` |
+| `publication_pending` | publish issue | issue marker read-back | `issue_filed` or `linked_existing` |
+| `issue_filed` or `linked_existing` | implement | low-risk scope | `implementing` |
+| `issue_filed` or `linked_existing` | checkpoint | restricted or expanded scope | `implementation_checkpoint` |
+| `implementation_checkpoint` | approve-implementation | matching implementation approval | `implementing` |
+| `implementation_checkpoint` | handoff or reject-implementation | explicit operator action | `maintainer_queue` |
+| `implementing` | push | regression, checks, and patched replay pass | `pr_publication_pending` |
+| `pr_publication_pending` | publish | PR marker read-back | `pr_filed` |
+| `pr_filed` | merge | maintainer merge recorded | `merged_waiting_release` |
+| `merged_waiting_release` | release | merge is ancestor of release tag | `waiting_real_use` |
+| `waiting_real_use` | evaluate-closure | qualifying real-use verification | `closed` |
+| `waiting_real_use` or `closed` | recurrence | new brief required for public action | `regressed` |
+| any active state | blocked | external transient failure; preserve resume state | `blocked` |
+| `blocked` | retry | stored resume state and its guards | stored resume state |
+
+Any mutation not in this table is invalid and leaves the finding unchanged. While `blocked`, validate every invariant of `resume_state`; blocking suspends an operation but never erases its approval, artifact identity, or verification proof.
+
+## Operator behavior
+
+- `inbox`: retention, packet ingestion, due-state advancement, blocked inspection without retry, PR/release refresh, then due listing. No public mutation.
+- `retry`: recover a remote marker, then attempt the stored resume state once.
+- `replay`: create a new attempt ID and execute the scenario.
+- `status`: no state transition.
+- `defer`: default seven days; deferred items do not block newer work.
+- invalid-state mutation: no change; report allowed transitions.
+
+## Skill trigger fixtures
+
+Positive:
+
+- Review the Portal friction recorded by my last tunnel attempt.
+- Show the Portal feedback inbox.
+- Approve finding `<id>` and carry the low-risk fix through a PR.
+- Retry the blocked Portal feedback publication.
+- Replay finding `<id>` against the patch.
+
+Negative:
+
+- Expose this app through Portal.
+- Start a persistent Portal tunnel.
+- Run a Portal relay.
+- Explain the last Portal error without creating an upstream artifact.

--- a/plugins/portal-deploy/skills/portal-feedback/references/verification-attempt.schema.json
+++ b/plugins/portal-deploy/skills/portal-feedback/references/verification-attempt.schema.json
@@ -1,0 +1,685 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Portal feedback verification attempt",
+  "description": "One verification attempt: a patched replay, a post-review replay, or a later real use. Verification attempts never vote. record_digest is the lowercase SHA-256 hex of the RFC 8785 canonical form of this object with the record_digest property omitted.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "attempt_id",
+    "finding_id",
+    "run_id",
+    "kind",
+    "origin",
+    "started_at",
+    "ended_at",
+    "environment",
+    "operation",
+    "mode",
+    "requested_outcome_class",
+    "commands",
+    "validations",
+    "signals",
+    "diagnostic_command_count",
+    "metrics",
+    "merge_containment",
+    "record_digest"
+  ],
+  "properties": {
+    "attempt_id": {
+      "description": "Canonical lowercase UUIDv4, distinct per attempt even when one real run verifies several findings.",
+      "$ref": "#/$defs/uuid_v4"
+    },
+    "finding_id": {
+      "description": "The finding this attempt verifies: the full 64-character lowercase SHA-256 finding identifier.",
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "run_id": {
+      "description": "Canonical lowercase UUIDv4 of the experience run that produced this attempt.",
+      "$ref": "#/$defs/uuid_v4"
+    },
+    "kind": {
+      "enum": [
+        "patched_replay",
+        "post_review",
+        "real_use"
+      ]
+    },
+    "origin": {
+      "enum": [
+        "real",
+        "replay"
+      ]
+    },
+    "started_at": {
+      "$ref": "#/$defs/utc_rfc3339"
+    },
+    "ended_at": {
+      "description": "Not before started_at; ordering is checked by the skill.",
+      "$ref": "#/$defs/utc_rfc3339"
+    },
+    "environment": {
+      "$ref": "#/$defs/environment"
+    },
+    "operation": {
+      "enum": [
+        "install",
+        "expose",
+        "agent_run",
+        "restart",
+        "stop",
+        "inspect",
+        "update"
+      ]
+    },
+    "mode": {
+      "enum": [
+        "foreground",
+        "managed",
+        "not_applicable"
+      ]
+    },
+    "requested_outcome_class": {
+      "description": "SHA-256 of the same RFC 8785 requested-outcome object used by the finding; a closing real use must match it.",
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "commands": {
+      "description": "Sanitized command records.",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 64,
+      "items": {
+        "$ref": "#/$defs/command_record"
+      }
+    },
+    "validations": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "items": {
+        "$ref": "#/$defs/validation_record"
+      }
+    },
+    "signals": {
+      "description": "Observed friction signals; empty for a qualifying real use.",
+      "type": "array",
+      "maxItems": 4,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/friction_signal"
+      }
+    },
+    "diagnostic_command_count": {
+      "description": "Excess diagnostic invocations only; a closing real use must not exceed the patched replay count.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 64
+    },
+    "metrics": {
+      "$ref": "#/$defs/metric_object"
+    },
+    "merge_containment": {
+      "$ref": "#/$defs/merge_containment"
+    },
+    "record_digest": {
+      "description": "Lowercase SHA-256 hex over the RFC 8785 canonical verification object with record_digest omitted.",
+      "$ref": "#/$defs/sha256_hex"
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "Replay kinds originate from replay and never vote or close; their containment may be unresolved.",
+      "if": {
+        "properties": {
+          "kind": {
+            "enum": [
+              "patched_replay",
+              "post_review"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "origin": {
+            "const": "replay"
+          }
+        }
+      }
+    },
+    {
+      "$comment": "A qualifying real use is real, observes no friction signal, passes every validation, and is verified through tag ancestry.",
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "real_use"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "origin": {
+            "const": "real"
+          },
+          "signals": {
+            "maxItems": 0
+          },
+          "validations": {
+            "items": {
+              "properties": {
+                "passed": {
+                  "const": true
+                }
+              }
+            }
+          },
+          "merge_containment": {
+            "properties": {
+              "verified": {
+                "const": true
+              },
+              "method": {
+                "const": "tag_ancestry"
+              },
+              "merge_sha": {
+                "type": "string"
+              },
+              "runner_ref": {
+                "type": "string"
+              },
+              "runner_commit": {
+                "type": "string"
+              },
+              "release_tag": {
+                "type": "string"
+              },
+              "release_commit": {
+                "type": "string"
+              }
+            }
+          },
+          "metrics": {
+            "properties": {
+              "requested_outcome_reached": {
+                "const": true
+              },
+              "original_signal_absent": {
+                "const": true
+              },
+              "human_correction_count": {
+                "const": 0
+              },
+              "state_mismatch_count": {
+                "const": 0
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "uuid_v4": {
+      "description": "Canonical lowercase UUIDv4.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "sha256_hex": {
+      "description": "Full lowercase SHA-256 hex digest.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "commit_sha": {
+      "description": "Lowercase 40-hex Git commit SHA-1.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "nullable_commit_sha": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/commit_sha"
+        }
+      ]
+    },
+    "utc_rfc3339": {
+      "description": "RFC 3339 timestamp in UTC (Z offset only).",
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$"
+    },
+    "friction_signal": {
+      "enum": [
+        "objective_failure",
+        "state_mismatch",
+        "user_correction",
+        "excess_diagnosis"
+      ]
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "portal_version",
+        "os",
+        "arch",
+        "service_manager",
+        "source_revision"
+      ],
+      "properties": {
+        "portal_version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 32,
+          "description": "Installed Portal version, or null when Portal could not run."
+        },
+        "os": {
+          "enum": [
+            "linux",
+            "darwin",
+            "windows"
+          ]
+        },
+        "arch": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32
+        },
+        "service_manager": {
+          "enum": [
+            "systemd",
+            "launchd",
+            "windows_service",
+            "none"
+          ]
+        },
+        "source_revision": {
+          "description": "Portal source commit when known.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[0-9a-f]{40}$"
+        }
+      }
+    },
+    "command_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "argv",
+        "duration_ms",
+        "termination",
+        "exit_code",
+        "signal",
+        "stdout_summary",
+        "stderr_summary"
+      ],
+      "properties": {
+        "argv": {
+          "description": "Sanitized argument vector.",
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "items": {
+            "type": "string",
+            "maxLength": 256
+          }
+        },
+        "duration_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "termination": {
+          "enum": [
+            "exited",
+            "timeout",
+            "signal",
+            "not_started"
+          ]
+        },
+        "exit_code": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "signal": {
+          "description": "Signal number when termination is signal.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "stdout_summary": {
+          "description": "Collapsed-whitespace excerpt that proves the signal.",
+          "type": "string",
+          "maxLength": 1024
+        },
+        "stderr_summary": {
+          "description": "Collapsed-whitespace excerpt that proves the signal.",
+          "type": "string",
+          "maxLength": 1024
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "termination": {
+                "const": "exited"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "exit_code": {
+                "type": "integer"
+              },
+              "signal": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "termination": {
+                "const": "signal"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "exit_code": {
+                "type": "null"
+              },
+              "signal": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "termination": {
+                "enum": [
+                  "timeout",
+                  "not_started"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "exit_code": {
+                "type": "null"
+              },
+              "signal": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "validation_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "contract_code",
+        "expected",
+        "observed",
+        "passed"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "service",
+            "http",
+            "hostname",
+            "identity",
+            "process",
+            "protocol"
+          ]
+        },
+        "contract_code": {
+          "enum": [
+            "service_active",
+            "process_running",
+            "process_stopped",
+            "http_200_399",
+            "http_auth_401",
+            "http_auth_403",
+            "http_x402_402",
+            "hostname_stable",
+            "identity_reused",
+            "protocol_nonmutating"
+          ]
+        },
+        "expected": {
+          "type": "string",
+          "maxLength": 512
+        },
+        "observed": {
+          "type": "string",
+          "maxLength": 512
+        },
+        "passed": {
+          "type": "boolean"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "service"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "contract_code": {
+                "enum": [
+                  "service_active"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "http"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "contract_code": {
+                "enum": [
+                  "http_200_399",
+                  "http_auth_401",
+                  "http_auth_403",
+                  "http_x402_402"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "hostname"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "contract_code": {
+                "enum": [
+                  "hostname_stable"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "identity"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "contract_code": {
+                "enum": [
+                  "identity_reused"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "process"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "contract_code": {
+                "enum": [
+                  "process_running",
+                  "process_stopped"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "protocol"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "contract_code": {
+                "enum": [
+                  "protocol_nonmutating"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "metric_object": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requested_outcome_reached",
+        "original_signal_absent",
+        "human_correction_count",
+        "diagnostic_command_count",
+        "state_mismatch_count",
+        "elapsed_ms"
+      ],
+      "properties": {
+        "requested_outcome_reached": {
+          "type": "boolean"
+        },
+        "original_signal_absent": {
+          "type": "boolean"
+        },
+        "human_correction_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "diagnostic_command_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "state_mismatch_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "elapsed_ms": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "merge_containment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "merge_sha",
+        "runner_ref",
+        "runner_commit",
+        "release_tag",
+        "release_commit",
+        "verified",
+        "method"
+      ],
+      "properties": {
+        "merge_sha": {
+          "description": "Maintainer merge commit.",
+          "$ref": "#/$defs/nullable_commit_sha"
+        },
+        "runner_ref": {
+          "description": "Runner ref when the installed Portal version maps unambiguously to one.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "runner_commit": {
+          "$ref": "#/$defs/nullable_commit_sha"
+        },
+        "release_tag": {
+          "description": "Containing release tag.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "release_commit": {
+          "description": "Commit the containing release tag resolves to after peeling annotated tags.",
+          "$ref": "#/$defs/nullable_commit_sha"
+        },
+        "verified": {
+          "type": "boolean"
+        },
+        "method": {
+          "enum": [
+            "tag_ancestry",
+            "source_ancestry",
+            "unresolved"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

AI agents can now turn real Portal usage friction into a controlled upstream feedback loop. The plugin records only sanitized friction evidence, groups repeated causes, requires one approval before public GitHub work, and keeps normal successful exposure runs artifact-free.

Approved low-risk findings can proceed through issue creation, regression work, replay, and PR publication without a second checkpoint. Maintainers retain merge authority. A finding closes only after a release contains the fix and a later real Portal run confirms that the original friction is gone.

## Design

- `portal-expose` remains the operation skill and owns the in-memory trace plus redacted evidence handoff.
- `portal-feedback` owns correlation, promotion, approval, issue/PR recovery, release tracking, and closure.
- Three strict Draft 2020-12 schemas cover evidence packets, findings, and verification attempts.
- Finding IDs and authorization digests use full SHA-256 values over defined canonical inputs.
- The low-risk autonomous allowlist covers CLI output, docs and skills, installer/service generation, bounded config validation, and read-only status reporting.
- Security, identity, signing, TLS, relay protocol, payment, migration, and compatibility changes stop at an implementation checkpoint.

```mermaid
flowchart LR
  A[Portal usage] --> B{Friction?}
  B -->|No| C[Discard trace]
  B -->|Yes| D[Sanitize packet]
  D --> E[Correlate finding]
  E --> F[Approval checkpoint]
  F --> G[Issue]
  G --> H[Low-risk fix and replay]
  H --> I[PR]
  I --> J[Maintainer merge]
  J --> K[Containing release]
  K --> L[Next real use]
  L -->|Pass| M[Close finding]
  L -->|Repeat| N[Regressed]
```

## Verification

- Schema behavioral fixtures: `schema behavioral fixtures: PASS`
- Expose skill validation: passed
- Feedback skill validation: passed
- Portal plugin validation: passed
- Marketplace/plugin manifest JSON parsing: passed
- `git diff --check`: passed

## Known limitations

This PR defines a skills-only workflow. It does not add a Portal daemon, telemetry service, MCP server, hook, or live background monitor. Evidence processing runs during an active host-agent task or a later explicit `portal-feedback inbox` invocation.

## Post-Deploy Monitoring & Validation

No additional production monitoring is required for the Portal runtime. This change modifies agent skills, local evidence rules, and plugin metadata; it does not change the Portal relay, tunnel protocol, or service runtime.

After release, validate the feedback loop with these searches and checks:

- Search agent output for `portal-feedback`, `evidence packet rejected by redaction gate`, `awaiting_approval`, and `blocked`.
- Confirm ordinary successful Portal exposure leaves no feedback files under the resolved state root.
- Confirm a reproduced friction creates one sanitized packet and no identity, token, cookie, or credential material.
- Confirm issue and PR bodies contain the feedback marker and no raw logs.
- Confirm a maintainer merge followed by a containing release moves the finding to `waiting_real_use`, not directly to `closed`.

Rollback trigger: any evidence packet containing secret material, any public GitHub mutation before approval, duplicate issue creation after retry, or any finding closed without patched replay plus containing release plus qualifying real use. Mitigation is to disable the feedback skill, delete only unsafe local packets, and leave Portal exposure operation unchanged.
