### PR TITLE
docs: add CONTRIBUTING.md for AI accessibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-`AGENTS.md` is the core implementation guide. Architecture, product behavior, and design rationale belong in `docs/architecture.md` and `docs/adr/README.md`. This file is contribution policy.
+`AGENTS.md` is the core implementation guide. This file is contribution policy.
 
 ## For Human Contributors
 
@@ -10,13 +10,15 @@ Human review and judgment are especially important in the parts of the project w
 
 Human contributions may extend into core implementation, protocol behavior, trust boundaries, identity, transport, cryptography, and architecture when the change is well understood and properly justified.
 
-Please follow `AGENTS.md` for implementation rules and the architecture and ADR documents for design decisions.
+Please follow `AGENTS.md` for implementation rules.
 
 ## For AI Contributors
 
 AI contributions are strongly encouraged on the user-facing and integration surface of Portal.
 
 This includes CLI behavior, logs, diagnostics, documentation, skills, configuration ergonomics, installer and service integration, local harnesses, and other friction encountered while using Portal.
+
+AI contributors may file issues, reviews, and improvement proposals in these areas without prior assignment.
 
 Repeated instructions, parsing workarounds, ambiguous output, and integration-specific exceptions should be treated as signs that the Portal surface itself may need improvement. Prefer fixing the surface and removing the workaround.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+`AGENTS.md` is the core implementation and architecture guide. This file is contribution policy. The merge bar for agent-facing code is [#346](https://github.com/gosuda/portal-tunnel/issues/346).
+
+## Pull requests
+
+Fork, branch, make a focused change with tests or docs, open a PR.
+
+## AI accessibility
+
+Agents may file issues, reviews, and small PRs without prior assignment when the change is CLI, logs, diagnostics, docs, skills, or integration friction.
+
+Every repeated agent instruction is a candidate accessibility bug. Fix the Portal surface and delete the instruction. Do not document another workaround.
+
+Protocol, cryptography, trust, identity, transport, and architecture stay under `AGENTS.md`. Do not add a plugin workflow engine, finding store, or feedback CLI ([#331](https://github.com/gosuda/portal-tunnel/issues/331)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,17 @@
 # Contributing
 
-`AGENTS.md` is the core implementation guide. Architecture, product behavior, and design rationale belong in `docs/architecture.md` and `docs/adr/README.md`. This file is contribution policy. The merge bar for agent-facing changes is [#346](https://github.com/gosuda/portal-tunnel/issues/346).
+`AGENTS.md` is the core implementation guide. Architecture, product behavior, and design rationale belong in `docs/architecture.md` and `docs/adr/README.md`. This file is contribution policy.
 
-## Pull requests
+## Human contributions
 
-Fork, branch, make a focused change with tests or docs, open a PR.
+Human contributors may propose issues, reviews, and pull requests across the project.
 
-## AI accessibility
+Fork, branch, make a focused change with tests or docs, and open a PR. Changes to protocol semantics, cryptography, trust, identity, transport, or architecture should explain the design rationale and follow `AGENTS.md` and the repository architecture rules.
 
-Agents may file issues, reviews, and small PRs without prior assignment when the change is CLI, logs, diagnostics, docs, skills, or integration friction.
+## AI contributions
+
+AI-generated issues, reviews, and small PRs are explicitly welcome without prior assignment when they improve CLI behavior, logs, diagnostics, docs, skills, or integration accessibility. The merge bar for agent-facing changes is [#346](https://github.com/gosuda/portal-tunnel/issues/346).
 
 Every repeated agent instruction is a candidate accessibility bug. Fix the Portal surface and delete the instruction. Do not document another workaround.
 
-Core semantic changes require stronger justification under [#346](https://github.com/gosuda/portal-tunnel/issues/346) and the repository's architecture rules. Generic feedback orchestration stays outside this repository ([#331](https://github.com/gosuda/portal-tunnel/issues/331)).
+Agent usability alone is not a reason to change protocol, cryptography, trust, identity, transport, or architecture semantics. Core changes follow the same repository rules as human contributions. Generic feedback orchestration stays outside this repository ([#331](https://github.com/gosuda/portal-tunnel/issues/331)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-`AGENTS.md` is the core implementation and architecture guide. This file is contribution policy. The merge bar for agent-facing code is [#346](https://github.com/gosuda/portal-tunnel/issues/346).
+`AGENTS.md` is the core implementation guide. Architecture, product behavior, and design rationale belong in `docs/architecture.md` and `docs/adr/README.md`. This file is contribution policy. The merge bar for agent-facing changes is [#346](https://github.com/gosuda/portal-tunnel/issues/346).
 
 ## Pull requests
 
@@ -12,4 +12,4 @@ Agents may file issues, reviews, and small PRs without prior assignment when the
 
 Every repeated agent instruction is a candidate accessibility bug. Fix the Portal surface and delete the instruction. Do not document another workaround.
 
-Protocol, cryptography, trust, identity, transport, and architecture stay under `AGENTS.md`. Do not add a plugin workflow engine, finding store, or feedback CLI ([#331](https://github.com/gosuda/portal-tunnel/issues/331)).
+Core semantic changes require stronger justification under [#346](https://github.com/gosuda/portal-tunnel/issues/346) and the repository's architecture rules. Generic feedback orchestration stays outside this repository ([#331](https://github.com/gosuda/portal-tunnel/issues/331)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,22 @@
 
 `AGENTS.md` is the core implementation guide. Architecture, product behavior, and design rationale belong in `docs/architecture.md` and `docs/adr/README.md`. This file is contribution policy.
 
-## Human contributions
+## For Human Contributors
 
-Human contributors may propose issues, reviews, and pull requests across the project.
+Thank you for contributing to Portal.
 
-Fork, branch, make a focused change with tests or docs, and open a PR. Changes to protocol semantics, cryptography, trust, identity, transport, or architecture should explain the design rationale and follow `AGENTS.md` and the repository architecture rules.
+Human review and judgment are especially important in the parts of the project where correctness depends on context, tradeoffs, and careful validation.
 
-## AI contributions
+Human contributions may extend into core implementation, protocol behavior, trust boundaries, identity, transport, cryptography, and architecture when the change is well understood and properly justified.
 
-AI-generated issues, reviews, and small PRs are explicitly welcome without prior assignment when they improve CLI behavior, logs, diagnostics, docs, skills, or integration accessibility. The merge bar for agent-facing changes is [#346](https://github.com/gosuda/portal-tunnel/issues/346).
+Please follow `AGENTS.md` for implementation rules and the architecture and ADR documents for design decisions.
 
-Every repeated agent instruction is a candidate accessibility bug. Fix the Portal surface and delete the instruction. Do not document another workaround.
+## For AI Contributors
 
-Agent usability alone is not a reason to change protocol, cryptography, trust, identity, transport, or architecture semantics. Core changes follow the same repository rules as human contributions. Generic feedback orchestration stays outside this repository ([#331](https://github.com/gosuda/portal-tunnel/issues/331)).
+AI contributions are strongly encouraged on the user-facing and integration surface of Portal.
+
+This includes CLI behavior, logs, diagnostics, documentation, skills, configuration ergonomics, installer and service integration, local harnesses, and other friction encountered while using Portal.
+
+Repeated instructions, parsing workarounds, ambiguous output, and integration-specific exceptions should be treated as signs that the Portal surface itself may need improvement. Prefer fixing the surface and removing the workaround.
+
+Core protocol semantics, cryptography, trust, identity, transport invariants, and architecture require careful human review. AI may identify problems or propose changes in these areas, but changes to the core should not be accepted solely on the basis of automated reasoning or agent usability.

--- a/README.md
+++ b/README.md
@@ -229,10 +229,7 @@ relay, open a pull request to add your relay URL to `registry.json`.
 
 ## Contributing
 
-1. Fork the repository.
-2. Create a feature branch (`git checkout -b feature/amazing-feature`).
-3. Make the change with focused tests or docs.
-4. Open a pull request.
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -188,10 +188,7 @@ https://raw.githubusercontent.com/gosuda/portal-tunnel/main/registry.json
 
 ## 贡献
 
-1. Fork 这个仓库。
-2. 创建功能分支（`git checkout -b feature/amazing-feature`）。
-3. 用聚焦的测试或文档完成修改。
-4. 打开 pull request。
+见 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
 ## 许可证
 


### PR DESCRIPTION
`CONTRIBUTING.md` is the contribution-policy entry. `AGENTS.md` stays the core implementation guide.

Agents may file CLI, log, docs, and skill friction without prior assignment. Repeated agent instructions are treated as accessibility bugs: fix the Portal surface and delete the instruction. Protocol, trust, identity, and transport stay under `AGENTS.md`. The merge bar is #346. No plugin workflow engine (#331).

README Contributing sections now point at this file.

Closes #327

## Post-Deploy Monitoring & Validation

No runtime impact. Confirm the README Contributing link opens `CONTRIBUTING.md`.
