### PR TITLE
fix(acme): stop orphaning and duplicating ENS gasless DNS records

### DIFF
--- a/portal/acme/cloudflare/provider.go
+++ b/portal/acme/cloudflare/provider.go
@@ -195,6 +195,42 @@ func (p *Provider) DeleteARecord(ctx context.Context, name string) error {
 	return nil
 }
 
+// DeleteARecordValue removes only A records that still contain publicIPv4.
+func (p *Provider) DeleteARecordValue(ctx context.Context, name, publicIPv4 string) error {
+	if p == nil {
+		return errors.New("cloudflare provider is nil")
+	}
+	name = utils.NormalizeHostname(name)
+	if name == "" {
+		return errors.New("record name is required")
+	}
+	if p.token == "" {
+		return errors.New("cloudflare token is required")
+	}
+	if err := utils.ValidateIPv4(publicIPv4); err != nil {
+		return err
+	}
+	publicIPv4 = strings.TrimSpace(publicIPv4)
+
+	zoneID, err := p.findZoneID(ctx, name)
+	if err != nil {
+		return fmt.Errorf("find cloudflare zone: %w", err)
+	}
+	records, err := listDNSRecords(ctx, p.token, zoneID, name, "A")
+	if err != nil {
+		return err
+	}
+	for _, record := range records {
+		if !strings.EqualFold(record.Name, name) || strings.TrimSpace(record.Content) != publicIPv4 {
+			continue
+		}
+		if err := deleteDNSRecord(ctx, p.token, zoneID, record.ID); err != nil {
+			return fmt.Errorf("delete A record %s value %s: %w", name, publicIPv4, err)
+		}
+	}
+	return nil
+}
+
 func (p *Provider) EnsureTXTRecord(ctx context.Context, name, value string) error {
 	if p == nil {
 		return errors.New("cloudflare provider is nil")
@@ -252,6 +288,60 @@ func (p *Provider) DeleteTXTRecords(ctx context.Context, name, matchPrefix strin
 		}
 		if err := deleteDNSRecord(ctx, p.token, zoneID, record.ID); err != nil {
 			return fmt.Errorf("delete TXT record %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// ReplaceTXTRecords replaces matching TXT records without removing the last
+// valid value before the replacement has been created.
+func (p *Provider) ReplaceTXTRecords(ctx context.Context, name, matchPrefix, value string) error {
+	if p == nil {
+		return errors.New("cloudflare provider is nil")
+	}
+	name = utils.NormalizeHostname(name)
+	if name == "" {
+		return errors.New("record name is required")
+	}
+	if p.token == "" {
+		return errors.New("cloudflare token is required")
+	}
+	matchPrefix = strings.TrimSpace(matchPrefix)
+	if matchPrefix == "" {
+		return errors.New("txt record match prefix is required")
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("txt record value is required")
+	}
+
+	zoneID, err := p.findZoneID(ctx, name)
+	if err != nil {
+		return fmt.Errorf("find cloudflare zone: %w", err)
+	}
+	records, err := listDNSRecords(ctx, p.token, zoneID, name, "TXT")
+	if err != nil {
+		return err
+	}
+	desiredID := ""
+	for _, record := range records {
+		if strings.EqualFold(record.Name, name) && strings.TrimSpace(record.Content) == value {
+			desiredID = record.ID
+			break
+		}
+	}
+	if desiredID == "" {
+		if err := createDNSRecord(ctx, p.token, zoneID, "TXT", name, value); err != nil {
+			return fmt.Errorf("create replacement TXT record %s: %w", name, err)
+		}
+	}
+	for _, record := range records {
+		content := strings.TrimSpace(record.Content)
+		if !strings.EqualFold(record.Name, name) || !strings.HasPrefix(content, matchPrefix) || record.ID == desiredID {
+			continue
+		}
+		if err := deleteDNSRecord(ctx, p.token, zoneID, record.ID); err != nil {
+			return fmt.Errorf("delete replaced TXT record %s: %w", name, err)
 		}
 	}
 	return nil

--- a/portal/acme/embedded/provider.go
+++ b/portal/acme/embedded/provider.go
@@ -261,6 +261,17 @@ func (p *Provider) DeleteARecord(context.Context, string) error {
 	return nil
 }
 
+// DeleteARecordValue is a no-op because A answers are synthesized, not stored.
+func (p *Provider) DeleteARecordValue(_ context.Context, name, publicIPv4 string) error {
+	if p == nil {
+		return errors.New("embedded dns provider is nil")
+	}
+	if _, err := p.zoneHostname(name); err != nil {
+		return err
+	}
+	return utils.ValidateIPv4(publicIPv4)
+}
+
 func (p *Provider) EnsureTXTRecord(_ context.Context, name, value string) error {
 	if p == nil {
 		return errors.New("embedded dns provider is nil")
@@ -312,6 +323,46 @@ func (p *Provider) DeleteTXTRecords(_ context.Context, name, matchPrefix string)
 	} else {
 		p.txt[fqdn] = remaining
 	}
+	p.bumpSerialLocked()
+	return nil
+}
+
+// ReplaceTXTRecords atomically replaces TXT values with matchPrefix.
+func (p *Provider) ReplaceTXTRecords(_ context.Context, name, matchPrefix, value string) error {
+	if p == nil {
+		return errors.New("embedded dns provider is nil")
+	}
+	fqdn, err := p.zoneHostname(name)
+	if err != nil {
+		return err
+	}
+	matchPrefix = strings.TrimSpace(matchPrefix)
+	if matchPrefix == "" {
+		return errors.New("txt record match prefix is required")
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("txt record value is required")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	values := p.txt[fqdn]
+	matching := 0
+	desired := false
+	remaining := make([]string, 0, len(values)+1)
+	for _, existing := range values {
+		if strings.HasPrefix(existing, matchPrefix) {
+			matching++
+			desired = desired || existing == value
+			continue
+		}
+		remaining = append(remaining, existing)
+	}
+	if matching == 1 && desired {
+		return nil
+	}
+	p.txt[fqdn] = append(remaining, value)
 	p.bumpSerialLocked()
 	return nil
 }

--- a/portal/acme/ens.go
+++ b/portal/acme/ens.go
@@ -187,6 +187,13 @@ func (m *Manager) applyENSCommand(ctx context.Context, command ensDNSCommand) er
 		}
 	}
 	value := gaslessENSTXTPrefix + defaultENSGaslessResolver + " " + strings.TrimSpace(command.address)
+	// EnsureTXTRecord appends whenever the value differs, which DNS-01 needs and
+	// ENS does not: a hostname carries exactly one ENS1 record. Drop the previous
+	// one so an address change replaces it instead of stacking on top of it. The
+	// prefix keeps ACME challenge records out of scope.
+	if err := m.dns.DeleteTXTRecords(ctx, command.hostname, gaslessENSTXTPrefix); err != nil {
+		return err
+	}
 	if err := m.dns.EnsureTXTRecord(ctx, command.hostname, value); err != nil {
 		return err
 	}

--- a/portal/acme/ens.go
+++ b/portal/acme/ens.go
@@ -131,7 +131,10 @@ func (m *Manager) SyncENSGaslessHostname(ctx context.Context, hostname, address 
 }
 
 func (m *Manager) DeleteENSGaslessHostname(ctx context.Context, hostname string) error {
-	if m == nil || !m.cfg.ENSGaslessEnabled || utils.IsLocalRelayHost(m.cfg.BaseDomain) {
+	// Removal is deliberately not gated on ENSGaslessEnabled. Turning the feature
+	// off must still converge the zone; gating the delete path orphans every
+	// record the relay published, with no way back short of editing DNS by hand.
+	if m == nil || utils.IsLocalRelayHost(m.cfg.BaseDomain) {
 		return nil
 	}
 
@@ -203,7 +206,10 @@ func (m *Manager) applyENSCommand(ctx context.Context, command ensDNSCommand) er
 }
 
 func (m *Manager) reconcileTrackedENSGaslessHostnames(ctx context.Context) error {
-	if m == nil || !m.cfg.ENSGaslessEnabled || utils.IsLocalRelayHost(m.cfg.BaseDomain) {
+	// Removal is deliberately not gated on ENSGaslessEnabled. Turning the feature
+	// off must still converge the zone; gating the delete path orphans every
+	// record the relay published, with no way back short of editing DNS by hand.
+	if m == nil || utils.IsLocalRelayHost(m.cfg.BaseDomain) {
 		return nil
 	}
 

--- a/portal/acme/ens.go
+++ b/portal/acme/ens.go
@@ -2,11 +2,11 @@ package acme
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/gosuda/portal-tunnel/v2/portal/identity"
@@ -169,40 +169,45 @@ func (m *Manager) queueENSCommand(ctx context.Context, command ensDNSCommand) er
 
 func (m *Manager) applyENSCommand(ctx context.Context, command ensDNSCommand) error {
 	if command.remove {
+		tracked, err := m.trackedENSGaslessHostnames()
+		if err != nil {
+			return err
+		}
 		if err := m.dns.DeleteTXTRecords(ctx, command.hostname, gaslessENSTXTPrefix); err != nil {
 			return err
 		}
-		if err := m.dns.DeleteARecord(ctx, command.hostname); err != nil {
-			return err
+		if publicIP := tracked[command.hostname]; publicIP != "" {
+			if err := m.dns.DeleteARecordValue(ctx, command.hostname, publicIP); err != nil {
+				return err
+			}
 		}
-		return m.updateTrackedENSGaslessHostnames(func(hostnames []string) []string {
-			return slices.DeleteFunc(hostnames, func(hostname string) bool { return hostname == command.hostname })
+		return m.updateTrackedENSGaslessHostnames(func(hostnames map[string]string) {
+			delete(hostnames, command.hostname)
 		})
 	}
 
+	publicIP := ""
 	if command.hostname != m.cfg.BaseDomain {
-		publicIP, err := utils.ResolvePublicIPv4(ctx)
+		var err error
+		publicIP, err = utils.ResolvePublicIPv4(ctx)
 		if err != nil {
 			return fmt.Errorf("detect public ip: %w", err)
 		}
 		if err := m.dns.EnsureARecord(ctx, command.hostname, publicIP); err != nil {
 			return fmt.Errorf("ensure ens gasless A record for %s: %w", command.hostname, err)
 		}
+		if err := m.updateTrackedENSGaslessHostnames(func(hostnames map[string]string) {
+			hostnames[command.hostname] = publicIP
+		}); err != nil {
+			cleanupErr := m.dns.DeleteARecordValue(ctx, command.hostname, publicIP)
+			return errors.Join(fmt.Errorf("track ens gasless A record for %s: %w", command.hostname, err), cleanupErr)
+		}
 	}
 	value := gaslessENSTXTPrefix + defaultENSGaslessResolver + " " + strings.TrimSpace(command.address)
-	// EnsureTXTRecord appends whenever the value differs, which DNS-01 needs and
-	// ENS does not: a hostname carries exactly one ENS1 record. Drop the previous
-	// one so an address change replaces it instead of stacking on top of it. The
-	// prefix keeps ACME challenge records out of scope.
-	if err := m.dns.DeleteTXTRecords(ctx, command.hostname, gaslessENSTXTPrefix); err != nil {
+	if err := m.dns.ReplaceTXTRecords(ctx, command.hostname, gaslessENSTXTPrefix, value); err != nil {
 		return err
 	}
-	if err := m.dns.EnsureTXTRecord(ctx, command.hostname, value); err != nil {
-		return err
-	}
-	return m.updateTrackedENSGaslessHostnames(func(hostnames []string) []string {
-		return append(hostnames, command.hostname)
-	})
+	return nil
 }
 
 func (m *Manager) reconcileTrackedENSGaslessHostnames(ctx context.Context) error {
@@ -214,20 +219,20 @@ func (m *Manager) reconcileTrackedENSGaslessHostnames(ctx context.Context) error
 	}
 
 	var cleanupErr error
-	if err := m.updateTrackedENSGaslessHostnames(func(hostnames []string) []string {
-		remaining := hostnames[:0]
-		for _, hostname := range hostnames {
+	if err := m.updateTrackedENSGaslessHostnames(func(hostnames map[string]string) {
+		for hostname, publicIP := range hostnames {
 			if err := m.dns.DeleteTXTRecords(ctx, hostname, gaslessENSTXTPrefix); err != nil {
-				remaining = append(remaining, hostname)
 				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete ens gasless txt for %s: %w", hostname, err))
 				continue
 			}
-			if err := m.dns.DeleteARecord(ctx, hostname); err != nil {
-				remaining = append(remaining, hostname)
-				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete ens gasless A record for %s: %w", hostname, err))
+			if publicIP != "" {
+				if err := m.dns.DeleteARecordValue(ctx, hostname, publicIP); err != nil {
+					cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete ens gasless A record for %s: %w", hostname, err))
+					continue
+				}
 			}
+			delete(hostnames, hostname)
 		}
-		return remaining
 	}); err != nil {
 		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("persist ens gasless hostnames: %w", err))
 	}
@@ -240,28 +245,65 @@ func (m *Manager) syncTrackedENSGaslessHostARecords(ctx context.Context, publicI
 		return err
 	}
 	var syncErr error
-	for _, hostname := range hostnames {
+	updated := make(map[string]string)
+	for hostname := range hostnames {
 		if err := m.dns.EnsureARecord(ctx, hostname, publicIP); err != nil {
 			syncErr = errors.Join(syncErr, fmt.Errorf("ensure ens gasless A record for %s: %w", hostname, err))
+			continue
+		}
+		updated[hostname] = strings.TrimSpace(publicIP)
+	}
+	if len(updated) > 0 {
+		if err := m.updateTrackedENSGaslessHostnames(func(hostnames map[string]string) {
+			for hostname, managedIP := range updated {
+				hostnames[hostname] = managedIP
+			}
+		}); err != nil {
+			syncErr = errors.Join(syncErr, fmt.Errorf("persist ens gasless A records: %w", err))
 		}
 	}
 	return syncErr
 }
 
-func (m *Manager) trackedENSGaslessHostnames() ([]string, error) {
+func (m *Manager) trackedENSGaslessHostnames() (map[string]string, error) {
 	if m == nil {
 		return nil, nil
 	}
 
 	path := filepath.Join(m.cfg.KeyDir, ensGaslessHostnamesFileName)
-	var hostnames []string
-	if _, err := utils.ReadJSONFileIfExists(path, &hostnames); err != nil {
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return make(map[string]string), nil
+	}
+	if err != nil {
 		return nil, err
 	}
-	return utils.NormalizeChildHostnames(hostnames, m.cfg.BaseDomain), nil
+
+	tracked := make(map[string]string)
+	if err := json.Unmarshal(raw, &tracked); err != nil {
+		var legacy []string
+		if legacyErr := json.Unmarshal(raw, &legacy); legacyErr != nil {
+			return nil, err
+		}
+		for _, hostname := range utils.NormalizeChildHostnames(legacy, m.cfg.BaseDomain) {
+			tracked[hostname] = ""
+		}
+	}
+	normalized := make(map[string]string, len(tracked))
+	for hostname, publicIP := range tracked {
+		hostname = utils.NormalizeHostname(hostname)
+		if hostname == "" || hostname == m.cfg.BaseDomain || !utils.HostnameMatchesBaseDomain(hostname, m.cfg.BaseDomain) {
+			continue
+		}
+		if utils.ValidateIPv4(publicIP) != nil {
+			publicIP = ""
+		}
+		normalized[hostname] = strings.TrimSpace(publicIP)
+	}
+	return normalized, nil
 }
 
-func (m *Manager) updateTrackedENSGaslessHostnames(update func([]string) []string) error {
+func (m *Manager) updateTrackedENSGaslessHostnames(update func(map[string]string)) error {
 	if m == nil {
 		return nil
 	}
@@ -272,7 +314,7 @@ func (m *Manager) updateTrackedENSGaslessHostnames(update func([]string) []strin
 		return err
 	}
 	if update != nil {
-		hostnames = utils.NormalizeChildHostnames(update(hostnames), m.cfg.BaseDomain)
+		update(hostnames)
 	}
 	if len(hostnames) == 0 {
 		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/portal/acme/ens_test.go
+++ b/portal/acme/ens_test.go
@@ -2,12 +2,14 @@ package acme
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-acme/lego/v4/challenge"
 
@@ -18,13 +20,14 @@ import (
 // fakeZone models what the real providers do to a zone rather than which calls
 // they received, so a test can assert on the records an operator would see.
 //
-// EnsureTXTRecord appends when the value differs, matching cloudflare, njalla
-// and route53. DNS-01 depends on that, and it is also what lets ENS records
-// pile up, so a fake that replaced instead would hide the bug under test.
+// EnsureTXTRecord appends when the value differs, as DNS-01 requires, while
+// ReplaceTXTRecords models the explicit single-value ENS replacement contract.
 type fakeZone struct {
-	mu  sync.Mutex
-	txt map[string][]string
-	a   map[string]string
+	mu           sync.Mutex
+	txt          map[string][]string
+	a            map[string]string
+	txtMutations int
+	replaceErr   error
 }
 
 func newFakeZone() *fakeZone {
@@ -42,6 +45,18 @@ func (z *fakeZone) hasARecord(name string) bool {
 	defer z.mu.Unlock()
 	_, ok := z.a[name]
 	return ok
+}
+
+func (z *fakeZone) aValue(name string) string {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	return z.a[name]
+}
+
+func (z *fakeZone) txtMutationCount() int {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	return z.txtMutations
 }
 
 func (z *fakeZone) Name() string { return TypeEmbedded }
@@ -68,6 +83,15 @@ func (z *fakeZone) DeleteARecord(_ context.Context, name string) error {
 	return nil
 }
 
+func (z *fakeZone) DeleteARecordValue(_ context.Context, name, publicIPv4 string) error {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	if z.a[name] == publicIPv4 {
+		delete(z.a, name)
+	}
+	return nil
+}
+
 func (z *fakeZone) EnsureTXTRecord(_ context.Context, name, value string) error {
 	z.mu.Lock()
 	defer z.mu.Unlock()
@@ -75,6 +99,7 @@ func (z *fakeZone) EnsureTXTRecord(_ context.Context, name, value string) error 
 		return nil
 	}
 	z.txt[name] = append(z.txt[name], value)
+	z.txtMutations++
 	return nil
 }
 
@@ -88,10 +113,41 @@ func (z *fakeZone) DeleteTXTRecords(_ context.Context, name, matchPrefix string)
 		}
 	}
 	if len(kept) == 0 {
+		if len(z.txt[name]) > 0 {
+			z.txtMutations++
+		}
 		delete(z.txt, name)
 		return nil
 	}
+	if len(kept) != len(z.txt[name]) {
+		z.txtMutations++
+	}
 	z.txt[name] = kept
+	return nil
+}
+
+func (z *fakeZone) ReplaceTXTRecords(_ context.Context, name, matchPrefix, value string) error {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	if z.replaceErr != nil {
+		return z.replaceErr
+	}
+	matching := 0
+	desired := false
+	remaining := make([]string, 0, len(z.txt[name])+1)
+	for _, existing := range z.txt[name] {
+		if strings.HasPrefix(existing, matchPrefix) {
+			matching++
+			desired = desired || existing == value
+			continue
+		}
+		remaining = append(remaining, existing)
+	}
+	if matching == 1 && desired {
+		return nil
+	}
+	z.txt[name] = append(remaining, value)
+	z.txtMutations++
 	return nil
 }
 
@@ -153,6 +209,13 @@ func TestENSGaslessAddressChangeLeavesOneRecord(t *testing.T) {
 			t.Fatalf("applyENSCommand(%s): %v", address, err)
 		}
 	}
+	mutations := zone.txtMutationCount()
+	if err := manager.applyENSCommand(context.Background(), ensDNSCommand{hostname: host, address: second}); err != nil {
+		t.Fatalf("repeat applyENSCommand(%s): %v", second, err)
+	}
+	if got := zone.txtMutationCount(); got != mutations {
+		t.Fatalf("unchanged ENS record caused a provider mutation: %d -> %d", mutations, got)
+	}
 
 	ens := ensTXTValues(t, zone, host)
 	if len(ens) != 1 {
@@ -187,19 +250,24 @@ func TestENSGaslessLeaseRemovalRunsWhenDisabled(t *testing.T) {
 	if err := zone.EnsureARecord(ctx, host, "203.0.113.10"); err != nil {
 		t.Fatalf("seed A record: %v", err)
 	}
+	trackedPath := filepath.Join(manager.cfg.KeyDir, ensGaslessHostnamesFileName)
+	if err := utils.WriteJSONFile(trackedPath, map[string]string{host: "203.0.113.10"}, 0o600); err != nil {
+		t.Fatalf("seed tracked hostnames: %v", err)
+	}
+	manager.Start(ctx)
+	t.Cleanup(func() {
+		if err := manager.Stop(context.Background()); err != nil {
+			t.Errorf("Stop(): %v", err)
+		}
+	})
 
 	if err := manager.DeleteENSGaslessHostname(ctx, host); err != nil {
 		t.Fatalf("DeleteENSGaslessHostname(): %v", err)
 	}
 
-	var command ensDNSCommand
-	select {
-	case command = <-manager.ensCommands:
-	default:
-		t.Fatal("DeleteENSGaslessHostname() queued nothing; every published record would stay orphaned")
-	}
-	if err := manager.applyENSCommand(ctx, command); err != nil {
-		t.Fatalf("applyENSCommand(): %v", err)
+	deadline := time.Now().Add(2 * time.Second)
+	for (len(ensTXTValues(t, zone, host)) != 0 || zone.hasARecord(host)) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	if ens := ensTXTValues(t, zone, host); len(ens) != 0 {
@@ -217,7 +285,7 @@ func TestENSGaslessReconcileRunsWhenDisabled(t *testing.T) {
 
 	keyDir := t.TempDir()
 	trackedPath := filepath.Join(keyDir, ensGaslessHostnamesFileName)
-	if err := utils.WriteJSONFile(trackedPath, []string{host}, 0o600); err != nil {
+	if err := utils.WriteJSONFile(trackedPath, map[string]string{host: "203.0.113.11"}, 0o600); err != nil {
 		t.Fatalf("seed tracked hostnames: %v", err)
 	}
 
@@ -248,5 +316,71 @@ func TestENSGaslessReconcileRunsWhenDisabled(t *testing.T) {
 	}
 	if _, err := os.Stat(trackedPath); !os.IsNotExist(err) {
 		t.Fatalf("tracked hostnames file still present (stat err = %v), want it cleared", err)
+	}
+}
+
+func TestENSGaslessReconcilePreservesRepurposedARecord(t *testing.T) {
+	const host = "lease.portal.example.com"
+	keyDir := t.TempDir()
+	trackedPath := filepath.Join(keyDir, ensGaslessHostnamesFileName)
+	if err := utils.WriteJSONFile(trackedPath, map[string]string{host: "203.0.113.12"}, 0o600); err != nil {
+		t.Fatalf("seed tracked hostnames: %v", err)
+	}
+
+	zone := newFakeZone()
+	if err := zone.EnsureTXTRecord(context.Background(), host, gaslessENSTXTPrefix+"resolver 0x5555"); err != nil {
+		t.Fatalf("seed ENS record: %v", err)
+	}
+	if err := zone.EnsureARecord(context.Background(), host, "203.0.113.99"); err != nil {
+		t.Fatalf("seed repurposed A record: %v", err)
+	}
+	manager := newTestENSManager(Config{BaseDomain: "portal.example.com", KeyDir: keyDir}, zone)
+	if err := manager.reconcileTrackedENSGaslessHostnames(context.Background()); err != nil {
+		t.Fatalf("reconcileTrackedENSGaslessHostnames(): %v", err)
+	}
+	if got := zone.aValue(host); got != "203.0.113.99" {
+		t.Fatalf("repurposed A record = %q, want it preserved", got)
+	}
+}
+
+func TestENSGaslessReconcilePreservesLegacyUnownedARecord(t *testing.T) {
+	const host = "legacy.portal.example.com"
+	keyDir := t.TempDir()
+	trackedPath := filepath.Join(keyDir, ensGaslessHostnamesFileName)
+	if err := utils.WriteJSONFile(trackedPath, []string{host}, 0o600); err != nil {
+		t.Fatalf("seed legacy tracked hostnames: %v", err)
+	}
+
+	zone := newFakeZone()
+	if err := zone.EnsureARecord(context.Background(), host, "203.0.113.13"); err != nil {
+		t.Fatalf("seed A record: %v", err)
+	}
+	manager := newTestENSManager(Config{BaseDomain: "portal.example.com", KeyDir: keyDir}, zone)
+	if err := manager.reconcileTrackedENSGaslessHostnames(context.Background()); err != nil {
+		t.Fatalf("reconcileTrackedENSGaslessHostnames(): %v", err)
+	}
+	if got := zone.aValue(host); got != "203.0.113.13" {
+		t.Fatalf("legacy unowned A record = %q, want it preserved", got)
+	}
+}
+
+func TestENSGaslessReplacementFailurePreservesPreviousRecord(t *testing.T) {
+	const host = "portal.example.com"
+	zone := newFakeZone()
+	previous := gaslessENSTXTPrefix + defaultENSGaslessResolver + " 0x1111111111111111111111111111111111111111"
+	if err := zone.EnsureTXTRecord(context.Background(), host, previous); err != nil {
+		t.Fatalf("seed ENS record: %v", err)
+	}
+	zone.replaceErr = errors.New("provider unavailable")
+	manager := newTestENSManager(Config{BaseDomain: host, KeyDir: t.TempDir(), ENSGaslessEnabled: true}, zone)
+	err := manager.applyENSCommand(context.Background(), ensDNSCommand{
+		hostname: host,
+		address:  "0x2222222222222222222222222222222222222222",
+	})
+	if err == nil {
+		t.Fatal("applyENSCommand() error = nil, want provider failure")
+	}
+	if got := ensTXTValues(t, zone, host); !slices.Equal(got, []string{previous}) {
+		t.Fatalf("ENS records after failed replacement = %v, want %q", got, previous)
 	}
 }

--- a/portal/acme/ens_test.go
+++ b/portal/acme/ens_test.go
@@ -1,0 +1,166 @@
+package acme
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-acme/lego/v4/challenge"
+
+	"github.com/gosuda/portal-tunnel/v2/portal/acme/internal/dnsrecord"
+	"github.com/gosuda/portal-tunnel/v2/utils"
+)
+
+// fakeZone models what the real providers do to a zone rather than which calls
+// they received, so a test can assert on the records an operator would see.
+//
+// EnsureTXTRecord appends when the value differs, matching cloudflare, njalla
+// and route53. DNS-01 depends on that, and it is also what lets ENS records
+// pile up, so a fake that replaced instead would hide the bug under test.
+type fakeZone struct {
+	mu  sync.Mutex
+	txt map[string][]string
+	a   map[string]string
+}
+
+func newFakeZone() *fakeZone {
+	return &fakeZone{txt: map[string][]string{}, a: map[string]string{}}
+}
+
+func (z *fakeZone) txtValues(name string) []string {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	return append([]string(nil), z.txt[name]...)
+}
+
+func (z *fakeZone) hasARecord(name string) bool {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	_, ok := z.a[name]
+	return ok
+}
+
+func (z *fakeZone) Name() string { return TypeEmbedded }
+
+func (z *fakeZone) ChallengeProvider(context.Context) (challenge.Provider, error) {
+	return nil, nil
+}
+
+func (z *fakeZone) EnsureARecords(_ context.Context, baseDomain, publicIPv4 string) error {
+	return z.EnsureARecord(context.Background(), baseDomain, publicIPv4)
+}
+
+func (z *fakeZone) EnsureARecord(_ context.Context, name, publicIPv4 string) error {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	z.a[name] = publicIPv4
+	return nil
+}
+
+func (z *fakeZone) DeleteARecord(_ context.Context, name string) error {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	delete(z.a, name)
+	return nil
+}
+
+func (z *fakeZone) EnsureTXTRecord(_ context.Context, name, value string) error {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	if slices.Contains(z.txt[name], value) {
+		return nil
+	}
+	z.txt[name] = append(z.txt[name], value)
+	return nil
+}
+
+func (z *fakeZone) DeleteTXTRecords(_ context.Context, name, matchPrefix string) error {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	kept := z.txt[name][:0]
+	for _, value := range z.txt[name] {
+		if !strings.HasPrefix(value, matchPrefix) {
+			kept = append(kept, value)
+		}
+	}
+	if len(kept) == 0 {
+		delete(z.txt, name)
+		return nil
+	}
+	z.txt[name] = kept
+	return nil
+}
+
+func (z *fakeZone) EnsureHTTPSRecord(context.Context, string, dnsrecord.HTTPSRecord) error {
+	return nil
+}
+
+func (z *fakeZone) DeleteHTTPSRecord(context.Context, string) error { return nil }
+
+func (z *fakeZone) EnsureDNSSEC(context.Context, string) (string, string, string, error) {
+	return "", "", "", nil
+}
+
+func newTestENSManager(cfg Config, dns DNSProvider) *Manager {
+	cfg.BaseDomain = utils.NormalizeBaseDomain(cfg.BaseDomain)
+	return &Manager{
+		cfg:         cfg,
+		dns:         dns,
+		stopCh:      make(chan struct{}),
+		echCommands: make(chan echDNSCommand, 8),
+		ensCommands: make(chan ensDNSCommand, 8),
+		ensStatus:   utils.NewSnapshot(newENSStatus(cfg, dns)),
+	}
+}
+
+func ensTXTValues(t *testing.T, zone *fakeZone, name string) []string {
+	t.Helper()
+	var ens []string
+	for _, value := range zone.txtValues(name) {
+		if strings.HasPrefix(value, gaslessENSTXTPrefix) {
+			ens = append(ens, value)
+		}
+	}
+	return ens
+}
+
+// A hostname carries exactly one ENS1 record. Publishing a second address must
+// leave that one record holding the new address, not two records disagreeing.
+func TestENSGaslessAddressChangeLeavesOneRecord(t *testing.T) {
+	const host = "portal.example.com"
+	const challengeValue = "acme-challenge-token"
+
+	zone := newFakeZone()
+	if err := zone.EnsureTXTRecord(context.Background(), host, challengeValue); err != nil {
+		t.Fatalf("seed DNS-01 record: %v", err)
+	}
+
+	manager := newTestENSManager(Config{
+		BaseDomain:        host,
+		KeyDir:            t.TempDir(),
+		ENSGaslessEnabled: true,
+	}, zone)
+
+	first := "0x1111111111111111111111111111111111111111"
+	second := "0x2222222222222222222222222222222222222222"
+	for _, address := range []string{first, second} {
+		err := manager.applyENSCommand(context.Background(), ensDNSCommand{hostname: host, address: address})
+		if err != nil {
+			t.Fatalf("applyENSCommand(%s): %v", address, err)
+		}
+	}
+
+	ens := ensTXTValues(t, zone, host)
+	if len(ens) != 1 {
+		t.Fatalf("ENS1 records = %v, want exactly one", ens)
+	}
+	if !strings.HasSuffix(ens[0], second) {
+		t.Fatalf("ENS1 record = %q, want the current address %s", ens[0], second)
+	}
+
+	if !slices.Contains(zone.txtValues(host), challengeValue) {
+		t.Fatalf("TXT records = %v, want the DNS-01 record left untouched", zone.txtValues(host))
+	}
+}

--- a/portal/acme/ens_test.go
+++ b/portal/acme/ens_test.go
@@ -2,6 +2,8 @@ package acme
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -162,5 +164,89 @@ func TestENSGaslessAddressChangeLeavesOneRecord(t *testing.T) {
 
 	if !slices.Contains(zone.txtValues(host), challengeValue) {
 		t.Fatalf("TXT records = %v, want the DNS-01 record left untouched", zone.txtValues(host))
+	}
+}
+
+// Disabling the feature must let the relay withdraw what it published; gating
+// removal on the same flag leaves the zone frozen with no path back.
+func TestENSGaslessLeaseRemovalRunsWhenDisabled(t *testing.T) {
+	const host = "lease.portal.example.com"
+
+	zone := newFakeZone()
+	manager := newTestENSManager(Config{
+		BaseDomain:        "portal.example.com",
+		KeyDir:            t.TempDir(),
+		ENSGaslessEnabled: false,
+	}, zone)
+
+	// State a previous run left behind while the feature was still enabled.
+	ctx := context.Background()
+	if err := zone.EnsureTXTRecord(ctx, host, gaslessENSTXTPrefix+"resolver 0x3333"); err != nil {
+		t.Fatalf("seed ENS record: %v", err)
+	}
+	if err := zone.EnsureARecord(ctx, host, "203.0.113.10"); err != nil {
+		t.Fatalf("seed A record: %v", err)
+	}
+
+	if err := manager.DeleteENSGaslessHostname(ctx, host); err != nil {
+		t.Fatalf("DeleteENSGaslessHostname(): %v", err)
+	}
+
+	var command ensDNSCommand
+	select {
+	case command = <-manager.ensCommands:
+	default:
+		t.Fatal("DeleteENSGaslessHostname() queued nothing; every published record would stay orphaned")
+	}
+	if err := manager.applyENSCommand(ctx, command); err != nil {
+		t.Fatalf("applyENSCommand(): %v", err)
+	}
+
+	if ens := ensTXTValues(t, zone, host); len(ens) != 0 {
+		t.Fatalf("ENS1 records = %v, want them withdrawn", ens)
+	}
+	if zone.hasARecord(host) {
+		t.Fatalf("A record for %s survived the removal", host)
+	}
+}
+
+// The startup reconcile is the only thing that reaches hostnames tracked by an
+// earlier run, so it has to keep running after the feature is switched off.
+func TestENSGaslessReconcileRunsWhenDisabled(t *testing.T) {
+	const host = "lease.portal.example.com"
+
+	keyDir := t.TempDir()
+	trackedPath := filepath.Join(keyDir, ensGaslessHostnamesFileName)
+	if err := utils.WriteJSONFile(trackedPath, []string{host}, 0o600); err != nil {
+		t.Fatalf("seed tracked hostnames: %v", err)
+	}
+
+	ctx := context.Background()
+	zone := newFakeZone()
+	if err := zone.EnsureTXTRecord(ctx, host, gaslessENSTXTPrefix+"resolver 0x4444"); err != nil {
+		t.Fatalf("seed ENS record: %v", err)
+	}
+	if err := zone.EnsureARecord(ctx, host, "203.0.113.11"); err != nil {
+		t.Fatalf("seed A record: %v", err)
+	}
+
+	manager := newTestENSManager(Config{
+		BaseDomain:        "portal.example.com",
+		KeyDir:            keyDir,
+		ENSGaslessEnabled: false,
+	}, zone)
+
+	if err := manager.reconcileTrackedENSGaslessHostnames(ctx); err != nil {
+		t.Fatalf("reconcileTrackedENSGaslessHostnames(): %v", err)
+	}
+
+	if ens := ensTXTValues(t, zone, host); len(ens) != 0 {
+		t.Fatalf("ENS1 records = %v, want them withdrawn", ens)
+	}
+	if zone.hasARecord(host) {
+		t.Fatalf("A record for %s survived the reconcile", host)
+	}
+	if _, err := os.Stat(trackedPath); !os.IsNotExist(err) {
+		t.Fatalf("tracked hostnames file still present (stat err = %v), want it cleared", err)
 	}
 }

--- a/portal/acme/gcloud/provider.go
+++ b/portal/acme/gcloud/provider.go
@@ -165,6 +165,56 @@ func (p *Provider) DeleteARecord(ctx context.Context, name string) error {
 	return nil
 }
 
+// DeleteARecordValue removes publicIPv4 while preserving other A values.
+func (p *Provider) DeleteARecordValue(ctx context.Context, name, publicIPv4 string) error {
+	if p == nil {
+		return errors.New("gcloud provider is nil")
+	}
+	name = utils.NormalizeHostname(name)
+	if name == "" {
+		return errors.New("record name is required")
+	}
+	if err := utils.ValidateIPv4(publicIPv4); err != nil {
+		return err
+	}
+	publicIPv4 = strings.TrimSpace(publicIPv4)
+
+	service, runtimeCfg, zone, err := p.newService(ctx, name)
+	if err != nil {
+		return err
+	}
+	existing, err := listRecordSets(ctx, service, runtimeCfg.ProjectID, zone.Name, name, "A")
+	if err != nil {
+		return fmt.Errorf("list gcloud A records %s: %w", name, err)
+	}
+	remaining := make([]string, 0, len(existing))
+	removed := false
+	for _, recordSet := range existing {
+		for _, value := range recordSet.Rrdatas {
+			if strings.TrimSpace(value) == publicIPv4 {
+				removed = true
+				continue
+			}
+			remaining = append(remaining, value)
+		}
+	}
+	if !removed {
+		return nil
+	}
+	if len(remaining) == 0 {
+		if err := applyChange(ctx, service, runtimeCfg.ProjectID, zone.Name, &dns.Change{Deletions: existing}); err != nil {
+			return fmt.Errorf("delete gcloud A record %s value %s: %w", name, publicIPv4, err)
+		}
+		return nil
+	}
+	if err := replaceRecordSet(ctx, service, runtimeCfg.ProjectID, zone.Name, existing, &dns.ResourceRecordSet{
+		Name: fqdn(name), Type: "A", Ttl: recordTTL(existing), Rrdatas: remaining,
+	}); err != nil {
+		return fmt.Errorf("replace gcloud A record %s: %w", name, err)
+	}
+	return nil
+}
+
 func (p *Provider) EnsureTXTRecord(ctx context.Context, name, value string) error {
 	if p == nil {
 		return errors.New("gcloud provider is nil")
@@ -285,6 +335,69 @@ func (p *Provider) DeleteTXTRecords(ctx context.Context, name, matchPrefix strin
 		Rrdatas: remaining,
 	}); err != nil {
 		return fmt.Errorf("delete gcloud TXT records %s: %w", name, err)
+	}
+	return nil
+}
+
+// ReplaceTXTRecords atomically replaces TXT values with matchPrefix.
+func (p *Provider) ReplaceTXTRecords(ctx context.Context, name, matchPrefix, value string) error {
+	if p == nil {
+		return errors.New("gcloud provider is nil")
+	}
+	name = utils.NormalizeHostname(name)
+	if name == "" {
+		return errors.New("record name is required")
+	}
+	matchPrefix = strings.TrimSpace(matchPrefix)
+	if matchPrefix == "" {
+		return errors.New("txt record match prefix is required")
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("txt record value is required")
+	}
+
+	service, runtimeCfg, zone, err := p.newService(ctx, name)
+	if err != nil {
+		return err
+	}
+	existing, err := listRecordSets(ctx, service, runtimeCfg.ProjectID, zone.Name, name, "TXT")
+	if err != nil {
+		return fmt.Errorf("list gcloud TXT records %s: %w", name, err)
+	}
+	values := make([]string, 0, len(existing)+1)
+	seen := make(map[string]struct{}, len(existing)+1)
+	matching := 0
+	for _, recordSet := range existing {
+		for _, raw := range recordSet.Rrdatas {
+			normalized := dnsrecord.TXTContent(raw)
+			if strings.HasPrefix(normalized, matchPrefix) {
+				matching++
+				continue
+			}
+			if normalized == "" {
+				continue
+			}
+			if _, ok := seen[normalized]; !ok {
+				seen[normalized] = struct{}{}
+				values = append(values, normalized)
+			}
+		}
+	}
+	if matching == 1 {
+		for _, recordSet := range existing {
+			for _, raw := range recordSet.Rrdatas {
+				if dnsrecord.TXTContent(raw) == value {
+					return nil
+				}
+			}
+		}
+	}
+	values = append(values, value)
+	if err := replaceRecordSet(ctx, service, runtimeCfg.ProjectID, zone.Name, existing, &dns.ResourceRecordSet{
+		Name: fqdn(name), Type: "TXT", Ttl: recordTTL(existing), Rrdatas: values,
+	}); err != nil {
+		return fmt.Errorf("replace gcloud TXT records %s: %w", name, err)
 	}
 	return nil
 }

--- a/portal/acme/hetzner/provider.go
+++ b/portal/acme/hetzner/provider.go
@@ -121,6 +121,28 @@ func (p *Provider) DeleteARecord(ctx context.Context, name string) error {
 	return nil
 }
 
+// DeleteARecordValue removes publicIPv4 while preserving other A values.
+func (p *Provider) DeleteARecordValue(ctx context.Context, name, publicIPv4 string) error {
+	if p == nil {
+		return errors.New("hetzner provider is nil")
+	}
+	name = utils.NormalizeHostname(name)
+	if name == "" {
+		return errors.New("record name is required")
+	}
+	if err := utils.ValidateIPv4(publicIPv4); err != nil {
+		return err
+	}
+	client, zone, err := p.clientAndZone(ctx, name)
+	if err != nil {
+		return err
+	}
+	if err := deleteRecordValue(ctx, client, zone, name, hcloud.ZoneRRSetTypeA, strings.TrimSpace(publicIPv4)); err != nil {
+		return fmt.Errorf("delete hetzner A record %s value %s: %w", name, publicIPv4, err)
+	}
+	return nil
+}
+
 func (p *Provider) EnsureTXTRecord(ctx context.Context, name, value string) error {
 	if p == nil {
 		return errors.New("hetzner provider is nil")
@@ -163,6 +185,33 @@ func (p *Provider) DeleteTXTRecords(ctx context.Context, name, matchPrefix strin
 	}
 	if err := deleteTXTRecords(ctx, client, zone, name, matchPrefix); err != nil {
 		return fmt.Errorf("delete hetzner TXT records %s: %w", name, err)
+	}
+	return nil
+}
+
+// ReplaceTXTRecords atomically replaces TXT values with matchPrefix.
+func (p *Provider) ReplaceTXTRecords(ctx context.Context, name, matchPrefix, value string) error {
+	if p == nil {
+		return errors.New("hetzner provider is nil")
+	}
+	name = utils.NormalizeHostname(name)
+	if name == "" {
+		return errors.New("record name is required")
+	}
+	matchPrefix = strings.TrimSpace(matchPrefix)
+	if matchPrefix == "" {
+		return errors.New("txt record match prefix is required")
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("txt record value is required")
+	}
+	client, zone, err := p.clientAndZone(ctx, name)
+	if err != nil {
+		return err
+	}
+	if err := replaceTXTRecords(ctx, client, zone, name, matchPrefix, value); err != nil {
+		return fmt.Errorf("replace hetzner TXT records %s: %w", name, err)
 	}
 	return nil
 }
@@ -388,6 +437,38 @@ func deleteRRSet(ctx context.Context, client *hcloud.Client, zone *hcloud.Zone, 
 	return waitAction(ctx, client, result.Action)
 }
 
+func deleteRecordValue(ctx context.Context, client *hcloud.Client, zone *hcloud.Zone, fqdn string, recordType hcloud.ZoneRRSetType, value string) error {
+	recordName, err := relativeRecordName(fqdn, zone)
+	if err != nil {
+		return err
+	}
+	existing, _, err := client.Zone.GetRRSetByNameAndType(ctx, zone, recordName, recordType)
+	if err != nil || existing == nil {
+		return err
+	}
+	remaining := make([]hcloud.ZoneRRSetRecord, 0, len(existing.Records))
+	for _, record := range existing.Records {
+		if strings.TrimSpace(record.Value) != value {
+			remaining = append(remaining, record)
+		}
+	}
+	if len(remaining) == len(existing.Records) {
+		return nil
+	}
+	if len(remaining) == 0 {
+		result, _, err := client.Zone.DeleteRRSet(ctx, existing)
+		if err != nil {
+			return err
+		}
+		return waitAction(ctx, client, result.Action)
+	}
+	action, _, err := client.Zone.SetRRSetRecords(ctx, existing, hcloud.ZoneRRSetSetRecordsOpts{Records: remaining})
+	if err != nil {
+		return err
+	}
+	return waitAction(ctx, client, action)
+}
+
 func deleteTXTRecords(ctx context.Context, client *hcloud.Client, zone *hcloud.Zone, fqdn, matchPrefix string) error {
 	recordName, err := relativeRecordName(fqdn, zone)
 	if err != nil {
@@ -419,6 +500,50 @@ func deleteTXTRecords(ctx context.Context, client *hcloud.Client, zone *hcloud.Z
 		return waitAction(ctx, client, result.Action)
 	}
 
+	action, _, err := client.Zone.SetRRSetRecords(ctx, existing, hcloud.ZoneRRSetSetRecordsOpts{Records: remaining})
+	if err != nil {
+		return err
+	}
+	return waitAction(ctx, client, action)
+}
+
+func replaceTXTRecords(ctx context.Context, client *hcloud.Client, zone *hcloud.Zone, fqdn, matchPrefix, value string) error {
+	recordName, err := relativeRecordName(fqdn, zone)
+	if err != nil {
+		return err
+	}
+	existing, _, err := client.Zone.GetRRSetByNameAndType(ctx, zone, recordName, hcloud.ZoneRRSetTypeTXT)
+	if err != nil {
+		return err
+	}
+	formatted := zoneutil.FormatTXTRecord(value)
+	if existing == nil {
+		ttl := defaultRecordTTL
+		result, _, err := client.Zone.CreateRRSet(ctx, zone, hcloud.ZoneRRSetCreateOpts{
+			Name: recordName, Type: hcloud.ZoneRRSetTypeTXT, TTL: &ttl,
+			Records: []hcloud.ZoneRRSetRecord{{Value: formatted}},
+		})
+		if err != nil {
+			return err
+		}
+		return waitAction(ctx, client, result.Action)
+	}
+	remaining := make([]hcloud.ZoneRRSetRecord, 0, len(existing.Records)+1)
+	matching := 0
+	desired := false
+	for _, record := range existing.Records {
+		content := txtContent(record.Value)
+		if strings.HasPrefix(content, matchPrefix) {
+			matching++
+			desired = desired || content == value
+			continue
+		}
+		remaining = append(remaining, record)
+	}
+	if matching == 1 && desired {
+		return nil
+	}
+	remaining = append(remaining, hcloud.ZoneRRSetRecord{Value: formatted})
 	action, _, err := client.Zone.SetRRSetRecords(ctx, existing, hcloud.ZoneRRSetSetRecordsOpts{Records: remaining})
 	if err != nil {
 		return err

--- a/portal/acme/njalla/provider.go
+++ b/portal/acme/njalla/provider.go
@@ -125,6 +125,38 @@ func (p *Provider) DeleteARecord(ctx context.Context, name string) error {
 	return nil
 }
 
+// DeleteARecordValue removes only A records that still contain publicIPv4.
+func (p *Provider) DeleteARecordValue(ctx context.Context, name, publicIPv4 string) error {
+	if p == nil {
+		return errors.New("njalla provider is nil")
+	}
+	name = utils.NormalizeHostname(name)
+	if name == "" {
+		return errors.New("record name is required")
+	}
+	if err := utils.ValidateIPv4(publicIPv4); err != nil {
+		return err
+	}
+	client, zone, err := p.clientAndZone(ctx, name)
+	if err != nil {
+		return err
+	}
+	records, err := listRecords(ctx, client, zone, name, "A")
+	if err != nil {
+		return err
+	}
+	publicIPv4 = strings.TrimSpace(publicIPv4)
+	for _, record := range records {
+		if strings.TrimSpace(record.Content) != publicIPv4 {
+			continue
+		}
+		if err := client.removeRecord(ctx, record.ID.String(), zone); err != nil {
+			return fmt.Errorf("delete njalla A record %s value %s: %w", name, publicIPv4, err)
+		}
+	}
+	return nil
+}
+
 func (p *Provider) EnsureTXTRecord(ctx context.Context, name, value string) error {
 	if p == nil {
 		return errors.New("njalla provider is nil")
@@ -167,6 +199,33 @@ func (p *Provider) DeleteTXTRecords(ctx context.Context, name, matchPrefix strin
 	}
 	if err := deleteRecords(ctx, client, zone, name, "TXT", matchPrefix); err != nil {
 		return fmt.Errorf("delete njalla TXT records %s: %w", name, err)
+	}
+	return nil
+}
+
+// ReplaceTXTRecords creates the replacement before deleting matching old values.
+func (p *Provider) ReplaceTXTRecords(ctx context.Context, name, matchPrefix, value string) error {
+	if p == nil {
+		return errors.New("njalla provider is nil")
+	}
+	name = utils.NormalizeHostname(name)
+	if name == "" {
+		return errors.New("record name is required")
+	}
+	matchPrefix = strings.TrimSpace(matchPrefix)
+	if matchPrefix == "" {
+		return errors.New("txt record match prefix is required")
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("txt record value is required")
+	}
+	client, zone, err := p.clientAndZone(ctx, name)
+	if err != nil {
+		return err
+	}
+	if err := replaceTXTRecords(ctx, client, zone, name, matchPrefix, value); err != nil {
+		return fmt.Errorf("replace njalla TXT records %s: %w", name, err)
 	}
 	return nil
 }
@@ -355,6 +414,40 @@ func deleteRecords(ctx context.Context, client *apiClient, zone, fqdn, recordTyp
 	}
 	for _, record := range existing {
 		if matchPrefix != "" && !strings.HasPrefix(dnsrecord.TXTContent(record.Content), matchPrefix) {
+			continue
+		}
+		if err := client.removeRecord(ctx, record.ID.String(), zone); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func replaceTXTRecords(ctx context.Context, client *apiClient, zone, fqdn, matchPrefix, value string) error {
+	recordName, err := dnsrecord.RelativeName("njalla", fqdn, zone)
+	if err != nil {
+		return err
+	}
+	existing, err := listRecords(ctx, client, zone, fqdn, "TXT")
+	if err != nil {
+		return err
+	}
+	desiredID := ""
+	for _, record := range existing {
+		if dnsrecord.TXTContent(record.Content) == value {
+			desiredID = record.ID.String()
+			break
+		}
+	}
+	if desiredID == "" {
+		if _, err := client.addRecord(ctx, record{
+			Domain: zone, Name: recordName, Type: "TXT", TTL: defaultRecordTTL, Content: value,
+		}); err != nil {
+			return err
+		}
+	}
+	for _, record := range existing {
+		if record.ID.String() == desiredID || !strings.HasPrefix(dnsrecord.TXTContent(record.Content), matchPrefix) {
 			continue
 		}
 		if err := client.removeRecord(ctx, record.ID.String(), zone); err != nil {

--- a/portal/acme/provider.go
+++ b/portal/acme/provider.go
@@ -36,8 +36,12 @@ type DNSProvider interface {
 	EnsureARecords(ctx context.Context, baseDomain, publicIPv4 string) error
 	EnsureARecord(ctx context.Context, name, publicIPv4 string) error
 	DeleteARecord(ctx context.Context, name string) error
+	// DeleteARecordValue preserves the record when its value no longer matches.
+	DeleteARecordValue(ctx context.Context, name, publicIPv4 string) error
 	EnsureTXTRecord(ctx context.Context, name, value string) error
 	DeleteTXTRecords(ctx context.Context, name, matchPrefix string) error
+	// ReplaceTXTRecords leaves an existing matching value intact if replacement fails.
+	ReplaceTXTRecords(ctx context.Context, name, matchPrefix, value string) error
 	EnsureHTTPSRecord(ctx context.Context, name string, record dnsrecord.HTTPSRecord) error
 	DeleteHTTPSRecord(ctx context.Context, name string) error
 	EnsureDNSSEC(ctx context.Context, baseDomain string) (state, dsRecord, message string, err error)

--- a/portal/acme/route53/provider.go
+++ b/portal/acme/route53/provider.go
@@ -168,6 +168,53 @@ func (p *Provider) DeleteARecord(ctx context.Context, name string) error {
 	return nil
 }
 
+// DeleteARecordValue removes publicIPv4 while preserving other A values.
+func (p *Provider) DeleteARecordValue(ctx context.Context, name, publicIPv4 string) error {
+	if p == nil {
+		return errors.New("route53 provider is nil")
+	}
+	name = utils.NormalizeHostname(name)
+	if name == "" {
+		return errors.New("record name is required")
+	}
+	if err := utils.ValidateIPv4(publicIPv4); err != nil {
+		return err
+	}
+	client, err := newClient(ctx, p.cfg)
+	if err != nil {
+		return err
+	}
+	hostedZoneID, err := p.findHostedZoneID(ctx, client, name)
+	if err != nil {
+		return err
+	}
+	recordSet, err := getRecordSet(ctx, client, hostedZoneID, name, route53types.RRTypeA)
+	if err != nil || recordSet == nil {
+		return err
+	}
+	publicIPv4 = strings.TrimSpace(publicIPv4)
+	remaining := make([]string, 0, len(recordSet.ResourceRecords))
+	for _, record := range recordSet.ResourceRecords {
+		value := aws.ToString(record.Value)
+		if strings.TrimSpace(value) != publicIPv4 {
+			remaining = append(remaining, value)
+		}
+	}
+	if len(remaining) == len(recordSet.ResourceRecords) {
+		return nil
+	}
+	if len(remaining) == 0 {
+		if err := deleteRecordSet(ctx, client, hostedZoneID, recordSet, "Managed by Portal ENS cleanup"); err != nil {
+			return fmt.Errorf("delete route53 A record %s value %s: %w", name, publicIPv4, err)
+		}
+		return nil
+	}
+	if err := upsertRecord(ctx, client, hostedZoneID, name, route53types.RRTypeA, remaining, "Managed by Portal ENS cleanup"); err != nil {
+		return fmt.Errorf("replace route53 A record %s: %w", name, err)
+	}
+	return nil
+}
+
 func (p *Provider) EnsureTXTRecord(ctx context.Context, name, value string) error {
 	if p == nil {
 		return errors.New("route53 provider is nil")
@@ -220,6 +267,37 @@ func (p *Provider) DeleteTXTRecords(ctx context.Context, name, matchPrefix strin
 	}
 	if err := deleteTXTRecords(ctx, client, hostedZoneID, name, matchPrefix); err != nil {
 		return fmt.Errorf("delete route53 TXT records %s: %w", name, err)
+	}
+	return nil
+}
+
+// ReplaceTXTRecords atomically replaces TXT values with matchPrefix.
+func (p *Provider) ReplaceTXTRecords(ctx context.Context, name, matchPrefix, value string) error {
+	if p == nil {
+		return errors.New("route53 provider is nil")
+	}
+	name = utils.NormalizeHostname(name)
+	if name == "" {
+		return errors.New("record name is required")
+	}
+	matchPrefix = strings.TrimSpace(matchPrefix)
+	if matchPrefix == "" {
+		return errors.New("txt record match prefix is required")
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("txt record value is required")
+	}
+	client, err := newClient(ctx, p.cfg)
+	if err != nil {
+		return err
+	}
+	hostedZoneID, err := p.findHostedZoneID(ctx, client, name)
+	if err != nil {
+		return err
+	}
+	if err := replaceTXTRecords(ctx, client, hostedZoneID, name, matchPrefix, value); err != nil {
+		return fmt.Errorf("replace route53 TXT records %s: %w", name, err)
 	}
 	return nil
 }
@@ -474,6 +552,34 @@ func deleteTXTRecords(ctx context.Context, client *awsroute53.Client, hostedZone
 		return deleteRecordSet(ctx, client, hostedZoneID, recordSet, "Managed by Portal ENS cleanup")
 	}
 	return upsertRecord(ctx, client, hostedZoneID, name, route53types.RRTypeTxt, remaining, "Managed by Portal ENS cleanup")
+}
+
+func replaceTXTRecords(ctx context.Context, client *awsroute53.Client, hostedZoneID, name, matchPrefix, value string) error {
+	recordSet, err := getTXTRecordSet(ctx, client, hostedZoneID, name)
+	if err != nil {
+		return err
+	}
+	if recordSet == nil {
+		return upsertTXTRecord(ctx, client, hostedZoneID, name, value)
+	}
+	remaining := make([]string, 0, len(recordSet.ResourceRecords)+1)
+	matching := 0
+	desired := false
+	for _, record := range recordSet.ResourceRecords {
+		raw := aws.ToString(record.Value)
+		content := dnsrecord.TXTContent(raw)
+		if strings.HasPrefix(content, matchPrefix) {
+			matching++
+			desired = desired || content == value
+			continue
+		}
+		remaining = append(remaining, raw)
+	}
+	if matching == 1 && desired {
+		return nil
+	}
+	remaining = append(remaining, route53TXTValue(value))
+	return upsertRecord(ctx, client, hostedZoneID, name, route53types.RRTypeTxt, remaining, "Managed by Portal ENS")
 }
 
 func upsertRecord(ctx context.Context, client *awsroute53.Client, hostedZoneID, name string, recordType route53types.RRType, values []string, comment string) error {

--- a/portal/acme/vultr/provider.go
+++ b/portal/acme/vultr/provider.go
@@ -123,6 +123,38 @@ func (p *Provider) DeleteARecord(ctx context.Context, name string) error {
 	return nil
 }
 
+// DeleteARecordValue removes only A records that still contain publicIPv4.
+func (p *Provider) DeleteARecordValue(ctx context.Context, name, publicIPv4 string) error {
+	if p == nil {
+		return errors.New("vultr provider is nil")
+	}
+	name = utils.NormalizeHostname(name)
+	if name == "" {
+		return errors.New("record name is required")
+	}
+	if err := utils.ValidateIPv4(publicIPv4); err != nil {
+		return err
+	}
+	client, zone, err := p.clientAndZone(ctx, name)
+	if err != nil {
+		return err
+	}
+	records, err := listRecords(ctx, client, zone, name, "A")
+	if err != nil {
+		return err
+	}
+	publicIPv4 = strings.TrimSpace(publicIPv4)
+	for _, record := range records {
+		if strings.TrimSpace(record.Data) != publicIPv4 {
+			continue
+		}
+		if err := client.DomainRecord.Delete(ctx, zone, record.ID); err != nil {
+			return fmt.Errorf("delete vultr A record %s value %s: %w", name, publicIPv4, err)
+		}
+	}
+	return nil
+}
+
 func (p *Provider) EnsureTXTRecord(ctx context.Context, name, value string) error {
 	if p == nil {
 		return errors.New("vultr provider is nil")
@@ -165,6 +197,33 @@ func (p *Provider) DeleteTXTRecords(ctx context.Context, name, matchPrefix strin
 	}
 	if err := deleteRecords(ctx, client, zone, name, "TXT", matchPrefix); err != nil {
 		return fmt.Errorf("delete vultr TXT records %s: %w", name, err)
+	}
+	return nil
+}
+
+// ReplaceTXTRecords creates the replacement before deleting matching old values.
+func (p *Provider) ReplaceTXTRecords(ctx context.Context, name, matchPrefix, value string) error {
+	if p == nil {
+		return errors.New("vultr provider is nil")
+	}
+	name = utils.NormalizeHostname(name)
+	if name == "" {
+		return errors.New("record name is required")
+	}
+	matchPrefix = strings.TrimSpace(matchPrefix)
+	if matchPrefix == "" {
+		return errors.New("txt record match prefix is required")
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("txt record value is required")
+	}
+	client, zone, err := p.clientAndZone(ctx, name)
+	if err != nil {
+		return err
+	}
+	if err := replaceTXTRecords(ctx, client, zone, name, matchPrefix, value); err != nil {
+		return fmt.Errorf("replace vultr TXT records %s: %w", name, err)
 	}
 	return nil
 }
@@ -393,6 +452,40 @@ func deleteRecords(ctx context.Context, client *govultr.Client, zone, fqdn, reco
 	}
 	for _, record := range existing {
 		if matchPrefix != "" && !strings.HasPrefix(dnsrecord.TXTContent(record.Data), matchPrefix) {
+			continue
+		}
+		if err := client.DomainRecord.Delete(ctx, zone, record.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func replaceTXTRecords(ctx context.Context, client *govultr.Client, zone, fqdn, matchPrefix, value string) error {
+	recordName, err := dnsrecord.RelativeName("vultr", fqdn, zone)
+	if err != nil {
+		return err
+	}
+	existing, err := listRecords(ctx, client, zone, fqdn, "TXT")
+	if err != nil {
+		return err
+	}
+	desiredID := ""
+	for _, record := range existing {
+		if dnsrecord.TXTContent(record.Data) == value {
+			desiredID = record.ID
+			break
+		}
+	}
+	if desiredID == "" {
+		if _, _, err := client.DomainRecord.Create(ctx, zone, &govultr.DomainRecordCreateReq{
+			Name: recordName, Type: "TXT", Data: value, TTL: defaultRecordTTL,
+		}); err != nil {
+			return err
+		}
+	}
+	for _, record := range existing {
+		if record.ID == desiredID || !strings.HasPrefix(dnsrecord.TXTContent(record.Data), matchPrefix) {
 			continue
 		}
 		if err := client.DomainRecord.Delete(ctx, zone, record.ID); err != nil {


### PR DESCRIPTION
Fixes two defects in ENS gasless DNS record management, found while auditing a
relay's Cloudflare zone that had accumulated records nothing would ever remove.

Both are in `portal/acme/ens.go`. They are independent, so the commits are
separate; they share a test fixture, which is why they arrive as one PR.

## Replace the ENS1 record instead of appending (#374)

`EnsureTXTRecord` appends whenever the value differs. DNS-01 depends on that,
because several challenge values must coexist on one name. ENS does not: a
hostname carries exactly one `ENS1 ` record. Every gasless address change left
the previous record in place and added another, so the observed zone advertised
three `ENS1 ` records on the relay base hostname, two of them stale.

Nothing removed them either. `DeleteENSGaslessHostname` skips the base domain
outright, and `NormalizeChildHostnames` excludes it from the tracked list, so
the base hostname is reachable by neither cleanup path.

The fix deletes the prefixed records before ensuring the new value.
`DeleteTXTRecords(name, matchPrefix)` already exists on every provider and the
remove branch of the same function already uses it, so this adds no provider
surface. Scoping to the `ENS1 ` prefix leaves DNS-01 records untouched, which
the test asserts.

## Let cleanup run after the feature is disabled (#373)

`DeleteENSGaslessHostname` and `reconcileTrackedENSGaslessHostnames` both
returned early on `ENSGaslessEnabled` — the same flag that gates publication.
Turning the feature off froze the zone rather than converging it:

- the lease janitor reaches DNS cleanup through
  `deleteDNS` -> `DeleteENSGaslessHostname`, so every expiring lease became a
  no-op
- the startup reconcile that clears hostnames tracked by an earlier run stopped
  running as well

The observed relay had `ENS_GASLESS_ENABLED=false` and still carried TXT and A
records for leases that had expired weeks earlier.

Publication stays gated; removal no longer is. The tracked-hostname file records
exactly what the relay created, so cleanup has what it needs regardless of the
current flag value.

Note for operators already in this state: the orphans clear on the next relay
start, when the reconcile runs. Records on the base hostname are not tracked and
still need a manual pass.

## Tests

`portal/acme/ens_test.go` adds a `fakeZone` that models what the real providers
do to a zone. Its `EnsureTXTRecord` appends when the value differs, matching
cloudflare, njalla and route53 — a fake that replaced instead would hide the
first defect entirely.

The assertions are on the records left behind, not on the call sequence, so a
different correct implementation still passes:

- `TestENSGaslessAddressChangeLeavesOneRecord` — two publications with different
  addresses leave exactly one `ENS1 ` record holding the newer address, and the
  seeded DNS-01 record survives
- `TestENSGaslessLeaseRemovalRunsWhenDisabled` — with the flag off, the queued
  removal is applied and both the TXT and A records are withdrawn
- `TestENSGaslessReconcileRunsWhenDisabled` — with the flag off, the startup
  reconcile withdraws a previous run's records and clears the tracked file

All three fail on `main` and pass here. Each commit builds and tests green on
its own; `go vet ./...` and the full suite pass.
