### PR TITLE
test(e2e): validate canonical tunnel path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 .DEFAULT_GOAL := help
 
-GO_PACKAGES := . ./cmd/... ./portal/... ./sdk/... ./types/... ./utils/...
+GO_PACKAGES := . ./cmd/... ./e2e/... ./portal/... ./sdk/... ./types/... ./utils/...
 GO_BUILD_FLAGS := -trimpath -ldflags "-s -w"
 GO_TOOLCHAIN_VERSION := $(shell awk '/^go / { print "go" $$2; exit }' go.mod)
 GOIMPORTS_VERSION := v0.49.0

--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -132,16 +132,16 @@ func (h *harness) close() {
 
 func (h *harness) waitForPublicURL() string {
 	h.t.Helper()
-	var publicURL string
-	h.eventually(func() bool {
-		relays := h.exposure.Relays()
-		if len(relays) != 1 {
-			return false
-		}
-		publicURL = relays[0].PublicURL
-		return publicURL != "" && len(h.server.PublicLeases()) == 1 && h.server.PublicLeases()[0].Ready > 0
-	}, "tunnel did not become ready")
-	return publicURL
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	relays, err := h.exposure.WaitReady(ctx)
+	if err != nil {
+		h.t.Fatalf("tunnel did not become ready: %v", err)
+	}
+	if len(relays) == 0 || relays[0].PublicURL == "" {
+		h.t.Fatal("ready relay did not report a public URL")
+	}
+	return relays[0].PublicURL
 }
 
 func (h *harness) get(publicURL string) string {
@@ -177,27 +177,6 @@ func (h *harness) get(publicURL string) string {
 		h.t.Fatalf("tenant response status = %d, want 200", resp.StatusCode)
 	}
 	return string(body)
-}
-
-func (h *harness) eventually(condition func() bool, message string) {
-	h.t.Helper()
-	if condition() {
-		return
-	}
-	ticker := time.NewTicker(25 * time.Millisecond)
-	defer ticker.Stop()
-	timeout := time.NewTimer(15 * time.Second)
-	defer timeout.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			if condition() {
-				return
-			}
-		case <-timeout.C:
-			h.t.Fatal(message)
-		}
-	}
 }
 
 var (

--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -1,0 +1,260 @@
+package e2e_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gosuda/portal-tunnel/v2/portal"
+	"github.com/gosuda/portal-tunnel/v2/portal/identity"
+	"github.com/gosuda/portal-tunnel/v2/sdk"
+)
+
+const marker = "portal-e2e-ok"
+
+type harness struct {
+	t           *testing.T
+	cancel      context.CancelFunc
+	server      *portal.Server
+	exposure    *sdk.Exposure
+	service     *httptest.Server
+	sniAddr     string
+	certificate string
+	proxyDone   chan error
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+
+	service := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, marker)
+	}))
+	target, err := url.Parse(service.URL)
+	if err != nil {
+		service.Close()
+		t.Fatalf("parse local service URL: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	apiPort := harnessPort(t)
+	sniPort := harnessPort(t)
+	stateDir := t.TempDir()
+	relayURL := "https://127.0.0.1:" + strconv.Itoa(apiPort)
+	relay, err := portal.NewServer(portal.ServerConfig{
+		PortalURL:     relayURL,
+		StateDir:      stateDir,
+		APIListenAddr: "127.0.0.1:" + strconv.Itoa(apiPort),
+		SNIListenAddr: "127.0.0.1:" + strconv.Itoa(sniPort),
+		SNIPort:       sniPort,
+	})
+	if err != nil {
+		cancel()
+		service.Close()
+		t.Fatalf("create relay: %v", err)
+	}
+	if err := relay.Start(ctx, nil); err != nil {
+		cancel()
+		service.Close()
+		t.Fatalf("start relay: %v", err)
+	}
+
+	clientIdentity, err := identity.Generate("e2e")
+	if err != nil {
+		cancel()
+		_ = relay.Shutdown(context.Background())
+		_ = relay.Wait()
+		service.Close()
+		t.Fatalf("generate client identity: %v", err)
+	}
+	exposure, err := sdk.Expose(ctx, sdk.ExposeConfig{
+		RelayURLs: []string{relayURL},
+		Identity:  clientIdentity,
+	})
+	if err != nil {
+		cancel()
+		_ = relay.Shutdown(context.Background())
+		_ = relay.Wait()
+		service.Close()
+		t.Fatalf("expose local service: %v", err)
+	}
+
+	h := &harness{
+		t:           t,
+		cancel:      cancel,
+		server:      relay,
+		exposure:    exposure,
+		service:     service,
+		sniAddr:     "127.0.0.1:" + strconv.Itoa(sniPort),
+		certificate: filepath.Join(stateDir, "fullchain.pem"),
+		proxyDone:   make(chan error, 1),
+	}
+	go func() {
+		h.proxyDone <- sdk.Proxy(ctx, exposure, target.Host)
+	}()
+	t.Cleanup(h.close)
+	return h
+}
+
+func (h *harness) close() {
+	h.cancel()
+	_ = h.exposure.Close()
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := h.server.Shutdown(shutdownCtx); err != nil {
+		h.t.Errorf("shutdown relay: %v", err)
+	}
+	if err := h.server.Wait(); err != nil {
+		h.t.Errorf("wait for relay: %v", err)
+	}
+	h.service.Close()
+	select {
+	case err := <-h.proxyDone:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			h.t.Errorf("proxy exposure: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		h.t.Errorf("proxy exposure did not stop")
+	}
+}
+
+func (h *harness) waitForPublicURL() string {
+	h.t.Helper()
+	var publicURL string
+	h.eventually(func() bool {
+		relays := h.exposure.Relays()
+		if len(relays) != 1 {
+			return false
+		}
+		publicURL = relays[0].PublicURL
+		return publicURL != "" && len(h.server.PublicLeases()) == 1 && h.server.PublicLeases()[0].Ready > 0
+	}, "tunnel did not become ready")
+	return publicURL
+}
+
+func (h *harness) get(publicURL string) string {
+	h.t.Helper()
+
+	certPEM, err := os.ReadFile(h.certificate)
+	if err != nil {
+		h.t.Fatalf("read relay certificate: %v", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(certPEM) {
+		h.t.Fatal("parse relay certificate")
+	}
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12},
+		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, network, h.sniAddr)
+		},
+		ForceAttemptHTTP2: false,
+	}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{Transport: transport, Timeout: 10 * time.Second}
+	resp, err := client.Get(publicURL + "/marker")
+	if err != nil {
+		h.t.Fatalf("request tenant URL: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		h.t.Fatalf("read tenant response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		h.t.Fatalf("tenant response status = %d, want 200", resp.StatusCode)
+	}
+	return string(body)
+}
+
+func (h *harness) eventually(condition func() bool, message string) {
+	h.t.Helper()
+	if condition() {
+		return
+	}
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	timeout := time.NewTimer(15 * time.Second)
+	defer timeout.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if condition() {
+				return
+			}
+		case <-timeout.C:
+			h.t.Fatal(message)
+		}
+	}
+}
+
+var (
+	harnessPortsMu sync.Mutex
+	harnessPorts   = map[int]struct{}{}
+)
+
+// harnessPort allocates an explicit listener port outside the kernel's
+// ephemeral range. The relay config needs concrete ports before startup — the
+// lease registry issues reverse endpoints from the configured port — so the
+// harness cannot bind :0 and read the result back, and probing an ephemeral
+// port and rebinding it races every concurrent bind(":0") in parallel test
+// binaries. Only an explicit bind can take a port outside the ephemeral range,
+// and nothing else binds there, so the released probe address stays free until
+// the relay binds it.
+func harnessPort(t *testing.T) int {
+	t.Helper()
+	harnessPortsMu.Lock()
+	defer harnessPortsMu.Unlock()
+	lo, hi := ephemeralPortRange()
+	start, end := 31000, 32100
+	if start <= hi && end >= lo {
+		start, end = hi+1, min(hi+1100, 65535)
+	}
+	for port := start; port <= end; port++ {
+		if _, used := harnessPorts[port]; used {
+			continue
+		}
+		listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		if err != nil {
+			continue
+		}
+		if err := listener.Close(); err != nil {
+			t.Fatalf("close harness port probe: %v", err)
+		}
+		harnessPorts[port] = struct{}{}
+		return port
+	}
+	t.Fatal("no free listener port outside the ephemeral range")
+	return 0
+}
+
+// ephemeralPortRange reports the kernel's automatic port allocation range,
+// assuming the common default when it cannot be read.
+func ephemeralPortRange() (lo, hi int) {
+	data, err := os.ReadFile("/proc/sys/net/ipv4/ip_local_port_range")
+	if err != nil {
+		return 49152, 65535
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) != 2 {
+		return 49152, 65535
+	}
+	parsedLo, loErr := strconv.Atoi(fields[0])
+	parsedHi, hiErr := strconv.Atoi(fields[1])
+	if loErr != nil || hiErr != nil {
+		return 49152, 65535
+	}
+	return parsedLo, parsedHi
+}

