### PR TITLE
fix(utils): accept loopback http relay URLs

### DIFF
--- a/utils/relayurl_test.go
+++ b/utils/relayurl_test.go
@@ -1,0 +1,24 @@
+package utils
+
+import "testing"
+
+func TestNormalizeRelayURLRewritesLoopbackHTTP(t *testing.T) {
+	t.Parallel()
+
+	got, err := NormalizeRelayURL("http://127.0.0.1:14017")
+	if err != nil {
+		t.Fatalf("NormalizeRelayURL(loopback http) error = %v", err)
+	}
+	if got != "https://127.0.0.1:14017" {
+		t.Fatalf("NormalizeRelayURL(loopback http) = %q, want https://127.0.0.1:14017", got)
+	}
+}
+
+func TestNormalizeRelayURLRejectsNonLoopbackHTTP(t *testing.T) {
+	t.Parallel()
+
+	_, err := NormalizeRelayURL("http://relay.example")
+	if err == nil {
+		t.Fatal("NormalizeRelayURL(non-loopback http) error = nil, want https required")
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -158,6 +158,9 @@ func NormalizeRelayURL(raw string) (string, error) {
 	if parsed.Host == "" {
 		return "", fmt.Errorf("relay url host is empty: %q", raw)
 	}
+	if strings.EqualFold(parsed.Scheme, "http") && IsLocalRelayHost(parsed.Hostname()) {
+		parsed.Scheme = "https"
+	}
 	if !strings.EqualFold(parsed.Scheme, "https") {
 		return "", fmt.Errorf("relay url must use https: %q", raw)
 	}


### PR DESCRIPTION
`relay-server --portal-url http://127.0.0.1:<api-port>` exited with `relay url must use https` and never reached the localhost development-certificate path.

Loopback `http://` URLs now rewrite to `https://` in `NormalizeRelayURL`. Public `http://` relay URLs stay rejected.

Tests: `TestNormalizeRelayURLRewritesLoopbackHTTP`, `TestNormalizeRelayURLRejectsNonLoopbackHTTP`.

Replay of the original command no longer fails at URL normalize; the next error is the documented missing embedded frontend (`make build-frontend`).

Closes #336

## Post-Deploy Monitoring & Validation

No production relay impact. Confirm a loopback `http://127.0.0.1` portal-url starts past URL normalize. If a non-loopback `http://` relay URL is accepted, revert.
