### PR TITLE
fix(sdk): emit public_url on HTTP service ready

### DIFF
--- a/plugins/portal-deploy/skills/portal-expose/SKILL.md
+++ b/plugins/portal-deploy/skills/portal-expose/SKILL.md
@@ -72,7 +72,7 @@ Before executing, show the exact public target and any important exposure conseq
 - Create or update only the selected agent config, then start it with `portal agent run --config <path>` after the user accepts OS-service installation, or `portal agent run --foreground --config <path>` when the current session should own the process. `--foreground` opens the interactive dashboard when stdin and stdout are TTYs. Run that command in a non-TTY managed session so logs stay capturable and the TUI does not start.
 - Do not run `portal agent dashboard`. It is an interactive TUI. Give the user that command in the handoff.
 - Capture bounded output. Redact tokens, identity material, signed payloads, and credentials.
-- HTTP tunnels are ready on the `service ready at https://...` line, not the first `https://` in relay logs. Raw TCP/UDP tunnels log `raw transport endpoints allocated` with `tcp_addr` and/or `udp_addr` instead. Do not wait for an HTTPS URL on a raw transport.
+- HTTP tunnels are ready on a log event with field `public_url`. The message still starts with `service ready at`. Relay `https://` values in `listener_relays` / `added_relays` are not ready. Raw TCP/UDP tunnels log `raw transport endpoints allocated` with `tcp_addr` and/or `udp_addr` instead. Do not wait for an HTTPS URL on a raw transport.
 
 ### 6. Verify the Public Endpoint
 

--- a/sdk/listener.go
+++ b/sdk/listener.go
@@ -239,7 +239,7 @@ func (l *listener) run(ctx context.Context) {
 		if udpAddr != "" || tcpAddr != "" {
 			event.Msg("raw transport endpoints allocated")
 		} else if publicURL != "" {
-			event.Msg("service ready at " + publicURL)
+			logHTTPReady(l.identity.Address, publicURL, l.route.ListenerRelayURL())
 		} else {
 			event.Msg("relay listener registered")
 		}
@@ -276,6 +276,16 @@ func (l *listener) run(ctx context.Context) {
 		_ = l.Close()
 		return
 	}
+}
+
+func logHTTPReady(address, publicURL, relayURL string) {
+	event := log.Info().
+		Str("address", address).
+		Str("public_url", publicURL)
+	if relayURL != "" {
+		event = event.Str("relay_url", relayURL)
+	}
+	event.Msg("service ready at " + publicURL)
 }
 
 func (l *listener) Close() error {

--- a/sdk/listener_ready_test.go
+++ b/sdk/listener_ready_test.go
@@ -1,0 +1,62 @@
+package sdk
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func captureLogger(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := log.Logger
+	log.Logger = zerolog.New(&buf)
+	t.Cleanup(func() {
+		log.Logger = prev
+	})
+	return &buf
+}
+
+func decodeLogObject(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	var obj map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &obj); err != nil {
+		t.Fatalf("decode log json: %v\nraw: %s", err, buf.String())
+	}
+	return obj
+}
+
+func TestLogHTTPReadyEmitsPublicURLAndRelayURL(t *testing.T) {
+	buf := captureLogger(t)
+	logHTTPReady("0xabc", "https://app.example/path", "https://relay.example")
+	obj := decodeLogObject(t, buf)
+
+	if got, want := obj["message"], "service ready at https://app.example/path"; got != want {
+		t.Fatalf("message = %v, want %q", got, want)
+	}
+	if got, want := obj["public_url"], "https://app.example/path"; got != want {
+		t.Fatalf("public_url = %v, want %q", got, want)
+	}
+	if got, want := obj["relay_url"], "https://relay.example"; got != want {
+		t.Fatalf("relay_url = %v, want %q", got, want)
+	}
+	if obj["public_url"] == obj["relay_url"] {
+		t.Fatal("public_url must not equal relay_url")
+	}
+}
+
+func TestReconciledRelayLogIsNotHTTPReady(t *testing.T) {
+	buf := captureLogger(t)
+	log.Info().Strs("listener_relays", []string{"https://relay.example"}).Msg("reconciled relay listeners")
+	obj := decodeLogObject(t, buf)
+
+	if got, want := obj["message"], "reconciled relay listeners"; got != want {
+		t.Fatalf("message = %v, want %q", got, want)
+	}
+	if _, ok := obj["public_url"]; ok {
+		t.Fatalf("reconcile log must not have public_url: %v", obj)
+	}
+}


### PR DESCRIPTION
Agents waiting for HTTP ready treated the first `https://` in Portal logs as the tenant URL. That string also appears on `reconciled relay listeners` (`listener_relays` / `added_relays`). HTTP ready now carries named `public_url` and `relay_url` fields, matching MITM logs, while the message still starts with `service ready at`.

Tests: `TestLogHTTPReadyEmitsPublicURLAndRelayURL`, `TestReconciledRelayLogIsNotHTTPReady`.

Closes #326

## Post-Deploy Monitoring & Validation

Watch expose logs for a JSON event whose message starts with `service ready at` and whose `public_url` equals the tenant URL. A `reconciled relay listeners` event must not have `public_url`. If agents still pick a relay URL as ready, revert this PR.
