### PR TITLE
fix(portal): log unknown public SNI hostnames

### DIFF
--- a/portal/server.go
+++ b/portal/server.go
@@ -584,6 +584,10 @@ func (s *Server) runPublicIngress(ctx context.Context) error {
 
 				record, ok := s.registry.Lookup(serverName)
 				if !ok {
+					log.Warn().
+						Str("server_name", serverName).
+						Str("remote_addr", wrappedConn.RemoteAddr().String()).
+						Msg("unknown public ingress hostname")
 					_ = wrappedConn.Close()
 					return
 				}


### PR DESCRIPTION
A loopback expose logged `service ready at https://name.localhost:14443` while the relay still had the lease as `name.127.0.0.1`. `openssl s_client` to the ready hostname got `unexpected eof`. The matching registered hostname completed TLS. The relay logged nothing.

Unknown SNI names now emit warn `unknown public ingress hostname` with `server_name` and `remote_addr`. Routing is unchanged.

Closes #342

## Post-Deploy Monitoring & Validation

A ClientHello whose SNI is not a registered lease should produce warn `unknown public ingress hostname`. If that line is missing and clients still see TLS EOF on a ready URL, revert.
