### PR TITLE
feat: add optional canonical HTTP redirect listener

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,16 @@ IDENTITY_PATH=/portal-certs
 # Compose publishes this port.
 WIREGUARD_PORT=51820
 
+# Optional HTTP redirect listener, disabled by default. Requires an HTTPS
+# PORTAL_URL and redirects to that fixed URL, ignoring incoming host/path/query.
+# Publish TCP port 80 only when enabled.
+HTTP_REDIRECT_ENABLED=false
+HTTP_REDIRECT_ADDR=:80
+
+# Optional HSTS: max-age=31536000, without includeSubDomains or preload.
+# Browsers ignore HSTS received over HTTP.
+HTTP_REDIRECT_HSTS=false
+
 # Inclusive lease port range shared by the UDP and raw TCP transports.
 # 0 disables both. Enabling a transport without a range does nothing; the relay
 # reports that at startup. Publish the same range in docker-compose.yml when set.

--- a/cmd/relay-server/config.go
+++ b/cmd/relay-server/config.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
+	"github.com/gosuda/portal-tunnel/v2/portal"
 	"github.com/gosuda/portal-tunnel/v2/portal/acme"
 	portalx402 "github.com/gosuda/portal-tunnel/v2/portal/x402"
 	"github.com/gosuda/portal-tunnel/v2/types"
@@ -74,7 +75,7 @@ func httpRedirectFeature(cfg relayServerConfig) feature {
 		return f
 	}
 	f.By = types.HTTPRedirectEnabledEnv + "=true"
-	redirect, err := utils.NormalizeHTTPRedirectConfig(cfg.HTTPRedirect, cfg.PortalURL)
+	redirect, err := portal.NormalizeHTTPRedirectConfig(cfg.HTTPRedirect, cfg.PortalURL)
 	if err != nil {
 		f.State, f.Missing = stateBlocked, err.Error()
 		return f

--- a/cmd/relay-server/config.go
+++ b/cmd/relay-server/config.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gosuda/portal-tunnel/v2/portal/acme"
 	portalx402 "github.com/gosuda/portal-tunnel/v2/portal/x402"
+	"github.com/gosuda/portal-tunnel/v2/types"
 	"github.com/gosuda/portal-tunnel/v2/utils"
 )
 
