### PR TITLE
fix(utils): use localhost for loopback lease hostnames

### DIFF
--- a/utils/leasehost_test.go
+++ b/utils/leasehost_test.go
@@ -1,0 +1,27 @@
+package utils
+
+import "testing"
+
+func TestLeaseHostnameMapsLoopbackIPToLocalhost(t *testing.T) {
+	t.Parallel()
+
+	got, err := LeaseHostname("bitcoin-rs-explorer-harness", "127.0.0.1")
+	if err != nil {
+		t.Fatalf("LeaseHostname() error = %v", err)
+	}
+	if got != "bitcoin-rs-explorer-harness.localhost" {
+		t.Fatalf("LeaseHostname() = %q, want bitcoin-rs-explorer-harness.localhost", got)
+	}
+}
+
+func TestLeaseHostnameKeepsDNSRoot(t *testing.T) {
+	t.Parallel()
+
+	got, err := LeaseHostname("app", "example.com")
+	if err != nil {
+		t.Fatalf("LeaseHostname() error = %v", err)
+	}
+	if got != "app.example.com" {
+		t.Fatalf("LeaseHostname() = %q, want app.example.com", got)
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -419,6 +419,9 @@ func LeaseHostname(name, rootHost string) (string, error) {
 	if rootHost == "" {
 		return "", errors.New("root host is required")
 	}
+	if ip := net.ParseIP(rootHost); ip != nil && ip.IsLoopback() {
+		rootHost = "localhost"
+	}
 	return label + "." + rootHost, nil
 }
 


### PR DESCRIPTION
Loopback `portal-url` `https://127.0.0.1:<api-port>` issued tenant hostnames like `name.127.0.0.1`. The development certificate covers `localhost` / `*.localhost`, so keyless verification failed and expose never logged `service ready at`.

`LeaseHostname` now maps loopback IP roots to `localhost`. Production DNS roots are unchanged.

Tests: `TestLeaseHostnameMapsLoopbackIPToLocalhost`, `TestLeaseHostnameKeepsDNSRoot`.

Replay against a local relay logged `service ready at https://bitcoin-rs-explorer-harness.localhost:14443`.

Closes #340

## Post-Deploy Monitoring & Validation

On a loopback relay, tenant URLs should use `.localhost`, not `.127.0.0.1`. If `keyless certificate does not cover name.127.0.0.1` returns, revert.
