### PR TITLE
fix(relay-server): keep ECH wording and env-file scope

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,10 +103,10 @@ PPROF_ADDR=127.0.0.1:6060
 # ─────────────────────────────────────────────────────────────────────────────
 # 4. DNS provider - pick one, fill only that block
 #
-# Used for ACME DNS-01, managed A records, ECH HTTPS records, and optional ENS
-# DNS automation. Unset means embedded, not "off": to manage certificates
-# yourself instead, place fullchain.pem and privatekey.pem under IDENTITY_PATH
-# and they are used when present.
+# Used for ACME DNS-01, managed A records, the relay ECH record,
+# opt-in tunnel ECH records, and optional ENS DNS automation. Unset means
+# embedded, not "off": to manage certificates yourself instead, place
+# fullchain.pem and privatekey.pem under IDENTITY_PATH and they are used when present.
 #
 # Only one provider's credentials are ever read. The unused blocks below stay
 # commented out on purpose.

--- a/cmd/relay-server/config.go
+++ b/cmd/relay-server/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"cmp"
 	"errors"
 	"flag"
 	"fmt"
@@ -136,9 +137,7 @@ func acmeFeature(cfg relayServerConfig) feature {
 	// server, so reporting "disabled" here would describe a relay that is in
 	// fact serving its own zone and answering ACME challenges from it.
 	provider := strings.ToLower(strings.TrimSpace(cfg.ACMEDNSProvider))
-	if provider == "" {
-		provider = acme.TypeEmbedded
-	}
+	provider = cmp.Or(provider, acme.TypeEmbedded)
 	if provider == acme.TypeEmbedded {
 		f.State, f.By = stateEnabled, "ACME_DNS_PROVIDER="+provider
 		f.Detail = fmt.Sprintf(
@@ -197,9 +196,7 @@ func ensGaslessFeature(cfg relayServerConfig) feature {
 	// unset ACME_DNS_PROVIDER selects, so this is the combination an operator
 	// reaches by turning ENS on and changing nothing else.
 	provider := strings.ToLower(strings.TrimSpace(cfg.ACMEDNSProvider))
-	if provider == "" {
-		provider = acme.TypeEmbedded
-	}
+	provider = cmp.Or(provider, acme.TypeEmbedded)
 	if provider == acme.TypeEmbedded {
 		f.State, f.By = stateBlocked, "ENS_GASLESS_ENABLED=true"
 		f.Missing = "ACME_DNS_PROVIDER=" + provider +
@@ -376,7 +373,9 @@ func loadEnvFile(path string) ([]envFileEntry, error) {
 		}
 		// Compose does not expand values read from an env file, so neither do we.
 		value = strings.TrimSpace(value)
-		if len(value) >= 2 && (value[0] == '"' || value[0] == '\'') && value[len(value)-1] == value[0] {
+		doubleQuoted := len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"'
+		singleQuoted := len(value) >= 2 && value[0] == '\'' && value[len(value)-1] == '\''
+		if doubleQuoted || singleQuoted {
 			value = value[1 : len(value)-1]
 		}
 		entries = append(entries, envFileEntry{Name: name, Value: value})

--- a/cmd/relay-server/config.go
+++ b/cmd/relay-server/config.go
@@ -709,9 +709,10 @@ func writeCommentWrapped(w io.Writer, text string) {
 // Setting only the file's own keys is not enough. A relay variable absent from
 // the file would stay inherited from the shell, and a higher-priority alias in
 // the shell would beat a value the file does supply — process AWS_REGION over
-// file AWS_DEFAULT_REGION, for instance. Either way the report would describe a
-// configuration different from the one Compose is going to deploy, which is the
-// opposite of what checking a file is for.
+// file AWS_DEFAULT_REGION, for instance. The report would then describe a mix
+// of file and shell, not the file against relay defaults. Isolation is for
+// that mix. It does not reproduce Compose; Compose injects its own defaults.
+// For that environment run the command inside the container.
 func applyEnvFileInIsolation(entries []envFileEntry) (func(), error) {
 	// A first pass populates the registry, which is how the set of names the
 	// deployment understands is known at all.


### PR DESCRIPTION
Follow-up to merged #294. One extra commit on current `main`. No rebase of #294 history.

- Restore the relay ECH / opt-in tunnel ECH wording in `.env.example` (the squash of #294 had shortened it to "ECH HTTPS records").
- `--env-file` isolation comments no longer claim to reproduce Compose. File-versus-shell is one question; `docker compose run --rm -T portal config` is the other.

`evaluateFeatures` is unchanged. `portal.NewServer` / `acme.NewManager` have no side-effect-free dry-run.

Closes the intent of https://github.com/gosuda/portal-tunnel/pull/348 (closed: it re-landed #294's commits after the squash and conflicted).
