### PR TITLE
fix(compose): restore always-pull policy for relay image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   portal:
     image: ghcr.io/gosuda/portal:2
+    pull_policy: always
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary

Restore `pull_policy: always` for the `portal` service in `docker-compose.yml`.

The relay image uses the mutable major tag `ghcr.io/gosuda/portal:2`, so deployments that run `docker compose up -d` can otherwise keep using a stale locally cached image even after a new 2.x release is published.

This regression was observed with a relay continuing to run v2.3.6 after v2.4.0 had been released, which also caused newer configuration such as `ACME_DNS_PROVIDER=embedded` to fail against the old binary.

## Change

```yaml
services:
  portal:
    image: ghcr.io/gosuda/portal:2
    pull_policy: always
```

This restores the previous Compose behavior and keeps the mutable `:2` tag aligned with the latest published 2.x image.