### PR TITLE
fix(lease): reverse endpoint에 실제 SNI 포트 반영

### DIFF
--- a/portal/lease.go
+++ b/portal/lease.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -52,6 +53,20 @@ type leaseRegistry struct {
 	mu       sync.RWMutex
 }
 
+// buildReverseURL derives the /sdk/connect endpoint the tunnel dials back to for
+// the reverse session. It reuses the issuer origin but forces the relay's own SNI
+// port so the advertised host always matches the relay the tunnel connected to —
+// even when the operator's PORTAL_URL omits a non-default SNI port. When the issuer
+// already carries a port, that port is trusted as-is.
+func buildReverseURL(issuerURL *url.URL, sniPort int) string {
+	base := issuerURL
+	if issuerURL.Port() == "" && sniPort != 443 && sniPort != 80 {
+		base = issuerURL.Clone()
+		base.Host = net.JoinHostPort(issuerURL.Hostname(), strconv.Itoa(sniPort))
+	}
+	return utils.ResolveAPIURL(base, types.PathSDKConnect).String()
+}
+
 func newLeaseRegistry(udpEnabled, tcpPortEnabled bool, minPort, maxPort int, rootHostname string, sniPort int, tokenAuthority identity.Authority, tokenIssuer string, trustProxyHeaders bool, rawTrustedProxyCIDRs string) (*leaseRegistry, error) {
 	if tokenAuthority == nil {
 		return nil, errors.New("lease token authority is required")
@@ -75,7 +90,7 @@ func newLeaseRegistry(udpEnabled, tcpPortEnabled bool, minPort, maxPort int, roo
 		sniPort:        sniPort,
 		tokenAuthority: tokenAuthority,
 		tokenIssuer:    tokenIssuer,
-		reverseURL:     utils.ResolveAPIURL(issuerURL, types.PathSDKConnect).String(),
+		reverseURL: buildReverseURL(issuerURL, sniPort),
 		policy:         runtime,
 		udpPorts:       transport.NewPortAllocator(minPort, maxPort, defaultPortReservationGrace),
 		tcpPorts:       transport.NewPortAllocator(minPort, maxPort, defaultPortReservationGrace),


### PR DESCRIPTION
## 문제

비권한으로 실행하는 WSL 등에서는 443을 바인드할 수 없어 **비기본값 `SNI_PORT`**를 반드시 써야 한다. 그런데 `PORTAL_URL`을 기본값 그대로 `https://localhost`(포트 생략)로 두면 tunnel이 lease 등록을 실패한다:

```
relay returned an overlay endpoint when overlay is disabled
```

## 원인

릴레이가 tunnel에게 발급하는 reverse endpoint(`/sdk/connect`)는 tunnel이 연결된 relay의 SNI port를 가리켜야 한다. 기존 `newLeaseRegistry`는 issuer(`PortalURL`)의 host/port를 그대로 사용했기 때문에, `PORTAL_URL`에 포트가 생략되고 `SNI_PORT`가 비기본값이면 발급된 reverse endpoint host(=localhost)와 tunnel의 relay host(=localhost:8443)가 달라진다.

SDK client의 `isAlternateReverseEndpoint`는 host/port 불일치를 multi-hop/overlay로 간주해 lease를 거부한다.

## 수정

`buildReverseURL` 헬퍼를 추가해 reverse endpoint host를 **relay 자신의 실제 SNI port**로 재설정:
- issuer가 이미 port를 지정했으면 그 port를 그대로 신뢰
- 생략돼 있고 SNI port가 443/80(기본)이면 그대로 생략
- 비기본값이면 relay의 SNI port를 host에 붙여 tunnel의 `--relays` 주소와 일치시킴

이로써 기본값이든 비기본값 SNI port든 reverse endpoint host가 tunnel이 연결된 relay와 항상 일치하게 된다.

## 검증

WSL(고유 ext4, Go 1.27.0)에서 e2e 확인:
- `PORTAL_URL=https://localhost`(포트 생략), `SNI_PORT=8443` → lease 등록 성공, reverse session 연결, tunnel public URL(`https://wsltest.localhost:8443`)로 curl이 directory listing 반환
- `./portal/...单元测试` 전부 통과