### PR TITLE
fix(sdk): warn on first explicit-relay retry

### DIFF
--- a/sdk/listener.go
+++ b/sdk/listener.go
@@ -1002,6 +1002,11 @@ func (l *listener) waitRetry(ctx context.Context, operation string, err error, r
 				Msg("raw transport port pool exhausted; waiting for a port")
 			return utils.SleepOrDone(ctx, l.retryWait)
 		}
+		logger.Warn().
+			Err(err).
+			Dur("retry_wait", l.retryWait).
+			Msg("operation failed; retrying")
+		return utils.SleepOrDone(ctx, l.retryWait)
 	}
 
 	logger.Debug().

--- a/sdk/listener_retry_test.go
+++ b/sdk/listener_retry_test.go
@@ -1,0 +1,44 @@
+package sdk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
+	"github.com/gosuda/portal-tunnel/v2/types"
+)
+
+func TestWaitRetryLogsFirstFailureAtWarn(t *testing.T) {
+	var buf bytes.Buffer
+	prev := log.Logger
+	log.Logger = zerolog.New(&buf)
+	t.Cleanup(func() { log.Logger = prev })
+
+	l := &listener{
+		identity:  types.Identity{Address: "0xabc"},
+		retryWait: time.Millisecond,
+	}
+	if !l.waitRetry(context.Background(), "lease registration", errors.New("boom"), 1, 0) {
+		t.Fatal("waitRetry returned false")
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &obj); err != nil {
+		t.Fatalf("decode log json: %v\nraw: %s", err, buf.String())
+	}
+	if got, want := obj["level"], "warn"; got != want {
+		t.Fatalf("level = %v, want %q", got, want)
+	}
+	if got, want := obj["message"], "operation failed; retrying"; got != want {
+		t.Fatalf("message = %v, want %q", got, want)
+	}
+	if got, want := obj["operation"], "lease registration"; got != want {
+		t.Fatalf("operation = %v, want %q", got, want)
+	}
+}


### PR DESCRIPTION
With `--relays` and `--discovery=false`, lease-registration failures retried forever and only logged at debug. The CLI is info-level, so a local-relay expose sat on `starting portal tunnel` with no `service ready at` and no error.

The first retry is now a warn that includes the error. Later retries stay debug. Unlimited retry for explicit relays is unchanged.

Tests: `TestWaitRetryLogsFirstFailureAtWarn`.

Closes #338

## Post-Deploy Monitoring & Validation

On a failing explicit `--relays` expose, the first retry should appear as warn `operation failed; retrying` with `operation=lease registration`. If that line is missing and the process still hangs with no ready log, revert.