--- a/e2e/keyless_test.go
+++ b/e2e/keyless_test.go
@@ -1,0 +1,56 @@
+package e2e_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gosuda/portal-tunnel/v2/portal"
+	"github.com/gosuda/portal-tunnel/v2/portal/acme"
+)
+
+func TestCertificateSignerMismatchRejectsStartup(t *testing.T) {
+	certPEM, _ := localTLSMaterial(t, t.TempDir())
+	_, otherKeyPEM := localTLSMaterial(t, t.TempDir())
+
+	stateDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stateDir, "fullchain.pem"), certPEM, 0o600); err != nil {
+		t.Fatalf("write certificate: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "privatekey.pem"), otherKeyPEM, 0o600); err != nil {
+		t.Fatalf("write private key: %v", err)
+	}
+
+	relay, err := portal.NewServer(portal.ServerConfig{
+		PortalURL:     "https://localhost",
+		StateDir:      stateDir,
+		APIListenAddr: "127.0.0.1:0",
+		SNIListenAddr: "127.0.0.1:0",
+	})
+	if err != nil {
+		t.Fatalf("create relay: %v", err)
+	}
+	err = relay.Start(context.Background(), nil)
+	if err == nil {
+		_ = relay.Shutdown(context.Background())
+		t.Fatal("start relay with mismatched certificate and signer succeeded")
+	}
+	if !strings.Contains(err.Error(), "private key does not match public key") {
+		t.Fatalf("start error = %q, want key mismatch", err)
+	}
+}
+
+func localTLSMaterial(t *testing.T, keyDir string) ([]byte, []byte) {
+	t.Helper()
+	manager, err := acme.NewManager(acme.Config{BaseDomain: "localhost", KeyDir: keyDir})
+	if err != nil {
+		t.Fatalf("create local certificate manager: %v", err)
+	}
+	certPEM, keyPEM, err := manager.EnsureTLSMaterial(context.Background())
+	if err != nil {
+		t.Fatalf("create local certificate: %v", err)
+	}
+	return certPEM, keyPEM
+}

