### PR TITLE
chore(release): update version to v2.4.1

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@
 # Bump protocol versions only when wire-level behavior changes.
 
 [release]
-version  = "v2.4.0"
+version  = "v2.4.1"
 base_url = "https://github.com/gosuda/portal-tunnel/releases"
 
 [protocol]


### PR DESCRIPTION
## 변경 사항

- release version을 `v2.4.0`에서 `v2.4.1`로 변경
- wire-level 변경이 없으므로 tunnel/discovery protocol version은 유지

## 확인

- 기존 release bump 패턴과 동일하게 `config.toml`만 수정
- `git diff --check` 통과
- 저장소 지침에 따라 테스트 명령은 실행하지 않음