### PR TITLE
feat(sdk): expose allocated TCP addresses on Exposure

### DIFF
--- a/sdk/expose.go
+++ b/sdk/expose.go
@@ -406,6 +406,7 @@ func (e *Exposure) Snapshot() types.AgentTunnelStatus {
 		}
 		if lease, ok := listener.leaseSnapshot(); ok {
 			snap.PublicURL = listener.publicURLForLease(lease)
+			snap.TCPAddr = lease.tcpAddr
 			snap.Connecting = snap.PublicURL == ""
 		}
 		if relayURL != "" {
@@ -528,6 +529,57 @@ func (e *Exposure) WaitDatagramReady(ctx context.Context) ([]string, error) {
 		}
 		if resolvedWithoutDatagram {
 			return nil, errors.New("relay did not expose udp")
+		}
+
+		select {
+		case <-e.done:
+			return nil, net.ErrClosed
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// ActiveTCPAddrs returns the public TCP addresses currently allocated for
+// this exposure, one per registered relay lease. Addresses are deduplicated
+// and sorted for stable output. The result is empty while no relay has
+// granted a TCP address yet.
+func (e *Exposure) ActiveTCPAddrs() []string {
+	e.mu.RLock()
+	addrs := make([]string, 0, len(e.relayListeners))
+	seen := make(map[string]struct{}, len(e.relayListeners))
+	for _, listener := range e.relayListeners {
+		lease, ok := listener.leaseSnapshot()
+		if !ok || lease.tcpAddr == "" {
+			continue
+		}
+		if _, dup := seen[lease.tcpAddr]; dup {
+			continue
+		}
+		seen[lease.tcpAddr] = struct{}{}
+		addrs = append(addrs, lease.tcpAddr)
+	}
+	e.mu.RUnlock()
+	slices.Sort(addrs)
+	return addrs
+}
+
+// WaitTCPReady blocks until the exposure has at least one allocated TCP
+// address, the exposure closes, or the context is canceled. It mirrors
+// WaitDatagramReady for raw-TCP consumers such as game servers.
+func (e *Exposure) WaitTCPReady(ctx context.Context) ([]string, error) {
+	if !e.Config().TCPEnabled {
+		return nil, errors.New("exposure does not have tcp enabled")
+	}
+
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		addrs := e.ActiveTCPAddrs()
+		if len(addrs) > 0 {
+			return addrs, nil
 		}
 
 		select {

--- a/sdk/expose_tcpaddr_test.go
+++ b/sdk/expose_tcpaddr_test.go
@@ -1,0 +1,120 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gosuda/portal-tunnel/v2/portal/discovery"
+	"github.com/gosuda/portal-tunnel/v2/utils"
+)
+
+func newTCPTestExposure(tcpEnabled bool, listeners map[string]*listener) *Exposure {
+	return &Exposure{
+		done:           make(chan struct{}),
+		cfg:            utils.NewSnapshot(ExposeConfig{TCPEnabled: tcpEnabled}),
+		relayListeners: listeners,
+	}
+}
+
+func tcpLeaseListener(addr string) *listener {
+	return &listener{lease: utils.NewSnapshot(listenerSnapshot{
+		accessToken: "test-token",
+		tcpAddr:     addr,
+	})}
+}
+
+func TestActiveTCPAddrsDedupesAndSorts(t *testing.T) {
+	e := newTCPTestExposure(true, map[string]*listener{
+		"https://relay-b.example": tcpLeaseListener("relay-b.example:7001"),
+		"https://relay-a.example": tcpLeaseListener("relay-a.example:7000"),
+		"https://relay-c.example": tcpLeaseListener("relay-a.example:7000"), // duplicate address
+		"https://relay-d.example": tcpLeaseListener(""),                     // lease without tcp addr
+		"https://relay-nil":       nil,
+	})
+
+	got := e.ActiveTCPAddrs()
+	want := []string{"relay-a.example:7000", "relay-b.example:7001"}
+	if len(got) != len(want) {
+		t.Fatalf("ActiveTCPAddrs() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ActiveTCPAddrs() = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestActiveTCPAddrsSkipsUnregisteredLease(t *testing.T) {
+	e := newTCPTestExposure(true, map[string]*listener{
+		// tcpAddr set but no access token: registration not completed.
+		"https://relay-pending.example": {lease: utils.NewSnapshot(listenerSnapshot{
+			tcpAddr: "relay-pending.example:7000",
+		})},
+	})
+
+	if got := e.ActiveTCPAddrs(); len(got) != 0 {
+		t.Fatalf("ActiveTCPAddrs() = %v, want empty for unregistered lease", got)
+	}
+}
+
+func TestWaitTCPReadyReturnsAllocatedAddrs(t *testing.T) {
+	e := newTCPTestExposure(true, map[string]*listener{
+		"https://relay-a.example": tcpLeaseListener("relay-a.example:7000"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	addrs, err := e.WaitTCPReady(ctx)
+	if err != nil {
+		t.Fatalf("WaitTCPReady() error = %v", err)
+	}
+	if len(addrs) != 1 || addrs[0] != "relay-a.example:7000" {
+		t.Fatalf("WaitTCPReady() = %v, want [relay-a.example:7000]", addrs)
+	}
+}
+
+func TestWaitTCPReadyRejectsTCPDisabled(t *testing.T) {
+	e := newTCPTestExposure(false, map[string]*listener{
+		"https://relay-a.example": tcpLeaseListener("relay-a.example:7000"),
+	})
+
+	if _, err := e.WaitTCPReady(context.Background()); err == nil {
+		t.Fatal("WaitTCPReady() must error when tcp is not enabled")
+	}
+}
+
+func TestWaitTCPReadyHonorsContextCancel(t *testing.T) {
+	e := newTCPTestExposure(true, map[string]*listener{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := e.WaitTCPReady(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("WaitTCPReady() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestSnapshotIncludesRelayTCPAddr(t *testing.T) {
+	e := newTCPTestExposure(true, map[string]*listener{
+		"https://relay-a.example": {
+			lease: utils.NewSnapshot(listenerSnapshot{
+				accessToken: "test-token",
+				tcpAddr:     "relay-a.example:7000",
+			}),
+			route:          discovery.NewRoute([]string{"https://relay-a.example"}, true),
+			releaseVersion: "v2.4.0",
+		},
+	})
+
+	snap := e.Snapshot()
+	if len(snap.Relays) != 1 {
+		t.Fatalf("Snapshot().Relays = %+v, want exactly one relay", snap.Relays)
+	}
+	relay := snap.Relays[0]
+	if relay.TCPAddr != "relay-a.example:7000" {
+		t.Fatalf("Snapshot().Relays[0].TCPAddr = %q, want %q", relay.TCPAddr, "relay-a.example:7000")
+	}
+}

--- a/types/agent.go
+++ b/types/agent.go
@@ -38,6 +38,7 @@ type AgentHTTPRoute struct {
 type AgentRelayStatus struct {
 	RelayURL        string `json:"relay_url"`
 	PublicURL       string `json:"public_url,omitempty"`
+	TCPAddr         string `json:"tcp_addr,omitempty"`
 	Version         string `json:"version,omitempty"`
 	Explicit        bool   `json:"explicit,omitempty"`
 	Connecting      bool   `json:"connecting"`


### PR DESCRIPTION
## Summary

Raw-TCP exposure consumers (game servers, TCP proxies) currently cannot learn the public TCP address a relay allocated for their lease. The value is already stored in the listener lease snapshot (`resp.TCPAddr`, set at registration) but no public API surfaces it — `ActiveRelayURLs()` is URLs only, `Addr()` returns a synthetic identity string, and `AgentTunnelStatus`/`AgentRelayStatus` carry no TCP address.

## Changes

- **`Exposure.ActiveTCPAddrs() []string`** — deduplicated, sorted public TCP addresses across registered relay leases; empty while no relay has granted one yet
- **`Exposure.WaitTCPReady(ctx) ([]string, error)`** — blocks until at least one TCP address exists, the exposure closes, or ctx is canceled; mirrors `WaitDatagramReady` for symmetry
- **`types.AgentRelayStatus.TCPAddr`** (additive, `omitempty`) — populated in `Exposure.Snapshot()` so callers can key each address to its relay, since addresses differ per relay (relevant with discovery enabled)

Reads go through the existing `listener.leaseSnapshot()` helper (nil-safe, skips leases without an access token), so addresses appear exactly when registration completes — same moment the ready-event log emits `tcp_addr`.

## Consumer

gosuda/portal-toys#8 (Minecraft TCP toy) will drop its manual `--tcp-addr` display flag and use `WaitTCPReady`/`ActiveTCPAddrs` once this lands.

## Verification

- `gofmt -l sdk/ types/` clean
- `go vet ./sdk/... ./types/...` ✅
- `go test ./sdk/... ./types/... -count=1` ✅ (`ok sdk 15.129s`)
- New focused tests (6, all passing): dedup+sort, unregistered-lease skip, ready-return, tcp-disabled rejection, context-cancel, Snapshot per-relay TCPAddr