--- a/e2e/reconnect_test.go
+++ b/e2e/reconnect_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func TestReverseConnectionRecoversAfterFailedTenantHandshake(t *testing.T) {
+func TestTunnelRemainsUsableAfterFailedTenantHandshake(t *testing.T) {
 	h := newHarness(t)
 	publicURL := h.waitForPublicURL()
 	parsed, err := url.Parse(publicURL)
@@ -17,7 +17,6 @@ func TestReverseConnectionRecoversAfterFailedTenantHandshake(t *testing.T) {
 		t.Fatalf("parse public URL: %v", err)
 	}
 
-	initialLease := h.server.PublicLeases()[0]
 	dialer := &net.Dialer{Timeout: 5 * time.Second}
 	conn, err := tls.DialWithDialer(dialer, "tcp", h.sniAddr, &tls.Config{
 		ServerName: parsed.Hostname(),
@@ -32,11 +31,7 @@ func TestReverseConnectionRecoversAfterFailedTenantHandshake(t *testing.T) {
 		t.Fatalf("tenant TLS handshake error = %v, want certificate verification failure", err)
 	}
 
-	h.eventually(func() bool {
-		leases := h.server.PublicLeases()
-		return len(leases) == 1 && leases[0].Ready >= 2 && leases[0].LastSeenAt.After(initialLease.LastSeenAt)
-	}, "reverse sessions were not replenished")
 	if got := h.get(publicURL); got != marker {
-		t.Fatalf("tenant response after reconnect = %q, want %q", got, marker)
+		t.Fatalf("tenant response after failed handshake = %q, want %q", got, marker)
 	}
 }

--- a/e2e/reconnect_test.go
+++ b/e2e/reconnect_test.go
@@ -1,0 +1,42 @@
+package e2e_test
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestReverseConnectionRecoversAfterFailedTenantHandshake(t *testing.T) {
+	h := newHarness(t)
+	publicURL := h.waitForPublicURL()
+	parsed, err := url.Parse(publicURL)
+	if err != nil {
+		t.Fatalf("parse public URL: %v", err)
+	}
+
+	initialLease := h.server.PublicLeases()[0]
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	conn, err := tls.DialWithDialer(dialer, "tcp", h.sniAddr, &tls.Config{
+		ServerName: parsed.Hostname(),
+		MinVersion: tls.VersionTLS12,
+	})
+	if err == nil {
+		_ = conn.Close()
+		t.Fatal("untrusted tenant TLS handshake unexpectedly succeeded")
+	}
+	var verificationErr *tls.CertificateVerificationError
+	if !errors.As(err, &verificationErr) {
+		t.Fatalf("tenant TLS handshake error = %v, want certificate verification failure", err)
+	}
+
+	h.eventually(func() bool {
+		leases := h.server.PublicLeases()
+		return len(leases) == 1 && leases[0].Ready >= 2 && leases[0].LastSeenAt.After(initialLease.LastSeenAt)
+	}, "reverse sessions were not replenished")
+	if got := h.get(publicURL); got != marker {
+		t.Fatalf("tenant response after reconnect = %q, want %q", got, marker)
+	}
+}

--- a/e2e/tunnel_test.go
+++ b/e2e/tunnel_test.go
@@ -1,0 +1,11 @@
+package e2e_test
+
+import "testing"
+
+func TestCanonicalTunnel(t *testing.T) {
+	h := newHarness(t)
+	publicURL := h.waitForPublicURL()
+	if got := h.get(publicURL); got != marker {
+		t.Fatalf("tenant response = %q, want %q", got, marker)
+	}
+}


### PR DESCRIPTION
## Summary

Rework of the original harness onto the current facade (#414/#425/#428), following the review direction: the diff is **`e2e/` plus the Makefile only — no production changes**.

- The relay needs concrete ports at `NewServer` because the lease registry issues reverse endpoints from the configured port, so `:0` cannot work without runtime rewrites. The harness instead allocates explicit listener ports **outside the kernel ephemeral range** (`harnessPort`): only an explicit bind can take such a port, so the probe→bind gap cannot be stolen by concurrent `bind(":0")` in parallel test binaries — the same determinism argument as #430, needing no listener-observation hook at all.
- Client side aligned with the slim facade: `sdk.ExposeConfig{RelayURLs, Identity}` with `portal/identity.Generate`, proxying via `sdk.Proxy`; relay side uses `ServerConfig.StateDir`.
- Readiness goes through the public `Exposure.WaitReady` contract ("at least one relay can accept tenant connections") and the public URL from its `RelayStatus`. The harness no longer reads `Server.PublicLeases()` at all — the E2E observes the public SDK surface, not relay-internal lease state.

Three tests, three contracts:

- `TestCanonicalTunnel` — a normal tenant request actually traverses the tunnel: registration → reverse session → tenant TLS → SDK proxy → local HTTP marker.
- `TestTunnelRemainsUsableAfterFailedTenantHandshake` — one bad TLS client (a real `tls.CertificateVerificationError`) does not break the tunnel; a valid tenant request still succeeds afterwards.
- `TestCertificateSignerMismatchRejectsStartup` — a relay with a mismatched certificate/signer refuses to start.

Reverse-session replenishment itself is deliberately not asserted here: `PublicLeases().Ready` and `LastSeenAt` are relay-internal state, and pinning them — or the default ready-target count — would couple the canonical E2E to the reverse-stream pool implementation, contradicting #383's goal that these tests survive package-boundary refactors. That behavior belongs in narrow SDK/transport tests.

## Verification

- `gofmt -l e2e`, `go vet ./e2e/...` — clean
- `go test ./e2e/... -count=1 -v` — 3/3 PASS; `-count=5` — PASS (flake check)
- lint via CI (`make lint`)

Closes #383