@@ -36,7 +37,7 @@ const (
 
 type feature struct {
 	Name string
-	// State is what the feature is actually doing, not what was requested.
+	// State reflects validated configuration, not listener readiness.
 	State featureState
 	// By is the setting that produced the state, e.g. "DISCOVERY=true".
 	By string
@@ -68,13 +69,20 @@ func evaluateFeatures(cfg relayServerConfig) []feature {
 }
 
 func httpRedirectFeature(cfg relayServerConfig) feature {
-	f := feature{Name: "http-redirect", State: stateDisabled, By: "HTTP_REDIRECT_ENABLED=false"}
-	if cfg.HTTPRedirectEnabled {
-		f.State, f.By = stateEnabled, "HTTP_REDIRECT_ENABLED=true"
-		f.Detail = "addr=" + cfg.HTTPRedirectAddr + "; canonical PORTAL_URL only; target validation and binding occur at startup"
-		if cfg.HTTPRedirectHSTS {
-			f.Detail += "; HSTS header requested (browsers ignore it over HTTP)"
-		}
+	f := feature{Name: types.HTTPRedirectFeatureName, State: stateDisabled, By: types.HTTPRedirectEnabledEnv + "=false"}
+	if !cfg.HTTPRedirect.Enabled {
+		return f
+	}
+	f.By = types.HTTPRedirectEnabledEnv + "=true"
+	redirect, err := utils.NormalizeHTTPRedirectConfig(cfg.HTTPRedirect, cfg.PortalURL)
+	if err != nil {
+		f.State, f.Missing = stateBlocked, err.Error()
+		return f
+	}
+	f.State = stateEnabled
+	f.Detail = "addr=" + redirect.Addr + "; canonical PORTAL_URL only; configuration valid; listener binding occurs at startup"
+	if redirect.HSTS {
+		f.Detail += "; HSTS header requested (browsers ignore it over HTTP)"
 	}
 	return f
 }

--- a/cmd/relay-server/config.go
+++ b/cmd/relay-server/config.go
@@ -63,7 +63,20 @@ func evaluateFeatures(cfg relayServerConfig) []feature {
 		proxyHeaderFeature(cfg),
 		x402Feature(cfg),
 		pprofFeature(cfg),
+		httpRedirectFeature(cfg),
 	}
+}
+
+func httpRedirectFeature(cfg relayServerConfig) feature {
+	f := feature{Name: "http-redirect", State: stateDisabled, By: "HTTP_REDIRECT_ENABLED=false"}
+	if cfg.HTTPRedirectEnabled {
+		f.State, f.By = stateEnabled, "HTTP_REDIRECT_ENABLED=true"
+		f.Detail = "addr=" + cfg.HTTPRedirectAddr + "; canonical PORTAL_URL only; target validation and binding occur at startup"
+		if cfg.HTTPRedirectHSTS {
+			f.Detail += "; HSTS header requested (browsers ignore it over HTTP)"
+		}
+	}
+	return f
 }
 
 func frontendFeature(cfg relayServerConfig) feature {

--- a/cmd/relay-server/config_test.go
+++ b/cmd/relay-server/config_test.go
@@ -39,6 +39,22 @@ func resolveWithEnvFile(t *testing.T, path string) relayServerConfig {
 	return cfg
 }
 
+func TestHTTPRedirectEnvironment(t *testing.T) {
+	cfg := resolveWithEnvFile(t, writeEnvFile(t,
+		"HTTP_REDIRECT_ENABLED=true", "HTTP_REDIRECT_ADDR=127.0.0.1:18080", "HTTP_REDIRECT_HSTS=true"))
+	if !cfg.HTTPRedirectEnabled || cfg.HTTPRedirectAddr != "127.0.0.1:18080" || !cfg.HTTPRedirectHSTS {
+		t.Fatalf("redirect environment not resolved: %+v", cfg)
+	}
+	f := featureByName(t, cfg, "http-redirect")
+	if f.State != stateEnabled || !strings.Contains(f.Detail, "browsers ignore") {
+		t.Fatalf("redirect capability report=%+v", f)
+	}
+	cfg = resolveWithEnvFile(t, writeEnvFile(t))
+	if cfg.HTTPRedirectEnabled || cfg.HTTPRedirectHSTS || cfg.HTTPRedirectAddr != ":80" {
+		t.Fatalf("unexpected redirect defaults: %+v", cfg)
+	}
+}
+
 func featureByName(t *testing.T, cfg relayServerConfig, name string) feature {
 	t.Helper()
 	for _, f := range evaluateFeatures(cfg) {

--- a/cmd/relay-server/config_test.go
+++ b/cmd/relay-server/config_test.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/gosuda/portal-tunnel/v2/portal"
+	"github.com/gosuda/portal-tunnel/v2/types"
 )
 
 // writeEnvFile writes lines to a temporary env file and returns its path.
@@ -41,17 +46,100 @@ func resolveWithEnvFile(t *testing.T, path string) relayServerConfig {
 
 func TestHTTPRedirectEnvironment(t *testing.T) {
 	cfg := resolveWithEnvFile(t, writeEnvFile(t,
-		"HTTP_REDIRECT_ENABLED=true", "HTTP_REDIRECT_ADDR=127.0.0.1:18080", "HTTP_REDIRECT_HSTS=true"))
-	if !cfg.HTTPRedirectEnabled || cfg.HTTPRedirectAddr != "127.0.0.1:18080" || !cfg.HTTPRedirectHSTS {
+		types.HTTPRedirectEnabledEnv+"=true", "HTTP_REDIRECT_ADDR=127.0.0.1:18080", "HTTP_REDIRECT_HSTS=true"))
+	if !cfg.HTTPRedirect.Enabled || cfg.HTTPRedirect.Addr != "127.0.0.1:18080" || !cfg.HTTPRedirect.HSTS {
 		t.Fatalf("redirect environment not resolved: %+v", cfg)
 	}
-	f := featureByName(t, cfg, "http-redirect")
+	f := featureByName(t, cfg, types.HTTPRedirectFeatureName)
 	if f.State != stateEnabled || !strings.Contains(f.Detail, "browsers ignore") {
 		t.Fatalf("redirect capability report=%+v", f)
 	}
 	cfg = resolveWithEnvFile(t, writeEnvFile(t))
-	if cfg.HTTPRedirectEnabled || cfg.HTTPRedirectHSTS || cfg.HTTPRedirectAddr != ":80" {
+	if cfg.HTTPRedirect.Enabled || cfg.HTTPRedirect.HSTS || cfg.HTTPRedirect.Addr != types.DefaultHTTPRedirectAddr {
 		t.Fatalf("unexpected redirect defaults: %+v", cfg)
+	}
+}
+
+func TestHTTPRedirectReportMatchesServerValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		target  string
+		addr    string
+		enabled bool
+		blocked bool
+	}{
+		{name: "HTTPS", target: "HTTPS://localhost:4017/base/?q=discarded#fragment", addr: "127.0.0.1:0", enabled: true},
+		{name: "mixed case", target: "hTtPs://localhost:4017", addr: "[::1]:0", enabled: true},
+		{name: "default address", target: "https://localhost:4017", enabled: true},
+		{name: "trimmed address", target: " https://localhost:4017/ ", addr: " 127.0.0.1:18080 ", enabled: true},
+		{name: "DNS deferred", target: "https://localhost:4017", addr: "does-not-resolve.invalid:80", enabled: true},
+		{name: "HTTP", target: "http://relay.example", addr: "127.0.0.1:0", enabled: true, blocked: true},
+		{name: "loopback HTTP", target: "http://localhost:4017", enabled: true, blocked: true},
+		{name: "relative target", target: "//relay.example", enabled: true, blocked: true},
+		{name: "credentials", target: "https://user:pass@relay.example", enabled: true, blocked: true},
+		{name: "empty root", target: "https://./", enabled: true, blocked: true},
+		{name: "zero target port", target: "https://relay.example:0", enabled: true, blocked: true},
+		{name: "high target port", target: "https://relay.example:65536", enabled: true, blocked: true},
+		{name: "nonnumeric target port", target: "https://relay.example:bad", enabled: true, blocked: true},
+		{name: "missing listen port", target: "https://localhost:4017", addr: "127.0.0.1", enabled: true, blocked: true},
+		{name: "empty listen port", target: "https://localhost:4017", addr: "127.0.0.1:", enabled: true, blocked: true},
+		{name: "nonnumeric listen port", target: "https://localhost:4017", addr: ":bad", enabled: true, blocked: true},
+		{name: "negative listen port", target: "https://localhost:4017", addr: ":-1", enabled: true, blocked: true},
+		{name: "high listen port", target: "https://localhost:4017", addr: ":65536", enabled: true, blocked: true},
+		{name: "invalid listen host", target: "https://localhost:4017", addr: "bad host:80", enabled: true, blocked: true},
+		{name: "invalid IPv6", target: "https://localhost:4017", addr: "[gg::1]:80", enabled: true, blocked: true},
+		{name: "disabled", target: "http://localhost:4017", addr: "invalid ignored address"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := resolveWithEnvFile(t, writeEnvFile(t,
+				"PORTAL_URL="+tc.target, "HTTP_REDIRECT_ADDR="+tc.addr,
+				types.HTTPRedirectEnabledEnv+"="+strconv.FormatBool(tc.enabled)))
+			f := featureByName(t, cfg, types.HTTPRedirectFeatureName)
+			want := stateDisabled
+			if tc.enabled {
+				want = stateEnabled
+			}
+			if tc.blocked {
+				want = stateBlocked
+			}
+			if f.State != want {
+				t.Fatalf("redirect report=%+v, want state %s", f, want)
+			}
+			_, err := portal.NewServer(portal.ServerConfig{
+				PortalURL: cfg.PortalURL, IdentityPath: t.TempDir(), HTTPRedirect: cfg.HTTPRedirect,
+			})
+			if tc.blocked {
+				if err == nil || f.Missing != err.Error() {
+					t.Fatalf("report reason=%q, NewServer error=%v", f.Missing, err)
+				}
+			} else if err != nil || f.Missing != "" {
+				t.Fatalf("report=%+v, NewServer error=%v", f, err)
+			}
+			if tc.enabled && !tc.blocked && !strings.Contains(f.Detail, "listener binding occurs at startup") {
+				t.Fatalf("report must distinguish configuration from readiness: %+v", f)
+			}
+		})
+	}
+}
+
+func TestHTTPRedirectReportDoesNotBind(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer occupied.Close()
+	cfg := resolveWithEnvFile(t, writeEnvFile(t,
+		"PORTAL_URL=https://localhost:4017", types.HTTPRedirectEnabledEnv+"=true",
+		"HTTP_REDIRECT_ADDR="+occupied.Addr().String()))
+	f := featureByName(t, cfg, types.HTTPRedirectFeatureName)
+	if f.State != stateEnabled || f.Missing != "" {
+		t.Fatalf("occupied address must not block configuration reporting: %+v", f)
+	}
+	_, err = portal.NewServer(portal.ServerConfig{
+		PortalURL: cfg.PortalURL, IdentityPath: t.TempDir(), HTTPRedirect: cfg.HTTPRedirect,
+	})
+	if err != nil {
+		t.Fatalf("NewServer must defer binding until Start: %v", err)
 	}
 }
 

--- a/cmd/relay-server/main.go
+++ b/cmd/relay-server/main.go
@@ -35,27 +35,30 @@ func main() {
 }
 
 type relayServerConfig struct {
-	PortalURL          string
-	FrontendDir        string
-	IdentityPath       string
-	Bootstraps         string
-	DiscoveryEnabled   bool
-	WireGuardPort      int
-	APIPort            int
-	SNIPort            int
-	TrustProxyHeaders  bool
-	TrustedProxyCIDRs  string
-	UDPEnabled         bool
-	TCPEnabled         bool
-	LandingPageEnabled bool
-	MinPort            int
-	MaxPort            int
-	AdminToken         string
-	PProfEnabled       bool
-	PProfAddr          string
-	X402Enabled        bool
-	X402Testnet        bool
-	X402PayTo          string
+	PortalURL           string
+	FrontendDir         string
+	IdentityPath        string
+	Bootstraps          string
+	DiscoveryEnabled    bool
+	WireGuardPort       int
+	HTTPRedirectEnabled bool
+	HTTPRedirectAddr    string
+	HTTPRedirectHSTS    bool
+	APIPort             int
+	SNIPort             int
+	TrustProxyHeaders   bool
+	TrustedProxyCIDRs   string
+	UDPEnabled          bool
+	TCPEnabled          bool
+	LandingPageEnabled  bool
+	MinPort             int
+	MaxPort             int
+	AdminToken          string
+	PProfEnabled        bool
+	PProfAddr           string
+	X402Enabled         bool
+	X402Testnet         bool
+	X402PayTo           string
 
 	ACMEDNSProvider    string
 	ENSGaslessEnabled  bool
@@ -106,6 +109,9 @@ func registerRelayServerFlags(fs *flag.FlagSet, cfg *relayServerConfig) {
 	utils.BoolFlagEnv(fs, &cfg.DiscoveryEnabled, "discovery", false, "serve relay discovery endpoints and poll discovery peers", "DISCOVERY")
 	utils.IntFlagEnv(fs, &cfg.WireGuardPort, "wireguard-port", overlay.DefaultListenPort, utils.ParsePortNumber, "public and listen UDP port for relay overlay", "WIREGUARD_PORT")
 
+	utils.BoolFlagEnv(fs, &cfg.HTTPRedirectEnabled, "http-redirect-enabled", false, "enable HTTP redirects to the canonical HTTPS portal URL (not tenant hosts)", "HTTP_REDIRECT_ENABLED")
+	utils.StringFlagEnv(fs, &cfg.HTTPRedirectAddr, "http-redirect-addr", ":80", "HTTP redirect listen address when enabled", "HTTP_REDIRECT_ADDR")
+	utils.BoolFlagEnv(fs, &cfg.HTTPRedirectHSTS, "http-redirect-hsts", false, "include HSTS max-age=31536000 on redirects; browsers ignore HSTS received over HTTP", "HTTP_REDIRECT_HSTS")
 	utils.IntFlagEnv(fs, &cfg.APIPort, "api-port", 4017, utils.ParsePortNumber, "Admin/API server port", "API_PORT")
 	utils.IntFlagEnv(fs, &cfg.SNIPort, "sni-port", 443, utils.ParsePortNumber, "TCP SNI router port number", "SNI_PORT")
 	utils.BoolFlagEnv(fs, &cfg.TrustProxyHeaders, "trust-proxy-headers", false, "trust X-Forwarded-* and X-Real-IP headers from trusted proxies", "TRUST_PROXY_HEADERS")
@@ -175,24 +181,27 @@ func runServeCommand(args []string) error {
 
 func runServer(ctx context.Context, cfg relayServerConfig) error {
 	server, err := portal.NewServer(portal.ServerConfig{
-		PortalURL:         cfg.PortalURL,
-		IdentityPath:      cfg.IdentityPath,
-		Bootstraps:        utils.SplitCSV(cfg.Bootstraps),
-		DiscoveryEnabled:  cfg.DiscoveryEnabled,
-		WireGuardPort:     cfg.WireGuardPort,
-		APIPort:           cfg.APIPort,
-		SNIPort:           cfg.SNIPort,
-		TrustProxyHeaders: cfg.TrustProxyHeaders,
-		TrustedProxyCIDRs: cfg.TrustedProxyCIDRs,
-		UDPEnabled:        cfg.UDPEnabled,
-		TCPEnabled:        cfg.TCPEnabled,
-		MinPort:           cfg.MinPort,
-		MaxPort:           cfg.MaxPort,
-		PProfEnabled:      cfg.PProfEnabled,
-		PProfListenAddr:   cfg.PProfAddr,
-		X402Enabled:       cfg.X402Enabled,
-		X402Testnet:       cfg.X402Testnet,
-		X402PayTo:         cfg.X402PayTo,
+		PortalURL:           cfg.PortalURL,
+		HTTPRedirectEnabled: cfg.HTTPRedirectEnabled,
+		HTTPRedirectAddr:    cfg.HTTPRedirectAddr,
+		HTTPRedirectHSTS:    cfg.HTTPRedirectHSTS,
+		IdentityPath:        cfg.IdentityPath,
+		Bootstraps:          utils.SplitCSV(cfg.Bootstraps),
+		DiscoveryEnabled:    cfg.DiscoveryEnabled,
+		WireGuardPort:       cfg.WireGuardPort,
+		APIPort:             cfg.APIPort,
+		SNIPort:             cfg.SNIPort,
+		TrustProxyHeaders:   cfg.TrustProxyHeaders,
+		TrustedProxyCIDRs:   cfg.TrustedProxyCIDRs,
+		UDPEnabled:          cfg.UDPEnabled,
+		TCPEnabled:          cfg.TCPEnabled,
+		MinPort:             cfg.MinPort,
+		MaxPort:             cfg.MaxPort,
+		PProfEnabled:        cfg.PProfEnabled,
+		PProfListenAddr:     cfg.PProfAddr,
+		X402Enabled:         cfg.X402Enabled,
+		X402Testnet:         cfg.X402Testnet,
+		X402PayTo:           cfg.X402PayTo,
 		ACME: acme.Config{
 			KeyDir:             cfg.IdentityPath,
 			DNSProvider:        cfg.ACMEDNSProvider,

--- a/cmd/relay-server/main.go
+++ b/cmd/relay-server/main.go
@@ -35,30 +35,28 @@ func main() {
 }
 
 type relayServerConfig struct {
-	PortalURL           string
-	FrontendDir         string
-	IdentityPath        string
-	Bootstraps          string
-	DiscoveryEnabled    bool
-	WireGuardPort       int
-	HTTPRedirectEnabled bool
-	HTTPRedirectAddr    string
-	HTTPRedirectHSTS    bool
-	APIPort             int
-	SNIPort             int
-	TrustProxyHeaders   bool
-	TrustedProxyCIDRs   string
-	UDPEnabled          bool
-	TCPEnabled          bool
-	LandingPageEnabled  bool
-	MinPort             int
-	MaxPort             int
-	AdminToken          string
-	PProfEnabled        bool
-	PProfAddr           string
-	X402Enabled         bool
-	X402Testnet         bool
-	X402PayTo           string
+	PortalURL          string
+	FrontendDir        string
+	IdentityPath       string
+	Bootstraps         string
+	DiscoveryEnabled   bool
+	WireGuardPort      int
+	HTTPRedirect       types.HTTPRedirectConfig
+	APIPort            int
+	SNIPort            int
+	TrustProxyHeaders  bool
+	TrustedProxyCIDRs  string
+	UDPEnabled         bool
+	TCPEnabled         bool
+	LandingPageEnabled bool
+	MinPort            int
+	MaxPort            int
+	AdminToken         string
+	PProfEnabled       bool
+	PProfAddr          string
+	X402Enabled        bool
+	X402Testnet        bool
+	X402PayTo          string
 
 	ACMEDNSProvider    string
 	ENSGaslessEnabled  bool
@@ -109,9 +107,9 @@ func registerRelayServerFlags(fs *flag.FlagSet, cfg *relayServerConfig) {
 	utils.BoolFlagEnv(fs, &cfg.DiscoveryEnabled, "discovery", false, "serve relay discovery endpoints and poll discovery peers", "DISCOVERY")
 	utils.IntFlagEnv(fs, &cfg.WireGuardPort, "wireguard-port", overlay.DefaultListenPort, utils.ParsePortNumber, "public and listen UDP port for relay overlay", "WIREGUARD_PORT")
 
-	utils.BoolFlagEnv(fs, &cfg.HTTPRedirectEnabled, "http-redirect-enabled", false, "enable HTTP redirects to the canonical HTTPS portal URL (not tenant hosts)", "HTTP_REDIRECT_ENABLED")
-	utils.StringFlagEnv(fs, &cfg.HTTPRedirectAddr, "http-redirect-addr", ":80", "HTTP redirect listen address when enabled", "HTTP_REDIRECT_ADDR")
-	utils.BoolFlagEnv(fs, &cfg.HTTPRedirectHSTS, "http-redirect-hsts", false, "include HSTS max-age=31536000 on redirects; browsers ignore HSTS received over HTTP", "HTTP_REDIRECT_HSTS")
+	utils.BoolFlagEnv(fs, &cfg.HTTPRedirect.Enabled, "http-redirect-enabled", false, "enable HTTP redirects to the canonical HTTPS portal URL (not tenant hosts)", types.HTTPRedirectEnabledEnv)
+	utils.StringFlagEnv(fs, &cfg.HTTPRedirect.Addr, "http-redirect-addr", types.DefaultHTTPRedirectAddr, "HTTP redirect listen address when enabled", "HTTP_REDIRECT_ADDR")
+	utils.BoolFlagEnv(fs, &cfg.HTTPRedirect.HSTS, "http-redirect-hsts", false, "include HSTS max-age=31536000 on redirects; browsers ignore HSTS received over HTTP", "HTTP_REDIRECT_HSTS")
 	utils.IntFlagEnv(fs, &cfg.APIPort, "api-port", 4017, utils.ParsePortNumber, "Admin/API server port", "API_PORT")
 	utils.IntFlagEnv(fs, &cfg.SNIPort, "sni-port", 443, utils.ParsePortNumber, "TCP SNI router port number", "SNI_PORT")
 	utils.BoolFlagEnv(fs, &cfg.TrustProxyHeaders, "trust-proxy-headers", false, "trust X-Forwarded-* and X-Real-IP headers from trusted proxies", "TRUST_PROXY_HEADERS")
@@ -181,27 +179,25 @@ func runServeCommand(args []string) error {
 
 func runServer(ctx context.Context, cfg relayServerConfig) error {
 	server, err := portal.NewServer(portal.ServerConfig{
-		PortalURL:           cfg.PortalURL,
-		HTTPRedirectEnabled: cfg.HTTPRedirectEnabled,
-		HTTPRedirectAddr:    cfg.HTTPRedirectAddr,
-		HTTPRedirectHSTS:    cfg.HTTPRedirectHSTS,
-		IdentityPath:        cfg.IdentityPath,
-		Bootstraps:          utils.SplitCSV(cfg.Bootstraps),
-		DiscoveryEnabled:    cfg.DiscoveryEnabled,
-		WireGuardPort:       cfg.WireGuardPort,
-		APIPort:             cfg.APIPort,
-		SNIPort:             cfg.SNIPort,
-		TrustProxyHeaders:   cfg.TrustProxyHeaders,
-		TrustedProxyCIDRs:   cfg.TrustedProxyCIDRs,
-		UDPEnabled:          cfg.UDPEnabled,
-		TCPEnabled:          cfg.TCPEnabled,
-		MinPort:             cfg.MinPort,
-		MaxPort:             cfg.MaxPort,
-		PProfEnabled:        cfg.PProfEnabled,
-		PProfListenAddr:     cfg.PProfAddr,
-		X402Enabled:         cfg.X402Enabled,
-		X402Testnet:         cfg.X402Testnet,
-		X402PayTo:           cfg.X402PayTo,
+		PortalURL:         cfg.PortalURL,
+		HTTPRedirect:      cfg.HTTPRedirect,
+		IdentityPath:      cfg.IdentityPath,
+		Bootstraps:        utils.SplitCSV(cfg.Bootstraps),
+		DiscoveryEnabled:  cfg.DiscoveryEnabled,
+		WireGuardPort:     cfg.WireGuardPort,
+		APIPort:           cfg.APIPort,
+		SNIPort:           cfg.SNIPort,
+		TrustProxyHeaders: cfg.TrustProxyHeaders,
+		TrustedProxyCIDRs: cfg.TrustedProxyCIDRs,
+		UDPEnabled:        cfg.UDPEnabled,
+		TCPEnabled:        cfg.TCPEnabled,
+		MinPort:           cfg.MinPort,
+		MaxPort:           cfg.MaxPort,
+		PProfEnabled:      cfg.PProfEnabled,
+		PProfListenAddr:   cfg.PProfAddr,
+		X402Enabled:       cfg.X402Enabled,
+		X402Testnet:       cfg.X402Testnet,
+		X402PayTo:         cfg.X402PayTo,
 		ACME: acme.Config{
 			KeyDir:             cfg.IdentityPath,
 			DNSProvider:        cfg.ACMEDNSProvider,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,10 @@ services:
 
       API_PORT: 4017
       SNI_PORT: 443
+      # Optional canonical-portal redirect; also publish 80:80 under ports when enabled.
+      HTTP_REDIRECT_ENABLED: ${HTTP_REDIRECT_ENABLED:-false}
+      HTTP_REDIRECT_ADDR: ${HTTP_REDIRECT_ADDR:-:80}
+      HTTP_REDIRECT_HSTS: ${HTTP_REDIRECT_HSTS:-false}
       WIREGUARD_PORT: ${WIREGUARD_PORT:-51820}
 
       # Shared lease port range.

--- a/docs/src/routes/configuration/+page.md
+++ b/docs/src/routes/configuration/+page.md
@@ -70,9 +70,16 @@ paths and queries are discarded; this does not implement per-tenant redirects.
 Existing URL normalization retains a configured base path, removes trailing
 slashes and the legacy `/relay` suffix, and drops configured queries/fragments.
 Enabling redirects requires an explicit absolute HTTPS `PORTAL_URL` without
-credentials and with a valid port. Disabled mode preserves existing loopback
-HTTP-to-HTTPS URL normalization. Bind failures fail startup; shutdown releases
-the listener. The listener uses bounded read, write, and idle timeouts.
+credentials and with a valid port; HTTPS scheme spelling is case-insensitive.
+The listen address must use `host:port` syntax (bracket IPv6 addresses) with a
+numeric port from 0 to 65535; port 0 requests an automatically assigned port.
+`relay-server config` reports invalid targets or listen-address syntax as
+`blocked`. Reporting only validates configuration: it does not resolve listen
+hosts or bind sockets, so `enabled` is not a readiness check. Bind failures,
+including occupied ports or unavailable hosts, still fail startup.
+Disabled mode preserves existing loopback HTTP-to-HTTPS URL normalization.
+Shutdown releases the listener. The listener uses bounded read, write, and idle
+timeouts.
 
 **Browsers ignore HSTS received over HTTP.** This optional insecure-response
 header does not protect clients or establish HSTS. Effective HSTS must be served

--- a/docs/src/routes/configuration/+page.md
+++ b/docs/src/routes/configuration/+page.md
@@ -56,6 +56,39 @@ A value that cannot be parsed is a startup error rather than a silent fallback:
 | `SNI_PORT` | `443` | int | TCP SNI router listen port; non-standard values are intended for local testing, while the bundled public deployment requires `443` |
 | `WIREGUARD_PORT` | `51820` | int | Public and listen UDP port for relay discovery overlay |
 
+### Optional HTTP redirect listener
+
+| Variable | Default | Type | Description |
+|----------|---------|------|-------------|
+| `HTTP_REDIRECT_ENABLED` | `false` | bool | Enable the redirect-only listener (`--http-redirect-enabled`) |
+| `HTTP_REDIRECT_ADDR` | `:80` | string | TCP listen address (`--http-redirect-addr`); use `127.0.0.1:18080` for local testing |
+| `HTTP_REDIRECT_HSTS` | `false` | bool | Include `Strict-Transport-Security: max-age=31536000` on redirects (`--http-redirect-hsts`) |
+
+Every request receives **301 Moved Permanently** to the normalized configured
+`PORTAL_URL`, never to a request Host or forwarded-header destination. Request
+paths and queries are discarded; this does not implement per-tenant redirects.
+Existing URL normalization retains a configured base path, removes trailing
+slashes and the legacy `/relay` suffix, and drops configured queries/fragments.
+Enabling redirects requires an explicit absolute HTTPS `PORTAL_URL` without
+credentials and with a valid port. Disabled mode preserves existing loopback
+HTTP-to-HTTPS URL normalization. Bind failures fail startup; shutdown releases
+the listener. The listener uses bounded read, write, and idle timeouts.
+
+**Browsers ignore HSTS received over HTTP.** This optional insecure-response
+header does not protect clients or establish HSTS. Effective HSTS must be served
+over HTTPS by the destination. This option does not change HTTPS or tenant
+policy and does not add `includeSubDomains` or `preload`.
+
+```bash
+relay-server --portal-url https://localhost:14017 --api-port 14017 --sni-port 14443 --http-redirect-enabled --http-redirect-addr 127.0.0.1:18080
+curl -i -H "Host: untrusted.example" "http://127.0.0.1:18080/ignored?secret=value"
+```
+
+For bundled Compose, set `HTTP_REDIRECT_ENABLED=true`, retain
+`HTTP_REDIRECT_ADDR=:80`, and add `"80:80"` to the portal service's `ports`.
+Changing the container listen port also requires changing this mapping. Open
+TCP 80 in the firewall; binding privileged ports may require OS permissions.
+
 ### Transport
 
 | Variable | Default | Type | Description |

--- a/portal/server.go
+++ b/portal/server.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -39,27 +41,30 @@ const (
 )
 
 type ServerConfig struct {
-	PortalURL         string
-	IdentityPath      string
-	Bootstraps        []string
-	DiscoveryEnabled  bool
-	WireGuardPort     int
-	APIPort           int
-	SNIPort           int
-	APIListenAddr     string
-	SNIListenAddr     string
-	TrustProxyHeaders bool
-	TrustedProxyCIDRs string
-	UDPEnabled        bool
-	TCPEnabled        bool
-	MinPort           int
-	MaxPort           int
-	PProfEnabled      bool
-	PProfListenAddr   string
-	X402Enabled       bool
-	X402Testnet       bool
-	X402PayTo         string
-	ACME              acme.Config
+	PortalURL           string
+	IdentityPath        string
+	Bootstraps          []string
+	DiscoveryEnabled    bool
+	WireGuardPort       int
+	APIPort             int
+	SNIPort             int
+	HTTPRedirectEnabled bool
+	HTTPRedirectAddr    string
+	HTTPRedirectHSTS    bool
+	APIListenAddr       string
+	SNIListenAddr       string
+	TrustProxyHeaders   bool
+	TrustedProxyCIDRs   string
+	UDPEnabled          bool
+	TCPEnabled          bool
+	MinPort             int
+	MaxPort             int
+	PProfEnabled        bool
+	PProfListenAddr     string
+	X402Enabled         bool
+	X402Testnet         bool
+	X402PayTo           string
+	ACME                acme.Config
 }
 
 func normalizeServerConfig(cfg ServerConfig) (ServerConfig, error) {
@@ -67,6 +72,20 @@ func normalizeServerConfig(cfg ServerConfig) (ServerConfig, error) {
 	cfg.IdentityPath = identity.ResolveRelayStateDir(cfg.IdentityPath)
 	if cfg.IdentityPath == "" {
 		return ServerConfig{}, errors.New("identity path is required")
+	}
+
+	if cfg.HTTPRedirectEnabled {
+		target, err := url.Parse(cfg.PortalURL)
+		if err != nil || target.Scheme != "https" || target.Hostname() == "" || target.User != nil || target.Opaque != "" || strings.HasSuffix(target.Host, ":") {
+			return ServerConfig{}, errors.New("http redirect requires PORTAL_URL to be an absolute HTTPS URL without credentials")
+		}
+		if port := target.Port(); port != "" {
+			n, err := strconv.Atoi(port)
+			if err != nil || n < 1 || n > 65535 {
+				return ServerConfig{}, errors.New("http redirect PORTAL_URL port must be between 1 and 65535")
+			}
+		}
+		cfg.HTTPRedirectAddr = utils.StringOrDefault(strings.TrimSpace(cfg.HTTPRedirectAddr), ":80")
 	}
 
 	selfRelayURL, err := utils.NormalizeRelayURL(cfg.PortalURL)
@@ -131,13 +150,15 @@ type Server struct {
 	acmeManager *acme.Manager
 	proxy       proxy
 
-	apiListener   net.Listener
-	sniListener   net.Listener
-	apiServer     *http.Server
-	apiTLSClose   io.Closer
-	pprofListener net.Listener
-	pprofServer   *http.Server
-	quicBackhaul  *quic.Listener
+	apiListener      net.Listener
+	sniListener      net.Listener
+	apiServer        *http.Server
+	apiTLSClose      io.Closer
+	redirectListener net.Listener
+	redirectServer   *http.Server
+	pprofListener    net.Listener
+	pprofServer      *http.Server
+	quicBackhaul     *quic.Listener
 
 	overlay         *overlay.Overlay
 	relaySet        *discovery.RelaySet
@@ -242,6 +263,8 @@ func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {
 	var sniListener net.Listener
 	var apiServer *http.Server
 	var apiCloser io.Closer
+	var redirectListener net.Listener
+	var redirectServer *http.Server
 	var pprofListener net.Listener
 	var pprofServer *http.Server
 	var ov *overlay.Overlay
@@ -256,6 +279,12 @@ func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {
 		}
 		if apiServer != nil {
 			_ = apiServer.Close()
+		}
+		if redirectServer != nil {
+			_ = redirectServer.Close()
+		}
+		if redirectListener != nil {
+			_ = redirectListener.Close()
 		}
 		if pprofServer != nil {
 			_ = pprofServer.Close()
@@ -289,6 +318,26 @@ func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {
 	wrappedAPIListener, apiServer, apiCloser, err := s.newAPIServer(apiListener, apiMux, apiTLS)
 	if err != nil {
 		return err
+	}
+	if cfg.HTTPRedirectEnabled {
+		redirectListener, err = listenConfig.Listen(serverCtx, "tcp", cfg.HTTPRedirectAddr)
+		if err != nil {
+			return fmt.Errorf("listen http redirect: %w", err)
+		}
+		redirectServer = &http.Server{
+			DisableGeneralOptionsHandler: true,
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if cfg.HTTPRedirectHSTS {
+					w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+				}
+				// Canonical portal only: never forward request hosts, paths, or queries.
+				http.Redirect(w, r, cfg.PortalURL, http.StatusMovedPermanently)
+			}),
+			ReadHeaderTimeout: 10 * time.Second,
+			ReadTimeout:       10 * time.Second,
+			WriteTimeout:      10 * time.Second,
+			IdleTimeout:       30 * time.Second,
+		}
 	}
 	if cfg.PProfEnabled {
 		pprofListener, err = listenConfig.Listen(serverCtx, "tcp", cfg.PProfListenAddr)
@@ -325,6 +374,8 @@ func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {
 	s.sniListener = sniListener
 	s.apiServer = apiServer
 	s.apiTLSClose = apiCloser
+	s.redirectListener = redirectListener
+	s.redirectServer = redirectServer
 	s.pprofListener = pprofListener
 	s.pprofServer = pprofServer
 	s.acmeManager = acmeManager
@@ -335,6 +386,15 @@ func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {
 	started = true
 
 	group.Go(s.runAPIServer)
+	if s.redirectServer != nil {
+		group.Go(func() error {
+			err := s.redirectServer.Serve(s.redirectListener)
+			if errors.Is(err, http.ErrServerClosed) || errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return err
+		})
+	}
 	if s.pprofServer != nil {
 		group.Go(s.runPProfServer)
 	}
@@ -371,6 +431,9 @@ func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {
 		Bool("tcp_enabled", s.supportsTCP()).
 		Bool("api_ech_enabled", len(apiTLS.EncryptedClientHelloKeys) > 0).
 		Bool("pprof_enabled", s.pprofServer != nil)
+	if s.redirectListener != nil {
+		logEvent = logEvent.Str("http_redirect_addr", s.redirectListener.Addr().String())
+	}
 	if s.pprofListener != nil {
 		logEvent = logEvent.Str("pprof_addr", utils.HostPortOrLoopback(s.pprofListener.Addr().String()))
 	}
@@ -452,6 +515,16 @@ func (s *Server) Shutdown(ctx context.Context) error {
 			if err := s.apiServer.Shutdown(ctx); err != nil && shutdownErr == nil {
 				shutdownErr = err
 			}
+		}
+		if s.redirectServer != nil {
+			if err := s.redirectServer.Shutdown(ctx); err != nil {
+				_ = s.redirectServer.Close()
+				if shutdownErr == nil {
+					shutdownErr = err
+				}
+			}
+			// Shutdown can precede the Serve goroutine registering its listener.
+			_ = s.redirectListener.Close()
 		}
 		if s.pprofServer != nil {
 			if err := s.pprofServer.Shutdown(ctx); err != nil && shutdownErr == nil {

--- a/portal/server.go
+++ b/portal/server.go
@@ -9,6 +9,9 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"net/netip"
+	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -63,6 +66,46 @@ type ServerConfig struct {
 	ACME              acme.Config
 }
 
+// NormalizeHTTPRedirectConfig validates redirect settings without resolving names
+// or binding sockets. Listener availability is checked only when the server starts.
+func NormalizeHTTPRedirectConfig(cfg types.HTTPRedirectConfig, portalURL string) (types.HTTPRedirectConfig, error) {
+	if !cfg.Enabled {
+		return cfg, nil
+	}
+	target, err := url.Parse(strings.TrimSpace(portalURL))
+	if err != nil {
+		return types.HTTPRedirectConfig{}, errors.New("http redirect requires PORTAL_URL to be an absolute HTTPS URL without credentials")
+	}
+	hasHTTPSOrigin := target.Scheme == "https" && utils.NormalizeHostname(target.Hostname()) != "" && target.Opaque == ""
+	if !hasHTTPSOrigin || target.User != nil || strings.HasSuffix(target.Host, ":") {
+		return types.HTTPRedirectConfig{}, errors.New("http redirect requires PORTAL_URL to be an absolute HTTPS URL without credentials")
+	}
+	if port := target.Port(); port != "" {
+		n, err := strconv.Atoi(port)
+		if err != nil || n < 1 || n > 65535 {
+			return types.HTTPRedirectConfig{}, errors.New("http redirect PORTAL_URL port must be between 1 and 65535")
+		}
+	}
+	cfg.Addr = utils.StringOrDefault(strings.TrimSpace(cfg.Addr), types.DefaultHTTPRedirectAddr)
+	host, port, err := net.SplitHostPort(cfg.Addr)
+	if err != nil {
+		return types.HTTPRedirectConfig{}, fmt.Errorf("http redirect HTTP_REDIRECT_ADDR must be a host:port address: %w", err)
+	}
+	if strings.ContainsAny(host, " \t\r\n/#?@\\") {
+		return types.HTTPRedirectConfig{}, errors.New("http redirect HTTP_REDIRECT_ADDR has an invalid host")
+	}
+	if strings.Contains(host, ":") {
+		if _, err := netip.ParseAddr(host); err != nil {
+			return types.HTTPRedirectConfig{}, fmt.Errorf("http redirect HTTP_REDIRECT_ADDR has an invalid IP address: %w", err)
+		}
+	}
+	n, err := strconv.Atoi(port)
+	if err != nil || n < 0 || n > 65535 {
+		return types.HTTPRedirectConfig{}, errors.New("http redirect HTTP_REDIRECT_ADDR port must be between 0 and 65535")
+	}
+	return cfg, nil
+}
+
 func normalizeServerConfig(cfg ServerConfig) (ServerConfig, error) {
 	cfg.PortalURL = strings.TrimSuffix(strings.TrimSpace(cfg.PortalURL), "/")
 	cfg.IdentityPath = identity.ResolveRelayStateDir(cfg.IdentityPath)
@@ -70,7 +113,7 @@ func normalizeServerConfig(cfg ServerConfig) (ServerConfig, error) {
 		return ServerConfig{}, errors.New("identity path is required")
 	}
 
-	redirect, err := utils.NormalizeHTTPRedirectConfig(cfg.HTTPRedirect, cfg.PortalURL)
+	redirect, err := NormalizeHTTPRedirectConfig(cfg.HTTPRedirect, cfg.PortalURL)
 	if err != nil {
 		return ServerConfig{}, err
 	}

--- a/portal/server.go
+++ b/portal/server.go
@@ -9,8 +9,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
-	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -41,30 +39,28 @@ const (
 )
 
 type ServerConfig struct {
-	PortalURL           string
-	IdentityPath        string
-	Bootstraps          []string
-	DiscoveryEnabled    bool
-	WireGuardPort       int
-	APIPort             int
-	SNIPort             int
-	HTTPRedirectEnabled bool
-	HTTPRedirectAddr    string
-	HTTPRedirectHSTS    bool
-	APIListenAddr       string
-	SNIListenAddr       string
-	TrustProxyHeaders   bool
-	TrustedProxyCIDRs   string
-	UDPEnabled          bool
-	TCPEnabled          bool
-	MinPort             int
-	MaxPort             int
-	PProfEnabled        bool
-	PProfListenAddr     string
-	X402Enabled         bool
-	X402Testnet         bool
-	X402PayTo           string
-	ACME                acme.Config
+	PortalURL         string
+	IdentityPath      string
+	Bootstraps        []string
+	DiscoveryEnabled  bool
+	WireGuardPort     int
+	APIPort           int
+	SNIPort           int
+	HTTPRedirect      types.HTTPRedirectConfig
+	APIListenAddr     string
+	SNIListenAddr     string
+	TrustProxyHeaders bool
+	TrustedProxyCIDRs string
+	UDPEnabled        bool
+	TCPEnabled        bool
+	MinPort           int
+	MaxPort           int
+	PProfEnabled      bool
+	PProfListenAddr   string
+	X402Enabled       bool
+	X402Testnet       bool
+	X402PayTo         string
+	ACME              acme.Config
 }
 
 func normalizeServerConfig(cfg ServerConfig) (ServerConfig, error) {
@@ -74,23 +70,11 @@ func normalizeServerConfig(cfg ServerConfig) (ServerConfig, error) {
 		return ServerConfig{}, errors.New("identity path is required")
 	}
 
-	if cfg.HTTPRedirectEnabled {
-		target, err := url.Parse(cfg.PortalURL)
-		if err != nil {
-			return ServerConfig{}, errors.New("http redirect requires PORTAL_URL to be an absolute HTTPS URL without credentials")
-		}
-		hasHTTPSOrigin := target.Scheme == "https" && target.Hostname() != "" && target.Opaque == ""
-		if !hasHTTPSOrigin || target.User != nil || strings.HasSuffix(target.Host, ":") {
-			return ServerConfig{}, errors.New("http redirect requires PORTAL_URL to be an absolute HTTPS URL without credentials")
-		}
-		if port := target.Port(); port != "" {
-			n, err := strconv.Atoi(port)
-			if err != nil || n < 1 || n > 65535 {
-				return ServerConfig{}, errors.New("http redirect PORTAL_URL port must be between 1 and 65535")
-			}
-		}
-		cfg.HTTPRedirectAddr = utils.StringOrDefault(strings.TrimSpace(cfg.HTTPRedirectAddr), ":80")
+	redirect, err := utils.NormalizeHTTPRedirectConfig(cfg.HTTPRedirect, cfg.PortalURL)
+	if err != nil {
+		return ServerConfig{}, err
 	}
+	cfg.HTTPRedirect = redirect
 
 	selfRelayURL, err := utils.NormalizeRelayURL(cfg.PortalURL)
 	if err != nil {
@@ -323,15 +307,15 @@ func (s *Server) Start(ctx context.Context, apiMux *http.ServeMux) error {
 	if err != nil {
 		return err
 	}
-	if cfg.HTTPRedirectEnabled {
-		redirectListener, err = listenConfig.Listen(serverCtx, "tcp", cfg.HTTPRedirectAddr)
+	if cfg.HTTPRedirect.Enabled {
+		redirectListener, err = listenConfig.Listen(serverCtx, "tcp", cfg.HTTPRedirect.Addr)
 		if err != nil {
 			return fmt.Errorf("listen http redirect: %w", err)
 		}
 		redirectServer = &http.Server{
 			DisableGeneralOptionsHandler: true,
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if cfg.HTTPRedirectHSTS {
+				if cfg.HTTPRedirect.HSTS {
 					w.Header().Set("Strict-Transport-Security", "max-age=31536000")
 				}
 				// Canonical portal only: never forward request hosts, paths, or queries.

--- a/portal/server.go
+++ b/portal/server.go
@@ -76,7 +76,11 @@ func normalizeServerConfig(cfg ServerConfig) (ServerConfig, error) {
 
 	if cfg.HTTPRedirectEnabled {
 		target, err := url.Parse(cfg.PortalURL)
-		if err != nil || target.Scheme != "https" || target.Hostname() == "" || target.User != nil || target.Opaque != "" || strings.HasSuffix(target.Host, ":") {
+		if err != nil {
+			return ServerConfig{}, errors.New("http redirect requires PORTAL_URL to be an absolute HTTPS URL without credentials")
+		}
+		hasHTTPSOrigin := target.Scheme == "https" && target.Hostname() != "" && target.Opaque == ""
+		if !hasHTTPSOrigin || target.User != nil || strings.HasSuffix(target.Host, ":") {
 			return ServerConfig{}, errors.New("http redirect requires PORTAL_URL to be an absolute HTTPS URL without credentials")
 		}
 		if port := target.Port(); port != "" {

--- a/portal/server_test.go
+++ b/portal/server_test.go
@@ -115,28 +115,68 @@ func newTestClient(t *testing.T, cancel context.CancelFunc, server *Server) *htt
 }
 
 func TestHTTPRedirectTargetValidation(t *testing.T) {
-	for _, target := range []string{"http://localhost:4017", "http://relay.example", "//relay.example", "https://user:pass@relay.example", "https://relay.example:65536", "https://relay.example:bad", "https:///missing-host"} {
+	for _, target := range []string{"http://localhost:4017", "http://relay.example", "//relay.example", "https://user:pass@relay.example", "https://relay.example:0", "https://relay.example:65536", "https://relay.example:bad", "https://relay.example:", "https:///missing-host", "https://./"} {
 		t.Run(target, func(t *testing.T) {
-			_, err := normalizeServerConfig(ServerConfig{PortalURL: target, IdentityPath: t.TempDir(), HTTPRedirectEnabled: true})
+			_, err := NewServer(ServerConfig{
+				PortalURL: target, IdentityPath: t.TempDir(),
+				HTTPRedirect: types.HTTPRedirectConfig{Enabled: true},
+			})
 			if err == nil {
 				t.Fatal("expected invalid redirect target to fail")
 			}
 		})
 	}
-	cfg, err := normalizeServerConfig(ServerConfig{PortalURL: "http://localhost:4017", IdentityPath: t.TempDir()})
-	if err != nil || cfg.PortalURL != "https://localhost:4017" {
-		t.Fatalf("disabled redirect changed loopback behavior: cfg=%+v err=%v", cfg, err)
+}
+
+func TestHTTPRedirectDisabledPreservesLoopback(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer occupied.Close()
+	apiPort := tempLeasePort(t)
+	defer releaseTestLeasePort(apiPort)
+	apiAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(apiPort))
+	server, err := NewServer(ServerConfig{
+		PortalURL: "http://localhost:4017", IdentityPath: t.TempDir(), ACME: acme.Config{KeyDir: t.TempDir()},
+		APIListenAddr: apiAddr, SNIListenAddr: "127.0.0.1:0",
+		HTTPRedirect: types.HTTPRedirectConfig{Addr: occupied.Addr().String()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := server.Start(ctx, nil); err != nil {
+		t.Fatalf("disabled redirect attempted to bind or changed loopback behavior: %v", err)
+	}
+	client := newTestClient(t, cancel, server)
+	resp, err := client.Get("https://" + apiAddr + types.PathHealthz)
+	if err != nil {
+		t.Fatalf("loopback API is not serving HTTPS: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("loopback API status=%d, want 200", resp.StatusCode)
 	}
 }
 
 func TestHTTPRedirectLifecycle(t *testing.T) {
 	for _, hsts := range []bool{false, true} {
 		t.Run(strconv.FormatBool(hsts), func(t *testing.T) {
+			port := tempLeasePort(t)
+			defer releaseTestLeasePort(port)
+			addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+			// net/url accepts HTTPS schemes regardless of their spelling.
+			scheme := "HTTPS"
+			if hsts {
+				scheme = "hTtPs"
+			}
 			server, err := NewServer(ServerConfig{
-				PortalURL:    "https://localhost:4017/base/?configured=discarded#fragment",
+				PortalURL:    scheme + "://localhost:4017/base/?configured=discarded#fragment",
 				IdentityPath: t.TempDir(), ACME: acme.Config{KeyDir: t.TempDir()},
 				APIListenAddr: "127.0.0.1:0", SNIListenAddr: "127.0.0.1:0",
-				HTTPRedirectEnabled: true, HTTPRedirectAddr: "127.0.0.1:0", HTTPRedirectHSTS: hsts,
+				HTTPRedirect: types.HTTPRedirectConfig{Enabled: true, Addr: addr, HSTS: hsts},
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -148,7 +188,6 @@ func TestHTTPRedirectLifecycle(t *testing.T) {
 			}
 			client := newTestClient(t, cancel, server)
 			client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
-			addr := server.redirectListener.Addr().String()
 			for _, method := range []string{http.MethodGet, http.MethodHead, http.MethodPost, http.MethodOptions} {
 				req, err := http.NewRequest(method, "http://"+addr+"//tenant/path?secret=discarded", nil)
 				if err != nil {
@@ -204,7 +243,7 @@ func TestHTTPRedirectPartialStartupCleanup(t *testing.T) {
 	server, err := NewServer(ServerConfig{
 		PortalURL: "https://localhost:4017", IdentityPath: t.TempDir(), ACME: acme.Config{KeyDir: t.TempDir()},
 		APIListenAddr: "127.0.0.1:0", SNIListenAddr: "127.0.0.1:0",
-		HTTPRedirectEnabled: true, HTTPRedirectAddr: addr,
+		HTTPRedirect: types.HTTPRedirectConfig{Enabled: true, Addr: addr},
 		PProfEnabled: true, PProfListenAddr: occupied.Addr().String(),
 	})
 	if err != nil {
@@ -232,7 +271,7 @@ func TestHTTPRedirectBindFailure(t *testing.T) {
 	server, err := NewServer(ServerConfig{
 		PortalURL: "https://localhost:4017", IdentityPath: t.TempDir(), ACME: acme.Config{KeyDir: t.TempDir()},
 		APIListenAddr: "127.0.0.1:0", SNIListenAddr: "127.0.0.1:0",
-		HTTPRedirectEnabled: true, HTTPRedirectAddr: occupied.Addr().String(),
+		HTTPRedirect: types.HTTPRedirectConfig{Enabled: true, Addr: occupied.Addr().String()},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -243,17 +282,35 @@ func TestHTTPRedirectBindFailure(t *testing.T) {
 		}
 		t.Fatalf("Start error=%v, want redirect bind failure", err)
 	}
-	// Retry the same owner: failed startup must not leave live server state.
-	server.cfg.UpdateCopy(func(cfg *ServerConfig) { cfg.HTTPRedirectAddr = "127.0.0.1:0" })
+	// Retry the same server and configuration after releasing the occupied port.
+	addr := occupied.Addr().String()
+	if err := occupied.Close(); err != nil {
+		t.Fatal(err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if err := server.Start(ctx, nil); err != nil {
 		t.Fatal(err)
 	}
+	client := newTestClient(t, cancel, server)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	resp, err := client.Get("http://" + addr + "/ignored")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusMovedPermanently || resp.Header.Get("Location") != "https://localhost:4017" {
+		t.Fatalf("retry status=%d Location=%q", resp.StatusCode, resp.Header.Get("Location"))
+	}
 	cancel()
 	if err := server.Wait(); err != nil {
 		t.Fatal(err)
 	}
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("retry shutdown leaked redirect listener: %v", err)
+	}
+	listener.Close()
 }
 
 func TestRelayDiscoveryEnabledServesDiscoveryEnvelope(t *testing.T) {
@@ -344,10 +401,6 @@ func TestServerStartInitializesLocalACMEAndSigner(t *testing.T) {
 	}
 
 	client := newTestClient(t, cancel, server)
-
-	if server.redirectListener != nil || server.redirectServer != nil {
-		t.Fatal("HTTP redirect listener must be disabled by default")
-	}
 
 	healthResp, err := client.Get("https://" + utils.HostPortOrLoopback(server.apiListener.Addr().String()) + types.PathHealthz)
 	if err != nil {

--- a/portal/server_test.go
+++ b/portal/server_test.go
@@ -114,6 +114,148 @@ func newTestClient(t *testing.T, cancel context.CancelFunc, server *Server) *htt
 	return client
 }
 
+func TestHTTPRedirectTargetValidation(t *testing.T) {
+	for _, target := range []string{"http://localhost:4017", "http://relay.example", "//relay.example", "https://user:pass@relay.example", "https://relay.example:65536", "https://relay.example:bad", "https:///missing-host"} {
+		t.Run(target, func(t *testing.T) {
+			_, err := normalizeServerConfig(ServerConfig{PortalURL: target, IdentityPath: t.TempDir(), HTTPRedirectEnabled: true})
+			if err == nil {
+				t.Fatal("expected invalid redirect target to fail")
+			}
+		})
+	}
+	cfg, err := normalizeServerConfig(ServerConfig{PortalURL: "http://localhost:4017", IdentityPath: t.TempDir()})
+	if err != nil || cfg.PortalURL != "https://localhost:4017" {
+		t.Fatalf("disabled redirect changed loopback behavior: cfg=%+v err=%v", cfg, err)
+	}
+}
+
+func TestHTTPRedirectLifecycle(t *testing.T) {
+	for _, hsts := range []bool{false, true} {
+		t.Run(strconv.FormatBool(hsts), func(t *testing.T) {
+			server, err := NewServer(ServerConfig{
+				PortalURL:    "https://localhost:4017/base/?configured=discarded#fragment",
+				IdentityPath: t.TempDir(), ACME: acme.Config{KeyDir: t.TempDir()},
+				APIListenAddr: "127.0.0.1:0", SNIListenAddr: "127.0.0.1:0",
+				HTTPRedirectEnabled: true, HTTPRedirectAddr: "127.0.0.1:0", HTTPRedirectHSTS: hsts,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if err := server.Start(ctx, nil); err != nil {
+				t.Fatal(err)
+			}
+			client := newTestClient(t, cancel, server)
+			client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+			addr := server.redirectListener.Addr().String()
+			for _, method := range []string{http.MethodGet, http.MethodHead, http.MethodPost, http.MethodOptions} {
+				req, err := http.NewRequest(method, "http://"+addr+"//tenant/path?secret=discarded", nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if method == http.MethodOptions {
+					req.URL.Path = "*"
+					req.URL.RawQuery = ""
+				}
+				req.Host = "attacker.example"
+				req.Header.Set("X-Forwarded-Host", "other-attacker.example")
+				resp, err := client.Do(req)
+				if err != nil {
+					t.Fatal(err)
+				}
+				resp.Body.Close()
+				if resp.StatusCode != http.StatusMovedPermanently || resp.Header.Get("Location") != "https://localhost:4017/base" {
+					t.Fatalf("%s: status=%d Location=%q", method, resp.StatusCode, resp.Header.Get("Location"))
+				}
+				wantHSTS := ""
+				if hsts {
+					wantHSTS = "max-age=31536000"
+				}
+				if got := resp.Header.Get("Strict-Transport-Security"); got != wantHSTS {
+					t.Fatalf("HSTS=%q, want %q", got, wantHSTS)
+				}
+			}
+			cancel()
+			if err := server.Wait(); err != nil {
+				t.Fatal(err)
+			}
+			listener, err := net.Listen("tcp", addr)
+			if err != nil {
+				t.Fatalf("redirect port not released: %v", err)
+			}
+			listener.Close()
+		})
+	}
+}
+
+func TestHTTPRedirectPartialStartupCleanup(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer occupied.Close()
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := probe.Addr().String()
+	probe.Close()
+	server, err := NewServer(ServerConfig{
+		PortalURL: "https://localhost:4017", IdentityPath: t.TempDir(), ACME: acme.Config{KeyDir: t.TempDir()},
+		APIListenAddr: "127.0.0.1:0", SNIListenAddr: "127.0.0.1:0",
+		HTTPRedirectEnabled: true, HTTPRedirectAddr: addr,
+		PProfEnabled: true, PProfListenAddr: occupied.Addr().String(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.Start(context.Background(), nil); err == nil || !strings.Contains(err.Error(), "listen pprof") {
+		if err == nil {
+			server.Shutdown(context.Background())
+		}
+		t.Fatalf("Start error=%v, want later pprof bind failure", err)
+	}
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("partial startup leaked redirect listener: %v", err)
+	}
+	listener.Close()
+}
+
+func TestHTTPRedirectBindFailure(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer occupied.Close()
+	server, err := NewServer(ServerConfig{
+		PortalURL: "https://localhost:4017", IdentityPath: t.TempDir(), ACME: acme.Config{KeyDir: t.TempDir()},
+		APIListenAddr: "127.0.0.1:0", SNIListenAddr: "127.0.0.1:0",
+		HTTPRedirectEnabled: true, HTTPRedirectAddr: occupied.Addr().String(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.Start(context.Background(), nil); err == nil || !strings.Contains(err.Error(), "listen http redirect") {
+		if err == nil {
+			server.Shutdown(context.Background())
+		}
+		t.Fatalf("Start error=%v, want redirect bind failure", err)
+	}
+	// Retry the same owner: failed startup must not leave live server state.
+	server.cfg.UpdateCopy(func(cfg *ServerConfig) { cfg.HTTPRedirectAddr = "127.0.0.1:0" })
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := server.Start(ctx, nil); err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	if err := server.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRelayDiscoveryEnabledServesDiscoveryEnvelope(t *testing.T) {
 	t.Parallel()
 
@@ -202,6 +344,10 @@ func TestServerStartInitializesLocalACMEAndSigner(t *testing.T) {
 	}
 
 	client := newTestClient(t, cancel, server)
+
+	if server.redirectListener != nil || server.redirectServer != nil {
+		t.Fatal("HTTP redirect listener must be disabled by default")
+	}
 
 	healthResp, err := client.Get("https://" + utils.HostPortOrLoopback(server.apiListener.Addr().String()) + types.PathHealthz)
 	if err != nil {

--- a/types/types.go
+++ b/types/types.go
@@ -22,6 +22,20 @@ const (
 	MarkerTLSStart         = byte(0x02)
 )
 
+const (
+	DefaultHTTPRedirectAddr = ":80"
+	HTTPRedirectFeatureName = "http-redirect"
+	HTTPRedirectEnabledEnv  = "HTTP_REDIRECT_ENABLED"
+)
+
+// HTTPRedirectConfig controls the optional canonical-portal HTTP listener.
+// The zero value disables redirects and HSTS; an empty Addr defaults to :80.
+type HTTPRedirectConfig struct {
+	Enabled bool
+	Addr    string
+	HSTS    bool
+}
+
 var (
 	ReleaseVersion         string
 	SDKVersion             string

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,10 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/netip"
 	"net/url"
 	"path"
-	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -136,46 +134,6 @@ func isPlainDNSLabel(label string) bool {
 		return false
 	}
 	return true
-}
-
-// NormalizeHTTPRedirectConfig validates redirect settings without resolving names
-// or binding sockets. Listener availability is checked only when the server starts.
-func NormalizeHTTPRedirectConfig(cfg types.HTTPRedirectConfig, portalURL string) (types.HTTPRedirectConfig, error) {
-	if !cfg.Enabled {
-		return cfg, nil
-	}
-	target, err := url.Parse(strings.TrimSpace(portalURL))
-	if err != nil {
-		return types.HTTPRedirectConfig{}, errors.New("http redirect requires PORTAL_URL to be an absolute HTTPS URL without credentials")
-	}
-	hasHTTPSOrigin := target.Scheme == "https" && NormalizeHostname(target.Hostname()) != "" && target.Opaque == ""
-	if !hasHTTPSOrigin || target.User != nil || strings.HasSuffix(target.Host, ":") {
-		return types.HTTPRedirectConfig{}, errors.New("http redirect requires PORTAL_URL to be an absolute HTTPS URL without credentials")
-	}
-	if port := target.Port(); port != "" {
-		n, err := strconv.Atoi(port)
-		if err != nil || n < 1 || n > 65535 {
-			return types.HTTPRedirectConfig{}, errors.New("http redirect PORTAL_URL port must be between 1 and 65535")
-		}
-	}
-	cfg.Addr = StringOrDefault(strings.TrimSpace(cfg.Addr), types.DefaultHTTPRedirectAddr)
-	host, port, err := net.SplitHostPort(cfg.Addr)
-	if err != nil {
-		return types.HTTPRedirectConfig{}, fmt.Errorf("http redirect HTTP_REDIRECT_ADDR must be a host:port address: %w", err)
-	}
-	if strings.ContainsAny(host, " \t\r\n/#?@\\") {
-		return types.HTTPRedirectConfig{}, errors.New("http redirect HTTP_REDIRECT_ADDR has an invalid host")
-	}
-	if strings.Contains(host, ":") {
-		if _, err := netip.ParseAddr(host); err != nil {
-			return types.HTTPRedirectConfig{}, fmt.Errorf("http redirect HTTP_REDIRECT_ADDR has an invalid IP address: %w", err)
-		}
-	}
-	n, err := strconv.Atoi(port)
-	if err != nil || n < 0 || n > 65535 {
-		return types.HTTPRedirectConfig{}, errors.New("http redirect HTTP_REDIRECT_ADDR port must be between 0 and 65535")
-	}
-	return cfg, nil
 }
 
 func NormalizeRelayURL(raw string) (string, error) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,8 +9,10 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -134,6 +136,46 @@ func isPlainDNSLabel(label string) bool {
 		return false
 	}
 	return true
+}
+
+// NormalizeHTTPRedirectConfig validates redirect settings without resolving names
+// or binding sockets. Listener availability is checked only when the server starts.
+func NormalizeHTTPRedirectConfig(cfg types.HTTPRedirectConfig, portalURL string) (types.HTTPRedirectConfig, error) {
+	if !cfg.Enabled {
+		return cfg, nil
+	}
+	target, err := url.Parse(strings.TrimSpace(portalURL))
+	if err != nil {
+		return types.HTTPRedirectConfig{}, errors.New("http redirect requires PORTAL_URL to be an absolute HTTPS URL without credentials")
+	}
+	hasHTTPSOrigin := target.Scheme == "https" && NormalizeHostname(target.Hostname()) != "" && target.Opaque == ""
+	if !hasHTTPSOrigin || target.User != nil || strings.HasSuffix(target.Host, ":") {
+		return types.HTTPRedirectConfig{}, errors.New("http redirect requires PORTAL_URL to be an absolute HTTPS URL without credentials")
+	}
+	if port := target.Port(); port != "" {
+		n, err := strconv.Atoi(port)
+		if err != nil || n < 1 || n > 65535 {
+			return types.HTTPRedirectConfig{}, errors.New("http redirect PORTAL_URL port must be between 1 and 65535")
+		}
+	}
+	cfg.Addr = StringOrDefault(strings.TrimSpace(cfg.Addr), types.DefaultHTTPRedirectAddr)
+	host, port, err := net.SplitHostPort(cfg.Addr)
+	if err != nil {
+		return types.HTTPRedirectConfig{}, fmt.Errorf("http redirect HTTP_REDIRECT_ADDR must be a host:port address: %w", err)
+	}
+	if strings.ContainsAny(host, " \t\r\n/#?@\\") {
+		return types.HTTPRedirectConfig{}, errors.New("http redirect HTTP_REDIRECT_ADDR has an invalid host")
+	}
+	if strings.Contains(host, ":") {
+		if _, err := netip.ParseAddr(host); err != nil {
+			return types.HTTPRedirectConfig{}, fmt.Errorf("http redirect HTTP_REDIRECT_ADDR has an invalid IP address: %w", err)
+		}
+	}
+	n, err := strconv.Atoi(port)
+	if err != nil || n < 0 || n > 65535 {
+		return types.HTTPRedirectConfig{}, errors.New("http redirect HTTP_REDIRECT_ADDR port must be between 0 and 65535")
+	}
+	return cfg, nil
 }
 
 func NormalizeRelayURL(raw string) (string, error) {


### PR DESCRIPTION
## Summary
- Add an opt-in redirect-only HTTP listener, owned by the existing relay lifecycle; disabled by default.
- Wire `HTTP_REDIRECT_ENABLED`, `HTTP_REDIRECT_ADDR` (default `:80`) and `HTTP_REDIRECT_HSTS` through CLI, configuration reporting, `.env.example`, Compose and existing configuration documentation.
- Redirect every request with HTTP 301 to normalized `PORTAL_URL`. Incoming Host/forwarded Host, path and query never select the destination; HTTPS is required only when the listener is enabled.
- Surface bind errors and release listeners after startup failure/shutdown. Keep ordinary loopback HTTP portal configuration working when redirect is disabled.

Closes #139

## HSTS and scope
`HTTP_REDIRECT_HSTS=true` adds `max-age=31536000` to the redirect response, without `includeSubDomains` or `preload`. Browsers ignore HSTS received over HTTP; this is not a replacement for HSTS on the canonical HTTPS endpoint. This PR does not introduce per-tenant hostname redirect/HSTS policy. Compose does not expose TCP80 unless the operator opts in.

## Verification
- Built the actual Windows relay with Go 1.27.0 and the existing release flags; built the real SPA used by the smoke relay.
- Ran the relay and observed 301 to the fixed canonical URL for hostile Host/forwarded Host plus ignored path/query.
- Exercised GET, HEAD and POST with HSTS enabled; correct Location and HSTS header on each. HSTS absent by default.
- Verified HTTP canonical target rejection and occupied redirect port startup failure.
- Restarted using the same listeners, then ran with redirect disabled: HTTPS frontend still returned 200 and an exclusive bind on the configured redirect port succeeded.
- Loaded the updated `.env.example` through the actual `config --env-file` command; all three settings were recognized with their documented defaults.
- `go vet ./portal ./cmd/relay-server` passed, including compilation of the added behavior tests.
- Local test suites were not executed, following repository instructions. Added tests cover listener behavior, defaults, target validation and lifecycle failures; normal PR CI runs them.
- `make` is not installed on this Windows machine, so the Makefile environment-reference check was not run; actual configuration-template loading was exercised instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in redirect-only HTTP listener that sends 301s to the canonical HTTPS `PORTAL_URL`, ignoring request Host, path, and query. Disabled by default; existing loopback HTTP-to-HTTPS normalization is unchanged when disabled. Closes #139.

- Wires `HTTP_REDIRECT_ENABLED`, `HTTP_REDIRECT_ADDR` (default `:80`), and `HTTP_REDIRECT_HSTS` through CLI flags, config reporting, `.env.example`, Compose, and docs.
- Enabling requires an absolute HTTPS `PORTAL_URL` without credentials and a valid port (1–65535) plus `host:port` listen syntax (port 0–65535, 0 auto-assigns); `config` reports only configuration validity, not bind readiness, and bind failures still fail startup, releasing listeners on failure or shutdown.
- `HTTP_REDIRECT_HSTS` adds `max-age=31536000` without `includeSubDomains` or `preload`; browsers ignore HSTS received over HTTP.

<sup>Written for commit a28a305873976bdfa703f0072a7f01f728ec32be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gosuda/portal-tunnel/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

