### PR TITLE
fix(agent): leave systemd WorkingDirectory unquoted

### DIFF
--- a/cmd/portal-tunnel/agent/service/service_linux.go
+++ b/cmd/portal-tunnel/agent/service/service_linux.go
@@ -109,7 +109,11 @@ RestartSec=5
 
 [Install]
 WantedBy=default.target
-`, def.Description, def.WorkingDir, strings.Join(parts, " "))
+`, def.Description, systemdPath(def.WorkingDir), strings.Join(parts, " "))
+}
+
+func systemdPath(value string) string {
+	return strings.ReplaceAll(value, "%", "%%")
 }
 
 func shellQuote(value string) string {

--- a/cmd/portal-tunnel/agent/service/service_linux.go
+++ b/cmd/portal-tunnel/agent/service/service_linux.go
@@ -109,7 +109,7 @@ RestartSec=5
 
 [Install]
 WantedBy=default.target
-`, def.Description, shellQuote(def.WorkingDir), strings.Join(parts, " "))
+`, def.Description, def.WorkingDir, strings.Join(parts, " "))
 }
 
 func shellQuote(value string) string {

--- a/cmd/portal-tunnel/agent/service/service_linux_test.go
+++ b/cmd/portal-tunnel/agent/service/service_linux_test.go
@@ -31,3 +31,16 @@ func TestSystemdUnitWorkingDirectoryIsAbsoluteAndUnquoted(t *testing.T) {
 		t.Fatalf("ExecStart should stay shell-quoted:\n%s", unit)
 	}
 }
+
+func TestSystemdUnitWorkingDirectoryEscapesSpecifiers(t *testing.T) {
+	t.Parallel()
+
+	unit := systemdUnit(Definition{
+		Executable: "/home/user/.local/bin/portal",
+		WorkingDir: "/home/user/foo%bar",
+	})
+
+	if !strings.Contains(unit, "WorkingDirectory=/home/user/foo%%bar\n") {
+		t.Fatalf("WorkingDirectory must escape systemd specifiers:\n%s", unit)
+	}
+}

--- a/cmd/portal-tunnel/agent/service/service_linux_test.go
+++ b/cmd/portal-tunnel/agent/service/service_linux_test.go
@@ -1,0 +1,33 @@
+//go:build linux
+
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSystemdUnitWorkingDirectoryIsAbsoluteAndUnquoted(t *testing.T) {
+	t.Parallel()
+
+	unit := systemdUnit(Definition{
+		Name:        "portal-agent",
+		Description: "Manages Portal tunnel definitions and relay membership.",
+		Executable:  "/home/user/.local/bin/portal",
+		Args: []string{
+			"agent", "run", "--service",
+			"--config", "/home/user/.config/portal-tunnel/agent/config.toml",
+		},
+		WorkingDir: "/home/user/.config/portal-tunnel/agent",
+	})
+
+	if !strings.Contains(unit, "WorkingDirectory=/home/user/.config/portal-tunnel/agent\n") {
+		t.Fatalf("WorkingDirectory line missing or quoted:\n%s", unit)
+	}
+	if strings.Contains(unit, "WorkingDirectory='") {
+		t.Fatal("WorkingDirectory must not use shell quotes; systemd 259 treats them as part of the path")
+	}
+	if !strings.Contains(unit, "ExecStart='/home/user/.local/bin/portal' 'agent' 'run'") {
+		t.Fatalf("ExecStart should stay shell-quoted:\n%s", unit)
+	}
+}


### PR DESCRIPTION
## Summary

`portal agent run` on Linux systemd 259 installed a user unit that never started: `WorkingDirectory=` was shell-quoted, so systemd treated the quotes as part of the path and rejected it as not absolute. An ordinary absolute config directory now renders unquoted. `ExecStart=` quoting is unchanged.

## Test plan

- `go test ./cmd/portal-tunnel/agent/service/` (linux): generated unit contains `WorkingDirectory=/home/user/.config/portal-tunnel/agent` and still quotes `ExecStart=`

Closes #328
