### PR TITLE
fix(portal): bind loopback portal-url on 127.0.0.1

### DIFF
--- a/portal/server.go
+++ b/portal/server.go
@@ -88,8 +88,12 @@ func normalizeServerConfig(cfg ServerConfig) (ServerConfig, error) {
 	cfg.APIPort = utils.IntOrDefault(cfg.APIPort, 4017)
 	cfg.SNIPort = utils.IntOrDefault(cfg.SNIPort, 443)
 	cfg.WireGuardPort = utils.IntOrDefault(cfg.WireGuardPort, overlay.DefaultListenPort)
-	cfg.APIListenAddr = utils.StringOrDefault(cfg.APIListenAddr, fmt.Sprintf(":%d", cfg.APIPort))
-	cfg.SNIListenAddr = utils.StringOrDefault(cfg.SNIListenAddr, fmt.Sprintf(":%d", cfg.SNIPort))
+	listenHost := ""
+	if utils.IsLocalRelayHost(utils.PortalRootHost(cfg.PortalURL)) {
+		listenHost = "127.0.0.1"
+	}
+	cfg.APIListenAddr = utils.StringOrDefault(cfg.APIListenAddr, net.JoinHostPort(listenHost, fmt.Sprintf("%d", cfg.APIPort)))
+	cfg.SNIListenAddr = utils.StringOrDefault(cfg.SNIListenAddr, net.JoinHostPort(listenHost, fmt.Sprintf("%d", cfg.SNIPort)))
 	if cfg.PProfEnabled {
 		cfg.PProfListenAddr = utils.StringOrDefault(strings.TrimSpace(cfg.PProfListenAddr), DefaultPProfListenAddr)
 	}

--- a/portal/server_listen_test.go
+++ b/portal/server_listen_test.go
@@ -1,0 +1,45 @@
+package portal
+
+import (
+	"testing"
+)
+
+func TestNormalizeServerConfigLoopbackListenAddrs(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := normalizeServerConfig(ServerConfig{
+		PortalURL:    "https://127.0.0.1:14017",
+		IdentityPath: t.TempDir(),
+		APIPort:      14017,
+		SNIPort:      14443,
+	})
+	if err != nil {
+		t.Fatalf("normalizeServerConfig() error = %v", err)
+	}
+	if cfg.APIListenAddr != "127.0.0.1:14017" {
+		t.Fatalf("APIListenAddr = %q, want 127.0.0.1:14017", cfg.APIListenAddr)
+	}
+	if cfg.SNIListenAddr != "127.0.0.1:14443" {
+		t.Fatalf("SNIListenAddr = %q, want 127.0.0.1:14443", cfg.SNIListenAddr)
+	}
+}
+
+func TestNormalizeServerConfigPublicListenAddrs(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := normalizeServerConfig(ServerConfig{
+		PortalURL:    "https://relay.example:4017",
+		IdentityPath: t.TempDir(),
+		APIPort:      4017,
+		SNIPort:      443,
+	})
+	if err != nil {
+		t.Fatalf("normalizeServerConfig() error = %v", err)
+	}
+	if cfg.APIListenAddr != ":4017" {
+		t.Fatalf("APIListenAddr = %q, want :4017", cfg.APIListenAddr)
+	}
+	if cfg.SNIListenAddr != ":443" {
+		t.Fatalf("SNIListenAddr = %q, want :443", cfg.SNIListenAddr)
+	}
+}


### PR DESCRIPTION
`relay-server --portal-url https://127.0.0.1:14017` logged `api_addr=127.0.0.1:14017` while `ss` showed `*:14017` and `*:14443`. Empty listen addrs defaulted to `:%d`.

Loopback portal-url hosts now default API and SNI to `127.0.0.1:<port>`. Non-local relays stay `:%d`. Explicit `APIListenAddr` / `SNIListenAddr` are unchanged.

Tests: `TestNormalizeServerConfigLoopbackListenAddrs`, `TestNormalizeServerConfigPublicListenAddrs`.

Closes #344

## Post-Deploy Monitoring & Validation

A loopback relay start should show `sni_addr=127.0.0.1:<sni-port>` and `ss` should not list `*:sni-port`. If a public relay binds only loopback, revert.
