### PR TITLE
fix(discovery): keep protocol-incompatible relays visible

### DIFF
--- a/frontend/src/components/ServerListView.test.ts
+++ b/frontend/src/components/ServerListView.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { mergeIncompatibleRelays } from "./ServerListView";
+import {
+  mergeIncompatibleRelays,
+  relayReleaseLabel,
+} from "./ServerListView";
 
 const CURRENT = "https://relay-current.example";
 
@@ -9,7 +12,7 @@ describe("mergeIncompatibleRelays", () => {
     expect(mergeIncompatibleRelays(known, undefined, CURRENT)).toBe(known);
   });
 
-  it("appends incompatible relay URLs not already known", () => {
+  it("appends incompatible relay URLs and preserves the observed protocol version", () => {
     const known = [{ relayURL: CURRENT, isCurrent: true }];
     expect(
       mergeIncompatibleRelays(
@@ -19,7 +22,11 @@ describe("mergeIncompatibleRelays", () => {
       )
     ).toEqual([
       { relayURL: CURRENT, isCurrent: true },
-      { relayURL: "https://relay-old.example", isCurrent: false },
+      {
+        relayURL: "https://relay-old.example",
+        isCurrent: false,
+        protocolVersion: "8",
+      },
     ]);
   });
 
@@ -32,5 +39,38 @@ describe("mergeIncompatibleRelays", () => {
         CURRENT
       )
     ).toEqual(known);
+  });
+});
+
+describe("relayReleaseLabel", () => {
+  const oldRelay = {
+    relayURL: "https://relay-old.example",
+    isCurrent: false,
+    protocolVersion: "8",
+  };
+
+  it("shows loading while the release probe is pending", () => {
+    expect(relayReleaseLabel({}, oldRelay)).toBe("loading...");
+    expect(relayReleaseLabel({ [oldRelay.relayURL]: null }, oldRelay)).toBe(
+      "loading..."
+    );
+  });
+
+  it("falls back to the observed discovery protocol when the probe fails", () => {
+    expect(
+      relayReleaseLabel({ [oldRelay.relayURL]: "" }, oldRelay)
+    ).toBe("discovery 8");
+  });
+
+  it("still reports offline without a protocol version", () => {
+    expect(
+      relayReleaseLabel({ [oldRelay.relayURL]: "" }, { ...oldRelay, protocolVersion: undefined })
+    ).toBe("offline");
+  });
+
+  it("prefers the probed release version when available", () => {
+    expect(
+      relayReleaseLabel({ [oldRelay.relayURL]: "v2.3.8" }, oldRelay)
+    ).toBe("v2.3.8");
   });
 });

--- a/frontend/src/components/ServerListView.test.ts
+++ b/frontend/src/components/ServerListView.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { mergeIncompatibleRelays } from "./ServerListView";
+
+const CURRENT = "https://relay-current.example";
+
+describe("mergeIncompatibleRelays", () => {
+  it("returns the known list unchanged without incompatible entries", () => {
+    const known = [{ relayURL: CURRENT, isCurrent: true }];
+    expect(mergeIncompatibleRelays(known, undefined, CURRENT)).toBe(known);
+  });
+
+  it("appends incompatible relay URLs not already known", () => {
+    const known = [{ relayURL: CURRENT, isCurrent: true }];
+    expect(
+      mergeIncompatibleRelays(
+        known,
+        [{ url: "https://relay-old.example", protocol_version: "8" }],
+        CURRENT
+      )
+    ).toEqual([
+      { relayURL: CURRENT, isCurrent: true },
+      { relayURL: "https://relay-old.example", isCurrent: false },
+    ]);
+  });
+
+  it("skips entries already known and blank URLs", () => {
+    const known = [{ relayURL: CURRENT, isCurrent: true }];
+    expect(
+      mergeIncompatibleRelays(
+        known,
+        [{ url: CURRENT }, { url: "   " }],
+        CURRENT
+      )
+    ).toEqual(known);
+  });
+});

--- a/frontend/src/components/ServerListView.tsx
+++ b/frontend/src/components/ServerListView.tsx
@@ -16,7 +16,7 @@ import { FloatingActionBar } from "@/components/FloatingActionBar";
 import { readCurrentOrigin } from "@/hooks/useTunnelCommand";
 import { apiClient } from "@/lib/apiClient";
 import { BROWSER_API_PATHS, ROUTE_PATHS } from "@/lib/apiPaths";
-import type { DiscoveryResponse, DomainResponse, RelayDescriptor } from "@/types/api";
+import type { DiscoveryResponse, DomainResponse, RelayDescriptor, IncompatibleRelayEntry } from "@/types/api";
 import {
   Dialog,
   DialogContent,
@@ -26,7 +26,7 @@ import {
 
 type ListServer = BaseServer | AdminServer;
 
-interface KnownRelay {
+export interface KnownRelay {
   relayURL: string;
   isCurrent: boolean;
 }
@@ -99,6 +99,34 @@ function normalizeKnownRelays(
   });
 
   return knownRelays;
+}
+
+export function mergeIncompatibleRelays(
+  knownRelays: KnownRelay[],
+  incompatible: IncompatibleRelayEntry[] | undefined,
+  currentRelayURL: string
+): KnownRelay[] {
+  if (!incompatible?.length) {
+    return knownRelays;
+  }
+
+  const seen = new Set(knownRelays.map((relay) => relay.relayURL));
+  const merged = [...knownRelays];
+
+  incompatible.forEach((entry) => {
+    const relayURL = normalizeRelayURL(entry.url);
+    if (relayURL === "" || seen.has(relayURL)) {
+      return;
+    }
+
+    seen.add(relayURL);
+    merged.push({
+      relayURL,
+      isCurrent: relayURL === currentRelayURL,
+    });
+  });
+
+  return merged;
 }
 
 function relayReleaseLabel(
@@ -303,8 +331,9 @@ export function ServerListView({
       try {
         const discovery =
           await apiClient.get<DiscoveryResponse>(BROWSER_API_PATHS.discovery);
-        nextKnownRelays = normalizeKnownRelays(
-          discovery?.relays,
+        nextKnownRelays = mergeIncompatibleRelays(
+          normalizeKnownRelays(discovery?.relays, currentRelayURL),
+          discovery?.incompatible_relays,
           currentRelayURL
         );
       } catch {

--- a/frontend/src/components/ServerListView.tsx
+++ b/frontend/src/components/ServerListView.tsx
@@ -29,6 +29,7 @@ type ListServer = BaseServer | AdminServer;
 export interface KnownRelay {
   relayURL: string;
   isCurrent: boolean;
+  protocolVersion?: string;
 }
 
 type RelayReleaseVersions = Record<string, string | null>;
@@ -118,26 +119,31 @@ export function mergeIncompatibleRelays(
     if (relayURL === "" || seen.has(relayURL)) {
       return;
     }
-
     seen.add(relayURL);
     merged.push({
       relayURL,
       isCurrent: relayURL === currentRelayURL,
+      protocolVersion: entry.protocol_version?.trim() || undefined,
     });
   });
 
   return merged;
 }
 
-function relayReleaseLabel(
+export function relayReleaseLabel(
   versions: RelayReleaseVersions,
-  relayURL: string
+  relay: KnownRelay
 ): string {
-  const version = versions[relayURL];
+  const version = versions[relay.relayURL];
   if (version === undefined || version === null) {
     return "loading...";
   }
-  return version || "offline";
+  if (!version) {
+    return relay.protocolVersion
+      ? `discovery ${relay.protocolVersion}`
+      : "offline";
+  }
+  return version;
 }
 
 interface ServerListViewProps {
@@ -923,7 +929,7 @@ export function ServerListView({
                               <span className="rounded-sm bg-secondary/70 px-2.5 py-1 font-mono text-[11px] font-medium text-text-muted ring-1 ring-border">
                                 {relayReleaseLabel(
                                   relayReleaseVersions,
-                                  relay.relayURL
+                                  relay
                                 )}
                               </span>
                             </div>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -116,8 +116,15 @@ export interface RelayDescriptor {
   api_https_addr?: string;
 }
 
+export interface IncompatibleRelayEntry {
+  url: string;
+  protocol_version?: string;
+  last_seen_at?: string;
+}
+
 export interface DiscoveryResponse {
   relays?: RelayDescriptor[];
+  incompatible_relays?: IncompatibleRelayEntry[];
 }
 
 export interface LeasePolicyUpdate {

--- a/internal/discovery/refresher.go
+++ b/internal/discovery/refresher.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"net/http"
 	"net/url"
 	"slices"
@@ -207,6 +208,13 @@ func (r *Refresher) refreshOneHTTPS(ctx context.Context, state RelayState) error
 	measuredAt := time.Now().UTC()
 
 	if _, err := r.relaySet.ApplyRelayDiscoveryResponse(relayURL, resp, measuredAt); err != nil {
+		if errors.Is(err, ErrProtocolMismatch) {
+			// The relay answered; protocol incompatibility is visibility
+			// metadata, not a health failure. Keep polling it without
+			// accumulating discovery failures or pool bans.
+			log.Debug().Err(err).Str("relay", relayURL).Msg("discovery protocol mismatch; relay kept visible as incompatible")
+			return nil
+		}
 		if recoveryFailures > 0 {
 			r.logDiscoveryFailure(relayURL, relayURL, recoveryFailures, err)
 		}

--- a/internal/discovery/relayset.go
+++ b/internal/discovery/relayset.go
@@ -47,7 +47,7 @@ type RelaySet struct {
 	mu           sync.RWMutex
 	relays       map[string]RelayState
 	keyIndex     map[string]keyIndexEntry
-	incompatible map[string]incompatibleRelay
+	incompatible map[string]types.IncompatibleRelayEntry
 }
 
 // keyIndexEntry records the rollback anchor for a signing identity.
@@ -60,27 +60,11 @@ type keyIndexEntry struct {
 	TombstoneUntil time.Time
 }
 
-// incompatibleRelayRetention bounds how long a directly observed but
-// protocol-incompatible relay stays visible after its last observation.
-const incompatibleRelayRetention = 24 * time.Hour
-
-// incompatibleRelay is the internal record for a relay this node contacted
-// directly whose discovery protocol version does not match ours. It lives
-// outside s.relays on purpose: it never becomes a descriptor and is never
-// routed; it exists only to keep older relays visible during rolling
-// upgrades.
-type incompatibleRelay struct {
-	ProtocolVersion string
-	LastSeenAt      time.Time
-}
-
-// IncompatibleRelayInfo is the read-only view of a directly observed relay
-// whose discovery protocol version is incompatible with the local one.
-type IncompatibleRelayInfo struct {
-	URL             string
-	ProtocolVersion string
-	LastSeenAt      time.Time
-}
+// ErrProtocolMismatch reports that a discovery response came from a relay
+// whose discovery protocol version is incompatible with ours. The relay
+// answered and is reachable; callers must not treat this as a health
+// failure.
+var ErrProtocolMismatch = errors.New("relay discovery protocol version mismatch")
 
 type upsertResult int
 
@@ -94,7 +78,7 @@ func NewRelaySet(bootstrapRelayURLs []string) *RelaySet {
 	set := &RelaySet{
 		relays:       make(map[string]RelayState),
 		keyIndex:     make(map[string]keyIndexEntry),
-		incompatible: make(map[string]incompatibleRelay),
+		incompatible: make(map[string]types.IncompatibleRelayEntry),
 	}
 	set.SetBootstrapRelayURLs(bootstrapRelayURLs)
 	return set
@@ -175,6 +159,8 @@ func (s *RelaySet) banFromPoolLocked(relayURL string, now time.Time) {
 	state.Banned = true
 	state.suppressActiveUntil = now.Add(relayPoolBanTTL)
 	s.relays[relayURL] = state
+	// A local ban outranks protocol-mismatch visibility.
+	delete(s.incompatible, relayURL)
 }
 
 func mergeLocalRelayState(record, existing RelayState) RelayState {
@@ -554,6 +540,8 @@ func (s *RelaySet) BanRelayURL(relayURL string) {
 	state.suppressActiveUntil = time.Time{}
 	state.Banned = true
 	s.relays[relayURL] = state
+	// A local ban outranks protocol-mismatch visibility.
+	delete(s.incompatible, relayURL)
 }
 
 func (s *RelaySet) DropRelayURLFromActivePool(relayURL string) {
@@ -729,7 +717,7 @@ func (s *RelaySet) ApplyRelayDiscoveryResponse(targetURL string, resp types.Disc
 		return relaySetChanged, errors.New("target relay descriptor missing from relays")
 	}
 	if protocolMismatch && authoritative {
-		return relaySetChanged, fmt.Errorf("relay discovery protocol version mismatch: relay=%q client=%q", resp.ProtocolVersion, types.DiscoveryVersion)
+		return relaySetChanged, fmt.Errorf("%w: relay=%q client=%q", ErrProtocolMismatch, resp.ProtocolVersion, types.DiscoveryVersion)
 	}
 	return relaySetChanged, nil
 }
@@ -746,18 +734,20 @@ func (s *RelaySet) recordIncompatibleRelayLocked(relayURL, protocolVersion strin
 		return
 	}
 	s.pruneIncompatibleLocked(now)
-	s.incompatible[relayURL] = incompatibleRelay{
+	s.incompatible[relayURL] = types.IncompatibleRelayEntry{
+		URL:             relayURL,
 		ProtocolVersion: protocolVersion,
 		LastSeenAt:      now,
 	}
 }
 
 // pruneIncompatibleLocked drops incompatible-relay entries whose last direct
-// observation is older than incompatibleRelayRetention. The caller must hold
+// observation is older than AnnounceMaxValidity, matching the window in which
+// descriptors from that observation could still matter. The caller must hold
 // s.mu for writing.
 func (s *RelaySet) pruneIncompatibleLocked(now time.Time) {
 	for relayURL, entry := range s.incompatible {
-		if now.Sub(entry.LastSeenAt) > incompatibleRelayRetention {
+		if now.Sub(entry.LastSeenAt) > AnnounceMaxValidity {
 			delete(s.incompatible, relayURL)
 		}
 	}
@@ -765,24 +755,27 @@ func (s *RelaySet) pruneIncompatibleLocked(now time.Time) {
 
 // KnownIncompatibleRelays returns directly observed relays whose discovery
 // protocol version is incompatible with the local one. Entries are sorted by
-// URL for stable output and expire after incompatibleRelayRetention without a
-// fresh observation. They are informational only and are never part of the
-// routable descriptor set.
-func (s *RelaySet) KnownIncompatibleRelays() []IncompatibleRelayInfo {
+// URL for stable output, expire (per AnnounceMaxValidity) without a fresh
+// observation, and are suppressed while the relay is locally banned: a local
+// ban outranks protocol-mismatch visibility. They are informational only and
+// are never part of the routable descriptor set.
+func (s *RelaySet) KnownIncompatibleRelays() []types.IncompatibleRelayEntry {
 	return s.knownIncompatibleRelaysAt(time.Now().UTC())
 }
 
-func (s *RelaySet) knownIncompatibleRelaysAt(now time.Time) []IncompatibleRelayInfo {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.pruneIncompatibleLocked(now)
-	out := make([]IncompatibleRelayInfo, 0, len(s.incompatible))
+func (s *RelaySet) knownIncompatibleRelaysAt(now time.Time) []types.IncompatibleRelayEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]types.IncompatibleRelayEntry, 0, len(s.incompatible))
 	for relayURL, entry := range s.incompatible {
-		out = append(out, IncompatibleRelayInfo{
-			URL:             relayURL,
-			ProtocolVersion: entry.ProtocolVersion,
-			LastSeenAt:      entry.LastSeenAt,
-		})
+		if now.Sub(entry.LastSeenAt) > AnnounceMaxValidity {
+			continue
+		}
+		if state, ok := s.relays[relayURL]; ok && state.Banned {
+			continue
+		}
+		out = append(out, entry)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].URL < out[j].URL })
 	return out

--- a/internal/discovery/relayset.go
+++ b/internal/discovery/relayset.go
@@ -713,11 +713,16 @@ func (s *RelaySet) ApplyRelayDiscoveryResponse(targetURL string, resp types.Disc
 		}
 	}
 	s.enforceCapLocked()
-	if missingTarget {
-		return relaySetChanged, errors.New("target relay descriptor missing from relays")
-	}
+	// Protocol mismatch outranks a missing target descriptor: the response
+	// arrived over HTTPS and its protocol version is the observation this
+	// package records, so the refresher must classify it as a mismatch
+	// (ErrProtocolMismatch) rather than a health failure even when the older
+	// relay omits its own descriptor from the response.
 	if protocolMismatch && authoritative {
 		return relaySetChanged, fmt.Errorf("%w: relay=%q client=%q", ErrProtocolMismatch, resp.ProtocolVersion, types.DiscoveryVersion)
+	}
+	if missingTarget {
+		return relaySetChanged, errors.New("target relay descriptor missing from relays")
 	}
 	return relaySetChanged, nil
 }

--- a/internal/discovery/relayset.go
+++ b/internal/discovery/relayset.go
@@ -44,9 +44,10 @@ import (
 // (notably from ApplyRelayDiscoveryResponse, which holds the write lock for
 // the entire batch).
 type RelaySet struct {
-	mu       sync.RWMutex
-	relays   map[string]RelayState
-	keyIndex map[string]keyIndexEntry
+	mu           sync.RWMutex
+	relays       map[string]RelayState
+	keyIndex     map[string]keyIndexEntry
+	incompatible map[string]incompatibleRelay
 }
 
 // keyIndexEntry records the rollback anchor for a signing identity.
@@ -59,6 +60,28 @@ type keyIndexEntry struct {
 	TombstoneUntil time.Time
 }
 
+// incompatibleRelayRetention bounds how long a directly observed but
+// protocol-incompatible relay stays visible after its last observation.
+const incompatibleRelayRetention = 24 * time.Hour
+
+// incompatibleRelay is the internal record for a relay this node contacted
+// directly whose discovery protocol version does not match ours. It lives
+// outside s.relays on purpose: it never becomes a descriptor and is never
+// routed; it exists only to keep older relays visible during rolling
+// upgrades.
+type incompatibleRelay struct {
+	ProtocolVersion string
+	LastSeenAt      time.Time
+}
+
+// IncompatibleRelayInfo is the read-only view of a directly observed relay
+// whose discovery protocol version is incompatible with the local one.
+type IncompatibleRelayInfo struct {
+	URL             string
+	ProtocolVersion string
+	LastSeenAt      time.Time
+}
+
 type upsertResult int
 
 const (
@@ -69,8 +92,9 @@ const (
 
 func NewRelaySet(bootstrapRelayURLs []string) *RelaySet {
 	set := &RelaySet{
-		relays:   make(map[string]RelayState),
-		keyIndex: make(map[string]keyIndexEntry),
+		relays:       make(map[string]RelayState),
+		keyIndex:     make(map[string]keyIndexEntry),
+		incompatible: make(map[string]incompatibleRelay),
 	}
 	set.SetBootstrapRelayURLs(bootstrapRelayURLs)
 	return set
@@ -659,6 +683,16 @@ func (s *RelaySet) ApplyRelayDiscoveryResponse(targetURL string, resp types.Disc
 	}
 	missingTarget := authoritative && !targetFound
 
+	if authoritative {
+		if protocolMismatch {
+			s.recordIncompatibleRelayLocked(targetURL, resp.ProtocolVersion, now)
+		} else if !missingTarget {
+			// The target now speaks our protocol (e.g. after a rolling
+			// upgrade); retire any stale incompatible-visibility entry.
+			delete(s.incompatible, targetURL)
+		}
+	}
+
 	for _, relayURL := range discoveredOrder {
 		record := discoveredByURL[relayURL]
 		existingAtURL, hasExistingAtURL := s.relays[relayURL]
@@ -698,6 +732,60 @@ func (s *RelaySet) ApplyRelayDiscoveryResponse(targetURL string, resp types.Disc
 		return relaySetChanged, fmt.Errorf("relay discovery protocol version mismatch: relay=%q client=%q", resp.ProtocolVersion, types.DiscoveryVersion)
 	}
 	return relaySetChanged, nil
+}
+
+// recordIncompatibleRelayLocked remembers a directly contacted relay whose
+// discovery protocol version does not match ours. Banned relays stay hidden.
+// The caller must hold s.mu for writing.
+func (s *RelaySet) recordIncompatibleRelayLocked(relayURL, protocolVersion string, now time.Time) {
+	if relayURL == "" {
+		return
+	}
+	if state, ok := s.relays[relayURL]; ok && state.Banned {
+		delete(s.incompatible, relayURL)
+		return
+	}
+	s.pruneIncompatibleLocked(now)
+	s.incompatible[relayURL] = incompatibleRelay{
+		ProtocolVersion: protocolVersion,
+		LastSeenAt:      now,
+	}
+}
+
+// pruneIncompatibleLocked drops incompatible-relay entries whose last direct
+// observation is older than incompatibleRelayRetention. The caller must hold
+// s.mu for writing.
+func (s *RelaySet) pruneIncompatibleLocked(now time.Time) {
+	for relayURL, entry := range s.incompatible {
+		if now.Sub(entry.LastSeenAt) > incompatibleRelayRetention {
+			delete(s.incompatible, relayURL)
+		}
+	}
+}
+
+// KnownIncompatibleRelays returns directly observed relays whose discovery
+// protocol version is incompatible with the local one. Entries are sorted by
+// URL for stable output and expire after incompatibleRelayRetention without a
+// fresh observation. They are informational only and are never part of the
+// routable descriptor set.
+func (s *RelaySet) KnownIncompatibleRelays() []IncompatibleRelayInfo {
+	return s.knownIncompatibleRelaysAt(time.Now().UTC())
+}
+
+func (s *RelaySet) knownIncompatibleRelaysAt(now time.Time) []IncompatibleRelayInfo {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneIncompatibleLocked(now)
+	out := make([]IncompatibleRelayInfo, 0, len(s.incompatible))
+	for relayURL, entry := range s.incompatible {
+		out = append(out, IncompatibleRelayInfo{
+			URL:             relayURL,
+			ProtocolVersion: entry.ProtocolVersion,
+			LastSeenAt:      entry.LastSeenAt,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].URL < out[j].URL })
+	return out
 }
 
 func (s *RelaySet) RecordDiscoveryRTT(relayURL string, rtt time.Duration, measuredAt time.Time) {

--- a/internal/discovery/relayset_test.go
+++ b/internal/discovery/relayset_test.go
@@ -336,3 +336,77 @@ func TestSelectRelaysIncludesExplicitRelayMissingFromSet(t *testing.T) {
 		t.Fatalf("route.RelayURL = %q, want %q", got, relayURL)
 	}
 }
+
+func TestProtocolMismatchKeepsOlderRelayVisibleWithoutRouting(t *testing.T) {
+	set := NewRelaySet(nil)
+
+	relayURL := "https://relay-old.example"
+	desc := mustRelayDescriptor(t, relayURL)
+	if _, err := set.ApplyRelayDiscoveryResponse(relayURL, types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion + "-older",
+		Relays:          []types.RelayDescriptor{desc},
+	}, time.Now().UTC()); err == nil {
+		t.Fatal("ApplyRelayDiscoveryResponse() should keep reporting the protocol mismatch")
+	}
+
+	known := set.KnownIncompatibleRelays()
+	if len(known) != 1 || known[0].URL != relayURL || known[0].ProtocolVersion != types.DiscoveryVersion+"-older" {
+		t.Fatalf("KnownIncompatibleRelays() = %+v, want one entry for %q", known, relayURL)
+	}
+	if known[0].LastSeenAt.IsZero() {
+		t.Fatal("KnownIncompatibleRelays() entry should carry LastSeenAt")
+	}
+
+	if servesDescriptor(set, relayURL) {
+		t.Fatal("incompatible relay must not be served as a routable descriptor")
+	}
+	if routesTo(t, set, relayURL) {
+		t.Fatal("incompatible relay must not be selected for routes")
+	}
+	for _, state := range relayStates(set) {
+		if state.Descriptor.APIHTTPSAddr == relayURL && state.Trust == RelayVerified {
+			t.Fatal("incompatible relay must not become a verified descriptor")
+		}
+	}
+}
+
+func TestKnownIncompatibleRelaysExpireAfterRetention(t *testing.T) {
+	set := NewRelaySet(nil)
+
+	relayURL := "https://relay-old.example"
+	desc := mustRelayDescriptor(t, relayURL)
+	observedAt := time.Now().UTC().Truncate(time.Microsecond)
+	if _, err := set.ApplyRelayDiscoveryResponse(relayURL, types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion + "-older",
+		Relays:          []types.RelayDescriptor{desc},
+	}, observedAt); err == nil {
+		t.Fatal("expected protocol mismatch error")
+	}
+	if known := set.knownIncompatibleRelaysAt(observedAt); len(known) != 1 {
+		t.Fatalf("knownIncompatibleRelaysAt(fresh) = %+v, want one entry", known)
+	}
+	if known := set.knownIncompatibleRelaysAt(observedAt.Add(incompatibleRelayRetention + time.Minute)); len(known) != 0 {
+		t.Fatalf("knownIncompatibleRelaysAt(stale) = %+v, want empty", known)
+	}
+}
+
+func TestCompatibleAuthoritativeDiscoveryClearsIncompatibleRelay(t *testing.T) {
+	set := NewRelaySet(nil)
+
+	relayURL := "https://relay-upgraded.example"
+	desc := mustRelayDescriptor(t, relayURL)
+	if _, err := set.ApplyRelayDiscoveryResponse(relayURL, types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion + "-older",
+		Relays:          []types.RelayDescriptor{desc},
+	}, time.Now().UTC()); err == nil {
+		t.Fatal("expected protocol mismatch error")
+	}
+	if known := set.KnownIncompatibleRelays(); len(known) != 1 {
+		t.Fatalf("KnownIncompatibleRelays() = %+v, want one entry before upgrade", known)
+	}
+
+	mustApplyAuthoritative(t, set, desc)
+	if known := set.KnownIncompatibleRelays(); len(known) != 0 {
+		t.Fatalf("KnownIncompatibleRelays() = %+v, want empty after compatible discovery", known)
+	}
+}

--- a/internal/discovery/relayset_test.go
+++ b/internal/discovery/relayset_test.go
@@ -436,3 +436,19 @@ func TestKnownIncompatibleRelaysSuppressBannedRelay(t *testing.T) {
 		t.Fatalf("KnownIncompatibleRelays() = %+v, want empty after local ban", known)
 	}
 }
+
+func TestProtocolMismatchOutranksMissingTarget(t *testing.T) {
+	set := NewRelaySet(nil)
+
+	relayURL := "https://relay-old.example"
+	_, err := set.ApplyRelayDiscoveryResponse(relayURL, types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion + "-older",
+		Relays:          nil,
+	}, time.Now().UTC())
+	if !errors.Is(err, ErrProtocolMismatch) {
+		t.Fatalf("ApplyRelayDiscoveryResponse() error = %v, want ErrProtocolMismatch even without a target descriptor", err)
+	}
+	if known := set.KnownIncompatibleRelays(); len(known) != 1 || known[0].URL != relayURL {
+		t.Fatalf("KnownIncompatibleRelays() = %+v, want one entry for %q", known, relayURL)
+	}
+}

--- a/internal/discovery/relayset_test.go
+++ b/internal/discovery/relayset_test.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -342,11 +343,15 @@ func TestProtocolMismatchKeepsOlderRelayVisibleWithoutRouting(t *testing.T) {
 
 	relayURL := "https://relay-old.example"
 	desc := mustRelayDescriptor(t, relayURL)
-	if _, err := set.ApplyRelayDiscoveryResponse(relayURL, types.DiscoveryResponse{
+	_, err := set.ApplyRelayDiscoveryResponse(relayURL, types.DiscoveryResponse{
 		ProtocolVersion: types.DiscoveryVersion + "-older",
 		Relays:          []types.RelayDescriptor{desc},
-	}, time.Now().UTC()); err == nil {
+	}, time.Now().UTC())
+	if err == nil {
 		t.Fatal("ApplyRelayDiscoveryResponse() should keep reporting the protocol mismatch")
+	}
+	if !errors.Is(err, ErrProtocolMismatch) {
+		t.Fatalf("ApplyRelayDiscoveryResponse() error = %v, want ErrProtocolMismatch", err)
 	}
 
 	known := set.KnownIncompatibleRelays()
@@ -385,7 +390,7 @@ func TestKnownIncompatibleRelaysExpireAfterRetention(t *testing.T) {
 	if known := set.knownIncompatibleRelaysAt(observedAt); len(known) != 1 {
 		t.Fatalf("knownIncompatibleRelaysAt(fresh) = %+v, want one entry", known)
 	}
-	if known := set.knownIncompatibleRelaysAt(observedAt.Add(incompatibleRelayRetention + time.Minute)); len(known) != 0 {
+	if known := set.knownIncompatibleRelaysAt(observedAt.Add(AnnounceMaxValidity + time.Minute)); len(known) != 0 {
 		t.Fatalf("knownIncompatibleRelaysAt(stale) = %+v, want empty", known)
 	}
 }
@@ -408,5 +413,26 @@ func TestCompatibleAuthoritativeDiscoveryClearsIncompatibleRelay(t *testing.T) {
 	mustApplyAuthoritative(t, set, desc)
 	if known := set.KnownIncompatibleRelays(); len(known) != 0 {
 		t.Fatalf("KnownIncompatibleRelays() = %+v, want empty after compatible discovery", known)
+	}
+}
+
+func TestKnownIncompatibleRelaysSuppressBannedRelay(t *testing.T) {
+	set := NewRelaySet(nil)
+
+	relayURL := "https://relay-old.example"
+	desc := mustRelayDescriptor(t, relayURL)
+	if _, err := set.ApplyRelayDiscoveryResponse(relayURL, types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion + "-older",
+		Relays:          []types.RelayDescriptor{desc},
+	}, time.Now().UTC()); err == nil {
+		t.Fatal("expected protocol mismatch error")
+	}
+	if known := set.KnownIncompatibleRelays(); len(known) != 1 {
+		t.Fatalf("KnownIncompatibleRelays() = %+v, want one entry before ban", known)
+	}
+
+	set.BanRelayURL(relayURL)
+	if known := set.KnownIncompatibleRelays(); len(known) != 0 {
+		t.Fatalf("KnownIncompatibleRelays() = %+v, want empty after local ban", known)
 	}
 }

--- a/portal/api_server.go
+++ b/portal/api_server.go
@@ -161,21 +161,11 @@ func (s *Server) handleRelayDiscovery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	knownIncompatible := s.relaySet.KnownIncompatibleRelays()
-	incompatible := make([]types.IncompatibleRelayEntry, 0, len(knownIncompatible))
-	for _, info := range knownIncompatible {
-		incompatible = append(incompatible, types.IncompatibleRelayEntry{
-			URL:             info.URL,
-			ProtocolVersion: info.ProtocolVersion,
-			LastSeenAt:      info.LastSeenAt,
-		})
-	}
-
 	utils.WriteAPIData(w, http.StatusOK, types.DiscoveryResponse{
 		ProtocolVersion:    types.DiscoveryVersion,
 		GeneratedAt:        now,
 		Relays:             s.relaySet.Descriptors(self),
-		IncompatibleRelays: incompatible,
+		IncompatibleRelays: s.relaySet.KnownIncompatibleRelays(),
 	})
 }
 

--- a/portal/api_server.go
+++ b/portal/api_server.go
@@ -161,10 +161,21 @@ func (s *Server) handleRelayDiscovery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	knownIncompatible := s.relaySet.KnownIncompatibleRelays()
+	incompatible := make([]types.IncompatibleRelayEntry, 0, len(knownIncompatible))
+	for _, info := range knownIncompatible {
+		incompatible = append(incompatible, types.IncompatibleRelayEntry{
+			URL:             info.URL,
+			ProtocolVersion: info.ProtocolVersion,
+			LastSeenAt:      info.LastSeenAt,
+		})
+	}
+
 	utils.WriteAPIData(w, http.StatusOK, types.DiscoveryResponse{
-		ProtocolVersion: types.DiscoveryVersion,
-		GeneratedAt:     now,
-		Relays:          s.relaySet.Descriptors(self),
+		ProtocolVersion:    types.DiscoveryVersion,
+		GeneratedAt:        now,
+		Relays:             s.relaySet.Descriptors(self),
+		IncompatibleRelays: incompatible,
 	})
 }
 

--- a/portal/server_test.go
+++ b/portal/server_test.go
@@ -13,7 +13,9 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/gosuda/portal-tunnel/v2/internal/discovery"
 	"github.com/gosuda/portal-tunnel/v2/internal/keyless"
 	"github.com/gosuda/portal-tunnel/v2/portal/acme"
 	"github.com/gosuda/portal-tunnel/v2/types"
@@ -590,5 +592,45 @@ func TestServerStartHidesDiscoveryRoutesWhenDisabled(t *testing.T) {
 	}
 	if server.config().DiscoveryEnabled {
 		t.Fatal("cfg.DiscoveryEnabled = true, want false without configured discovery service")
+	}
+}
+
+func TestRelayDiscoveryServesIncompatibleRelays(t *testing.T) {
+	t.Parallel()
+
+	server, err := NewServer(ServerConfig{
+		PortalURL:        "https://portal.example.com",
+		IdentityPath:     tempIdentityPath(t),
+		DiscoveryEnabled: true,
+	})
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	relaySet := discovery.NewRelaySet(nil)
+	relayURL := "https://relay-old.example"
+	if _, err := relaySet.ApplyRelayDiscoveryResponse(relayURL, types.DiscoveryResponse{
+		ProtocolVersion: types.DiscoveryVersion + "-older",
+	}, time.Now().UTC()); err == nil {
+		t.Fatal("expected protocol mismatch error")
+	}
+	server.relaySet = relaySet
+
+	req := httptest.NewRequest(http.MethodGet, types.PathDiscovery, nil)
+	rec := httptest.NewRecorder()
+	server.handleRelayDiscovery(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET relay discovery status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var envelope types.APIEnvelope[types.DiscoveryResponse]
+	if err := json.NewDecoder(rec.Body).Decode(&envelope); err != nil {
+		t.Fatalf("json.Decode() error = %v", err)
+	}
+	if len(envelope.Data.IncompatibleRelays) != 1 || envelope.Data.IncompatibleRelays[0].URL != relayURL {
+		t.Fatalf("IncompatibleRelays = %+v, want one entry for %q", envelope.Data.IncompatibleRelays, relayURL)
+	}
+	if envelope.Data.IncompatibleRelays[0].ProtocolVersion == "" {
+		t.Fatal("IncompatibleRelays[0].ProtocolVersion is empty, want observed protocol version")
 	}
 }

--- a/portal/server_test.go
+++ b/portal/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -195,6 +196,12 @@ func TestHTTPRedirectLifecycle(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				// Connection-per-request: with keep-alive pooling the transport
+				// races a speculative dial against parking the reused
+				// connection, and the losing dial sits silent on the server as
+				// StateNew, holding redirectServer.Shutdown() open until its 5s
+				// deadline. This test checks response semantics, not pooling.
+				req.Close = true
 				if method == http.MethodOptions {
 					req.URL.Path = "*"
 					req.URL.RawQuery = ""
@@ -609,10 +616,11 @@ func TestRelayDiscoveryServesIncompatibleRelays(t *testing.T) {
 
 	relaySet := discovery.NewRelaySet(nil)
 	relayURL := "https://relay-old.example"
-	if _, err := relaySet.ApplyRelayDiscoveryResponse(relayURL, types.DiscoveryResponse{
+	_, err = relaySet.ApplyRelayDiscoveryResponse(relayURL, types.DiscoveryResponse{
 		ProtocolVersion: types.DiscoveryVersion + "-older",
-	}, time.Now().UTC()); err == nil {
-		t.Fatal("expected protocol mismatch error")
+	}, time.Now().UTC())
+	if !errors.Is(err, discovery.ErrProtocolMismatch) {
+		t.Fatalf("ApplyRelayDiscoveryResponse() error = %v, want ErrProtocolMismatch", err)
 	}
 	server.relaySet = relaySet
 

--- a/types/api.go
+++ b/types/api.go
@@ -102,9 +102,20 @@ type RegisterResponse struct {
 }
 
 type DiscoveryResponse struct {
-	ProtocolVersion string            `json:"protocol_version"`
-	GeneratedAt     time.Time         `json:"generated_at"`
-	Relays          []RelayDescriptor `json:"relays"`
+	ProtocolVersion    string                   `json:"protocol_version"`
+	GeneratedAt        time.Time                `json:"generated_at"`
+	Relays             []RelayDescriptor        `json:"relays"`
+	IncompatibleRelays []IncompatibleRelayEntry `json:"incompatible_relays,omitempty"`
+}
+
+// IncompatibleRelayEntry describes a relay the serving relay contacted
+// directly whose discovery protocol version is incompatible with its own.
+// Such relays stay visible during rolling upgrades but never become
+// routable descriptors.
+type IncompatibleRelayEntry struct {
+	URL             string    `json:"url"`
+	ProtocolVersion string    `json:"protocol_version"`
+	LastSeenAt      time.Time `json:"last_seen_at"`
 }
 
 type DiscoveryAnnounceRequest struct {


### PR DESCRIPTION
Closes #398

## Problem

A newer relay that directly contacts an older relay learns the relay exists, but because the discovery protocol does not match, the relay never becomes a verified descriptor — and therefore disappears from `/discovery` and the frontend. Undesirable during rolling upgrades: protocol compatibility should decide whether a relay can be used for a feature, not whether it is visible at all.

## Approach

Exactly the direction suggested in the issue: minimal metadata for directly observed but protocol-incompatible relays kept **outside** the routable descriptor set.

**`internal/discovery/relayset.go`**
- Side map `incompatible map[string]types.IncompatibleRelayEntry` on `RelaySet` (single entry type, no per-layer conversions), guarded by `s.mu`
- `ApplyRelayDiscoveryResponse` records the target when an **authoritative** response reports a protocol mismatch (the direct HTTPS response itself is the observation), and deletes the entry once the target responds with a matching protocol (rolling-upgrade self-healing)
- Entries expire after `AnnounceMaxValidity` (the same 24h descriptor-validity window) without a fresh observation; expiry is enforced by pruning on the observation path and by skipping stale entries on the read path — the read path itself takes only `RLock` and never mutates state
- Local bans outrank visibility: `BanRelayURL` / `banFromPoolLocked` delete the entry, and the read path filters any straggler
- New sentinel `ErrProtocolMismatch`; the mismatch error wraps it

**`internal/discovery/refresher.go`**
- Protocol incompatibility is not a health failure: when `ApplyRelayDiscoveryResponse` returns `ErrProtocolMismatch`, the refresher logs at debug and returns without `RecordDiscoveryFailure`, so reachable-but-older relays keep being polled and their entry stays fresh instead of decaying into backoff and pool bans

**`types/api.go` / `portal/api_server.go`**
- `DiscoveryResponse` gains `incompatible_relays` (`omitempty`, additive wire change — older peers ignore it)
- `handleRelayDiscovery` serves the accessor's entries next to the normal descriptor list

**Frontend**
- `mergeIncompatibleRelays` appends incompatible relay URLs to the known-relay list and preserves the observed `protocol_version` on `KnownRelay`
- `relayReleaseLabel` falls back to `discovery <protocol>` when the `/sdk/domain` release probe fails across the version boundary, so the relay no longer renders as `offline` after discovery just contacted it

## What does NOT change

- `RelayTrust` / `RelayCandidate` / `RelayVerified` semantics untouched
- Incompatible relays never become verified or routable descriptors: they stay out of `Descriptors()`, `SelectRelays`, overlay, multihop, and MOLS, and no parallel descriptor-selection API was added. (Protocol-mismatched responses may still contribute descriptors as `RelayCandidate`s through the existing ingestion path; they just never promote to verified.)
- The mismatch error from `ApplyRelayDiscoveryResponse` is still returned; only its treatment as a health failure changed

## Verification

Go (`golang:1.27`, `GOTOOLCHAIN=local`):
- `gofmt -l` clean · `go vet ./internal/discovery/... ./portal/... ./types/...` ✅
- `go test ./internal/discovery/... ./portal/... ./types/... -count=1` ✅
- Tests cover: mismatch keeps relay visible (URL/protocol/last-seen) while excluded from descriptors/routes/verified trust; mismatch error wraps `ErrProtocolMismatch`; retention expiry (`AnnounceMaxValidity`); compatible discovery clears the entry; local ban suppresses the entry; `/discovery` envelope serves the entry

Frontend (`node:22-alpine`):
- `vitest run` full suite ✅ (49 tests, incl. merge tests asserting `protocolVersion` preservation and `relayReleaseLabel` fallbacks) · `tsc --noEmit` ✅ · `eslint --max-warnings 0` on changed files ✅

Loopback E2E (see comment): a v2.4.1+fix relay with a v2.3.8 bootstrap keeps the older relay visible in `/discovery` with its protocol version while excluding it from routable descriptors — and live protocol-8 production relays appear in `incompatible_relays` the same way.