### PR TITLE
feat(sdk): canonical event-driven relay lifecycle

### DIFF
--- a/cmd/portal-tunnel/agent/dashboard.go
+++ b/cmd/portal-tunnel/agent/dashboard.go
@@ -16,6 +16,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/gosuda/portal-tunnel/v2/sdk"
 	"github.com/gosuda/portal-tunnel/v2/types"
 	"github.com/gosuda/portal-tunnel/v2/utils"
 )
@@ -95,7 +96,6 @@ type agentDashboardModel struct {
 	selectedTunnelID string
 	selectedRelayURL string
 	activePane       agentDashboardPane
-	relayAttempts    map[string]bool
 
 	addingTunnel     bool
 	addFocus         int
@@ -237,7 +237,6 @@ func (m agentDashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.clampSelection()
 			m.ensureSelectedSettingsDraft()
-			m.syncRelayAttempts()
 			m.clampSidebarScroll()
 		}
 		return m, nil
@@ -607,84 +606,12 @@ func (m agentDashboardModel) selectedTunnelRelay() (types.AgentTunnelStatus, typ
 	return tunnel, relay, true
 }
 
-func (m *agentDashboardModel) trackRelayAttempt(tunnelID, relayURL string) {
-	key := agentDashboardRelayKey(tunnelID, relayURL)
-	if key == "" {
-		return
-	}
-	if m.relayAttempts == nil {
-		m.relayAttempts = make(map[string]bool)
-	}
-	m.relayAttempts[key] = false
-}
-
-func (m *agentDashboardModel) clearRelayAttempt(tunnelID, relayURL string) {
-	key := agentDashboardRelayKey(tunnelID, relayURL)
-	delete(m.relayAttempts, key)
-	if len(m.relayAttempts) == 0 {
-		m.relayAttempts = nil
-	}
-}
-
-func (m *agentDashboardModel) syncRelayAttempts() {
-	if len(m.relayAttempts) == 0 {
-		return
-	}
-	seen := make(map[string]struct{})
-	for _, tunnel := range m.status.Tunnels {
-		for _, relay := range tunnel.Relays {
-			key := agentDashboardRelayKey(tunnel.ID, relay.RelayURL)
-			if key == "" {
-				continue
-			}
-			seen[key] = struct{}{}
-			if _, ok := m.relayAttempts[key]; !ok {
-				continue
-			}
-			if relayDashboardConnected(tunnel, relay) {
-				delete(m.relayAttempts, key)
-				continue
-			}
-			if relay.Connecting {
-				m.relayAttempts[key] = false
-			} else {
-				m.relayAttempts[key] = true
-			}
-		}
-	}
-	for key := range m.relayAttempts {
-		if _, ok := seen[key]; !ok {
-			delete(m.relayAttempts, key)
-		}
-	}
-	if len(m.relayAttempts) == 0 {
-		m.relayAttempts = nil
-	}
-}
-
 func (m agentDashboardModel) relayDashboardFailed(tunnel types.AgentTunnelStatus, relay types.AgentRelayStatus) bool {
-	if relayDashboardConnected(tunnel, relay) || relay.Connecting {
-		return false
-	}
-	failed, ok := m.relayAttempts[agentDashboardRelayKey(tunnel.ID, relay.RelayURL)]
-	return ok && failed
+	return relay.State == string(sdk.RelayStateFailed)
 }
 
 func (m agentDashboardModel) relayDashboardConnecting(tunnel types.AgentTunnelStatus, relay types.AgentRelayStatus) bool {
-	if relayDashboardConnected(tunnel, relay) || relay.Connecting {
-		return relay.Connecting
-	}
-	failed, ok := m.relayAttempts[agentDashboardRelayKey(tunnel.ID, relay.RelayURL)]
-	return ok && !failed
-}
-
-func agentDashboardRelayKey(tunnelID, relayURL string) string {
-	tunnelID = strings.TrimSpace(tunnelID)
-	relayURL = strings.TrimSpace(relayURL)
-	if tunnelID == "" || relayURL == "" {
-		return ""
-	}
-	return tunnelID + "\x00" + relayURL
+	return relay.State == string(sdk.RelayStatePending) || relay.State == string(sdk.RelayStateRegistering)
 }
 
 func (m *agentDashboardModel) focusAddTunnelField(field int) {
@@ -1215,7 +1142,6 @@ func (m agentDashboardModel) connectSelectedRelay() (tea.Model, tea.Cmd) {
 	if relay.Banned || relayDashboardActive(tunnel, relay) || m.relayDashboardConnecting(tunnel, relay) {
 		return m, nil
 	}
-	m.trackRelayAttempt(tunnel.ID, relay.RelayURL)
 	return m, agentDashboardRun(func(ctx context.Context) error {
 		return ConnectRelay(ctx, m.stateDir, tunnel.ID, relay.RelayURL)
 	})
@@ -1229,7 +1155,6 @@ func (m agentDashboardModel) disconnectSelectedRelay() (tea.Model, tea.Cmd) {
 	if relay.Banned || !relayDashboardActive(tunnel, relay) {
 		return m, nil
 	}
-	m.clearRelayAttempt(tunnel.ID, relay.RelayURL)
 	return m, agentDashboardRun(func(ctx context.Context) error {
 		return DisconnectRelay(ctx, m.stateDir, tunnel.ID, relay.RelayURL)
 	})
@@ -1905,11 +1830,13 @@ func agentDashboardRelayStyle(selected bool, tunnel types.AgentTunnelStatus, rel
 }
 
 func relayDashboardActive(tunnel types.AgentTunnelStatus, relay types.AgentRelayStatus) bool {
-	return relayDashboardConnected(tunnel, relay) || relay.Connecting
+	return relayDashboardConnected(tunnel, relay) ||
+		relay.State == string(sdk.RelayStatePending) ||
+		relay.State == string(sdk.RelayStateRegistering)
 }
 
 func relayDashboardConnected(tunnel types.AgentTunnelStatus, relay types.AgentRelayStatus) bool {
-	return relay.PublicURL != ""
+	return relay.State == string(sdk.RelayStateReady) || relay.State == string(sdk.RelayStateDatagramReady)
 }
 
 func agentDashboardHTTPRouteSummary(route types.AgentHTTPRoute) string {
@@ -2032,18 +1959,18 @@ func relayDashboardRelayLabel(rawURL string) string {
 }
 
 func (m agentDashboardModel) relayDashboardMode(tunnel types.AgentTunnelStatus, relay types.AgentRelayStatus) string {
-	var modes []string
-	if relay.PublicURL != "" {
-		modes = append(modes, "direct")
-	} else if relay.Connecting || m.relayDashboardConnecting(tunnel, relay) {
-		modes = append(modes, "connecting...")
-	} else if m.relayDashboardFailed(tunnel, relay) {
-		modes = append(modes, "failed")
+	switch relay.State {
+	case string(sdk.RelayStateReady), string(sdk.RelayStateDatagramReady):
+		return "direct"
+	case string(sdk.RelayStatePending), string(sdk.RelayStateRegistering):
+		return "connecting..."
+	case string(sdk.RelayStateFailed):
+		return "failed"
+	case string(sdk.RelayStateRemoved):
+		return "removed"
+	default:
+		return "-"
 	}
-	if len(modes) > 0 {
-		return strings.Join(modes, ",")
-	}
-	return "-"
 }
 
 func tunnelDashboardName(tunnel types.AgentTunnelStatus) string {

--- a/sdk/expose.go
+++ b/sdk/expose.go
@@ -36,9 +36,92 @@ type Exposure struct {
 	mu             sync.RWMutex
 	relayListeners map[string]*listener
 
+	// Canonical per-relay runtime state. This is the single authoritative
+	// source for relay readiness, failure, and removal. All public status
+	// and readiness APIs consume this map directly.
+	relayStateMu sync.RWMutex
+	relayStates  map[string]*relayRuntimeState
+
+	// notifyCh is closed and replaced on every canonical state change so
+	// that WaitReady and WaitDatagramReady can react to transitions
+	// without polling.
+	notifyMu sync.Mutex
+	notifyCh chan struct{}
+
+	// updatesSubs holds fan-out channels for Updates() subscribers.
+	updatesMu   sync.Mutex
+	updatesSubs map[chan RelayUpdate]struct{}
+
 	closeOnce sync.Once
 	connSeq   atomic.Uint64
 }
+
+// RelayState is the canonical lifecycle state of a single relay runtime
+// owned by the SDK. It is the authoritative source for readiness, failure,
+// and removal; callers must not infer readiness from PublicURL alone.
+type RelayState string
+
+const (
+	// RelayStatePending is the initial state before registration begins.
+	RelayStatePending RelayState = "pending"
+	// RelayStateRegistering means the listener is actively registering a lease.
+	RelayStateRegistering RelayState = "registering"
+	// RelayStateReady means the relay has an active lease and is serving traffic.
+	RelayStateReady RelayState = "ready"
+	// RelayStateDatagramReady means the relay is ready and the UDP datagram
+	// backhaul is connected.
+	RelayStateDatagramReady RelayState = "datagram_ready"
+	// RelayStateFailed means the relay has terminally failed; the error is
+	// preserved in RelayStatus.Error.
+	RelayStateFailed RelayState = "failed"
+	// RelayStateRemoved means the relay was explicitly removed from the exposure.
+	RelayStateRemoved RelayState = "removed"
+)
+
+// RelayStatus is the canonical snapshot of a single relay runtime exposed by
+// the SDK. It is the single source of truth that the agent/dashboard and
+// external callers consume; wire projections such as types.AgentRelayStatus are
+// derived from it.
+type RelayStatus struct {
+	RelayURL    string
+	State       RelayState
+	PublicURL   string
+	Error       string
+	Version     string
+	Explicit    bool
+	Connecting  bool
+	Bootstrap   bool
+	Banned      bool
+	SupportsUDP bool
+	SupportsTCP bool
+}
+
+// relayRuntimeState is the canonical per-relay state owned by the SDK.
+// Each field is written by emitRelayEvent under relayStateMu and read by
+// Relays, Snapshot, WaitReady, and WaitDatagramReady.
+type relayRuntimeState struct {
+	state         RelayState
+	publicURL     string
+	err           error
+	udpAddr       string
+	datagramReady bool
+	version       string
+	explicit      bool
+}
+
+// RelayUpdate is emitted through Exposure.Updates() when a relay's
+// canonical state changes.
+type RelayUpdate struct {
+	RelayURL  string
+	State     RelayState
+	PublicURL string
+	Error     string
+}
+
+// ErrNoRelays indicates that the relay pool is exhausted: no relays are
+// available and discovery cannot yield new candidates. It is distinct
+// from a temporary zero-relay state where discovery is still active.
+var ErrNoRelays = errors.New("no relays available")
 
 type ExposeConfig struct {
 	RelayURLs []string
@@ -138,6 +221,9 @@ func Expose(ctx context.Context, cfg ExposeConfig) (*Exposure, error) {
 		datagrams:      make(chan types.DatagramFrame, max(initialRouteCount*32, 1)),
 		relaySet:       discovery.NewRelaySet(relaySetURLs),
 		relayListeners: make(map[string]*listener, initialRouteCount),
+		relayStates:    make(map[string]*relayRuntimeState, initialRouteCount),
+		notifyCh:       make(chan struct{}),
+		updatesSubs:    make(map[chan RelayUpdate]struct{}),
 	}
 
 	if cfg.Discovery {
@@ -165,6 +251,230 @@ func Expose(ctx context.Context, cfg ExposeConfig) (*Exposure, error) {
 	}()
 
 	return exposure, nil
+}
+
+// emitRelayEvent updates the canonical per-relay state and notifies all
+// waiters and Updates() subscribers. It is called by listener lifecycle
+// transitions and by reconcileRelayListeners for add/remove events.
+func (e *Exposure) emitRelayEvent(relayURL string, state RelayState, publicURL string, err error, udpAddr string, datagramReady bool, version string, explicit bool) {
+	if relayURL == "" {
+		return
+	}
+
+	e.relayStateMu.Lock()
+	if e.relayStates == nil {
+		e.relayStates = make(map[string]*relayRuntimeState)
+	}
+	rs, exists := e.relayStates[relayURL]
+	if !exists {
+		rs = &relayRuntimeState{}
+		e.relayStates[relayURL] = rs
+	}
+	rs.state = state
+	rs.publicURL = publicURL
+	rs.err = err
+	rs.udpAddr = udpAddr
+	rs.datagramReady = datagramReady
+	rs.version = version
+	rs.explicit = explicit
+	e.relayStateMu.Unlock()
+
+	// Wake up WaitReady / WaitDatagramReady.
+	e.notifyMu.Lock()
+	if e.notifyCh == nil {
+		e.notifyCh = make(chan struct{})
+	}
+	close(e.notifyCh)
+	e.notifyCh = make(chan struct{})
+	e.notifyMu.Unlock()
+
+	// Fan-out to Updates() subscribers.
+	update := RelayUpdate{
+		RelayURL:  relayURL,
+		State:     state,
+		PublicURL: publicURL,
+	}
+	if err != nil {
+		update.Error = err.Error()
+	}
+	e.updatesMu.Lock()
+	for ch := range e.updatesSubs {
+		select {
+		case ch <- update:
+		default:
+		}
+	}
+	e.updatesMu.Unlock()
+}
+
+// notifyChan returns the current notification channel. It is closed when
+// the canonical state changes.
+func (e *Exposure) notifyChan() chan struct{} {
+	e.notifyMu.Lock()
+	ch := e.notifyCh
+	if ch == nil {
+		ch = make(chan struct{})
+	}
+	e.notifyMu.Unlock()
+	return ch
+}
+
+// Relays returns a snapshot of all relay statuses derived from the
+// canonical per-relay state, merged with relay-set discovery metadata.
+// This is the single source of truth that Snapshot, the agent dashboard,
+// and external callers consume.
+// Relays returns a snapshot of all relay statuses derived from the
+// canonical per-relay state, merged with relay-set discovery metadata.
+// This is the single source of truth that the agent dashboard and
+// external callers consume.
+func (e *Exposure) Relays() []RelayStatus {
+	cfg := e.Config()
+
+	e.relayStateMu.RLock()
+	relayByURL := make(map[string]RelayStatus, len(e.relayStates))
+	for relayURL, rs := range e.relayStates {
+		snap := RelayStatus{
+			RelayURL:   relayURL,
+			State:      rs.state,
+			PublicURL:  rs.publicURL,
+			Version:    rs.version,
+			Explicit:   rs.explicit,
+			Connecting: rs.explicit && (rs.state == RelayStatePending || rs.state == RelayStateRegistering),
+		}
+		if rs.err != nil {
+			snap.Error = rs.err.Error()
+		}
+		relayByURL[relayURL] = snap
+	}
+	e.relayStateMu.RUnlock()
+
+	// Merge relay-set discovery state (banned, bootstrap, transport caps).
+	if e.relaySet != nil {
+		for _, state := range e.relaySet.AllRelays() {
+			relayURL := strings.TrimSpace(state.Descriptor.APIHTTPSAddr)
+			if relayURL == "" {
+				continue
+			}
+			if state.Dead {
+				delete(relayByURL, relayURL)
+				continue
+			}
+			snap := relayByURL[relayURL]
+			snap.RelayURL = relayURL
+			snap.Explicit = slices.Contains(cfg.RelayURLs, relayURL)
+			snap.Bootstrap = state.Bootstrap
+			snap.Banned = state.Banned
+			snap.SupportsUDP = state.Descriptor.SupportsUDP
+			snap.SupportsTCP = state.Descriptor.SupportsTCP
+			relayByURL[relayURL] = snap
+		}
+	}
+
+	relays := make([]RelayStatus, 0, len(relayByURL))
+	for _, snap := range relayByURL {
+		relays = append(relays, snap)
+	}
+	slices.SortFunc(relays, func(a, b RelayStatus) int {
+		aReady := a.State == RelayStateReady || a.State == RelayStateDatagramReady
+		bReady := b.State == RelayStateReady || b.State == RelayStateDatagramReady
+		if aReady != bReady {
+			if aReady {
+				return -1
+			}
+			return 1
+		}
+		if a.Connecting != b.Connecting {
+			if a.Connecting {
+				return -1
+			}
+			return 1
+		}
+		return strings.Compare(a.RelayURL, b.RelayURL)
+	})
+	return relays
+}
+
+// Updates returns a channel that receives a RelayUpdate every time a
+// relay's canonical state changes. The channel is buffered; events are
+// dropped if the buffer is full. The channel is closed when the exposure
+// is closed.
+func (e *Exposure) Updates() <-chan RelayUpdate {
+	ch := make(chan RelayUpdate, 32)
+	e.updatesMu.Lock()
+	e.updatesSubs[ch] = struct{}{}
+	e.updatesMu.Unlock()
+	return ch
+}
+
+// WaitReady blocks until at least one relay reaches the ready or
+// datagramReady state, or returns ErrNoRelays when the relay pool is
+// exhausted (no relays and discovery is disabled, or all relays have
+// terminally failed and discovery cannot yield new candidates).
+func (e *Exposure) WaitReady(ctx context.Context) error {
+	for {
+		if e.closed() {
+			return net.ErrClosed
+		}
+
+		e.relayStateMu.RLock()
+		hasReady := false
+		hasPending := false
+		activeRelays := 0
+		for _, rs := range e.relayStates {
+			if rs.state == RelayStateRemoved {
+				continue
+			}
+			activeRelays++
+			switch rs.state {
+			case RelayStateReady, RelayStateDatagramReady:
+				hasReady = true
+			case RelayStatePending, RelayStateRegistering:
+				hasPending = true
+			}
+		}
+		e.relayStateMu.RUnlock()
+
+		if hasReady {
+			return nil
+		}
+
+		discovery := e.Config().Discovery
+		if activeRelays == 0 && !discovery {
+			return ErrNoRelays
+		}
+		if !hasPending && !discovery {
+			return ErrNoRelays
+		}
+
+		select {
+		case <-e.done:
+			return net.ErrClosed
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-e.notifyChan():
+		}
+	}
+}
+
+// removeRelayState deletes a relay from the canonical state map and
+// notifies waiters. Called when a relay is explicitly removed via
+// RemoveRelay or when reconcileRelayListeners drops a stale listener
+// that was never started.
+func (e *Exposure) removeRelayState(relayURL string) {
+	if relayURL == "" {
+		return
+	}
+	e.relayStateMu.Lock()
+	if e.relayStates != nil {
+		delete(e.relayStates, relayURL)
+	}
+	e.relayStateMu.Unlock()
+	e.notifyMu.Lock()
+	if e.notifyCh != nil {
+		close(e.notifyCh)
+		e.notifyCh = make(chan struct{})
+	}
+	e.notifyMu.Unlock()
 }
 
 // AddRelay attaches an explicit relay to the running exposure without
@@ -299,83 +609,30 @@ func (e *Exposure) Identity() types.Identity {
 
 func (e *Exposure) Snapshot() types.AgentTunnelStatus {
 	cfg := e.Config()
-	e.mu.RLock()
-	listeners := make([]*listener, 0, len(e.relayListeners))
-	for _, listener := range e.relayListeners {
-		if listener != nil {
-			listeners = append(listeners, listener)
+	relays := e.Relays()
+	agentRelays := make([]types.AgentRelayStatus, len(relays))
+	for i, r := range relays {
+		agentRelays[i] = types.AgentRelayStatus{
+			RelayURL:    r.RelayURL,
+			State:       string(r.State),
+			PublicURL:   r.PublicURL,
+			Error:       r.Error,
+			Version:     r.Version,
+			Explicit:    r.Explicit,
+			Connecting:  r.Connecting,
+			Bootstrap:   r.Bootstrap,
+			Banned:      r.Banned,
+			SupportsUDP: r.SupportsUDP,
+			SupportsTCP: r.SupportsTCP,
 		}
 	}
-	e.mu.RUnlock()
-
-	relayByURL := make(map[string]types.AgentRelayStatus, len(listeners))
-	for _, listener := range listeners {
-		relayURL := listener.route.RelayURL
-		explicit := slices.Contains(cfg.RelayURLs, relayURL)
-		snap := types.AgentRelayStatus{
-			RelayURL:   relayURL,
-			Version:    listener.releaseVersion,
-			Explicit:   explicit,
-			Connecting: explicit,
-		}
-		if lease, ok := listener.leaseSnapshot(); ok {
-			snap.PublicURL = listener.publicURLForLease(lease)
-			snap.Connecting = snap.PublicURL == ""
-		}
-		if relayURL != "" {
-			relayByURL[relayURL] = snap
-		}
-	}
-	if e.relaySet != nil {
-		for _, state := range e.relaySet.AllRelays() {
-			relay := state.Descriptor
-			relayURL := strings.TrimSpace(relay.APIHTTPSAddr)
-			if relayURL == "" {
-				continue
-			}
-			if state.Dead {
-				delete(relayByURL, relayURL)
-				continue
-			}
-			snap := relayByURL[relayURL]
-			snap.RelayURL = relayURL
-			snap.Explicit = slices.Contains(cfg.RelayURLs, relayURL)
-			snap.Bootstrap = state.Bootstrap
-			snap.Banned = state.Banned
-			snap.SupportsUDP = relay.SupportsUDP
-			snap.SupportsTCP = relay.SupportsTCP
-			relayByURL[relayURL] = snap
-		}
-	}
-	relays := make([]types.AgentRelayStatus, 0, len(relayByURL))
-	for _, snap := range relayByURL {
-		relays = append(relays, snap)
-	}
-	slices.SortFunc(relays, func(a, b types.AgentRelayStatus) int {
-		aReady := a.PublicURL != ""
-		bReady := b.PublicURL != ""
-		if aReady != bReady {
-			if aReady {
-				return -1
-			}
-			return 1
-		}
-		if a.Connecting != b.Connecting {
-			if a.Connecting {
-				return -1
-			}
-			return 1
-		}
-		return strings.Compare(a.RelayURL, b.RelayURL)
-	})
-
 	return types.AgentTunnelStatus{
 		Address:         cfg.Identity.Address,
 		TargetAddr:      cfg.TargetAddr,
 		Overlay:         cfg.Overlay,
 		MaxActiveRelays: cfg.MaxActiveRelays,
 		Metadata:        cfg.Metadata,
-		Relays:          relays,
+		Relays:          agentRelays,
 	}
 }
 
@@ -411,36 +668,57 @@ func (e *Exposure) WaitDatagramReady(ctx context.Context) ([]string, error) {
 		return nil, errors.New("exposure does not have udp enabled")
 	}
 
-	ticker := time.NewTicker(50 * time.Millisecond)
-	defer ticker.Stop()
-
 	for {
-		e.mu.RLock()
-		addrs := make([]string, 0, len(e.relayListeners))
+		if e.closed() {
+			return nil, net.ErrClosed
+		}
+
+		e.relayStateMu.RLock()
+		addrs := make([]string, 0)
 		seen := make(map[string]struct{})
-		resolvedWithoutDatagram := true
-		for _, listener := range e.relayListeners {
-			if listener == nil {
+		hasPending := false
+		hasReadyWithoutDatagram := false
+		activeRelays := 0
+		for _, rs := range e.relayStates {
+			if rs.state == RelayStateRemoved {
 				continue
 			}
-
-			udpAddr, ready, pending := listener.datagramReady()
-			if ready {
-				if _, ok := seen[udpAddr]; !ok {
-					seen[udpAddr] = struct{}{}
-					addrs = append(addrs, udpAddr)
+			activeRelays++
+			switch rs.state {
+			case RelayStateDatagramReady:
+				if rs.udpAddr != "" {
+					if _, ok := seen[rs.udpAddr]; !ok {
+						seen[rs.udpAddr] = struct{}{}
+						addrs = append(addrs, rs.udpAddr)
+					}
 				}
-			}
-			if pending {
-				resolvedWithoutDatagram = false
+			case RelayStateReady:
+				// A ready relay with a UDP address may still connect its
+				// datagram backhaul; one without a UDP address is resolved.
+				if rs.udpAddr != "" {
+					hasPending = true
+				} else {
+					hasReadyWithoutDatagram = true
+				}
+			case RelayStatePending, RelayStateRegistering:
+				hasPending = true
 			}
 		}
-		e.mu.RUnlock()
+		e.relayStateMu.RUnlock()
+
 		if len(addrs) > 0 {
 			return addrs, nil
 		}
-		if resolvedWithoutDatagram {
-			return nil, errors.New("relay did not expose udp")
+
+		discovery := e.Config().Discovery
+		if activeRelays == 0 && !discovery {
+			return nil, ErrNoRelays
+		}
+		if !hasPending && !discovery {
+			if hasReadyWithoutDatagram {
+				return nil, errors.New("relay did not expose udp")
+			}
+			return nil, ErrNoRelays
 		}
 
 		select {
@@ -448,7 +726,7 @@ func (e *Exposure) WaitDatagramReady(ctx context.Context) ([]string, error) {
 			return nil, net.ErrClosed
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-ticker.C:
+		case <-e.notifyChan():
 		}
 	}
 }
@@ -577,6 +855,31 @@ func (e *Exposure) Close() error {
 			}
 		}
 
+		// Emit removed events for all relays in the canonical state.
+		e.relayStateMu.Lock()
+		if e.relayStates != nil {
+			for relayURL := range e.relayStates {
+				e.relayStates[relayURL].state = RelayStateRemoved
+			}
+		}
+		e.relayStateMu.Unlock()
+		e.notifyMu.Lock()
+		if e.notifyCh != nil {
+			close(e.notifyCh)
+			e.notifyCh = make(chan struct{})
+		}
+		e.notifyMu.Unlock()
+
+		// Close all Updates() subscriber channels.
+		e.updatesMu.Lock()
+		if e.updatesSubs != nil {
+			for ch := range e.updatesSubs {
+				close(ch)
+				delete(e.updatesSubs, ch)
+			}
+		}
+		e.updatesMu.Unlock()
+
 		event := log.Debug().
 			Int("relay_count", len(relayListeners)).
 			Strs("relays", relayURLs)
@@ -660,6 +963,7 @@ func (e *Exposure) reconcileRelayListeners(failOnError bool) error {
 		if listener == nil {
 			continue
 		}
+		e.emitRelayEvent(relayURL, RelayStateRemoved, "", nil, "", false, "", false)
 		if err := listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
 			log.Warn().Err(err).Str("relay_url", relayURL).Msg("close stale relay listener")
 		}
@@ -682,6 +986,7 @@ func (e *Exposure) reconcileRelayListeners(failOnError bool) error {
 			},
 			RetryCount: retryCount,
 			relaySet:   e.relaySet,
+			onEvent:    e.emitRelayEvent,
 		})
 		if err != nil {
 			if failOnError {

--- a/sdk/listener.go
+++ b/sdk/listener.go
@@ -28,6 +28,11 @@ import (
 	"github.com/gosuda/portal-tunnel/v2/utils"
 )
 
+// relayEventFunc is called by a listener when its canonical lifecycle state
+// changes. The Exposure sets this callback to update its canonical state
+// map and notify waiters.
+type relayEventFunc func(relayURL string, state RelayState, publicURL string, err error, udpAddr string, datagramReady bool, version string, explicit bool)
+
 type listenerConfig struct {
 	Identity   types.Identity
 	Overlay    bool
@@ -38,6 +43,7 @@ type listenerConfig struct {
 	Metadata   func() types.LeaseMetadata
 	RetryCount int
 	relaySet   *discovery.RelaySet
+	onEvent    relayEventFunc
 }
 
 var errLeaseRefreshRequired = errors.New("lease refresh required")
@@ -85,6 +91,7 @@ func (l *listener) closeForTerminalRelayError(err error) bool {
 		Str("relay_url", relayURL).
 		Str("address", l.identity.Address).
 		Msg("relay operation failed permanently; closing listener")
+	l.emitState(RelayStateFailed, "", err)
 	_ = l.Close()
 	return true
 }
@@ -101,6 +108,7 @@ type listener struct {
 	overlay           bool
 	warnOverlayDirect sync.Once
 	relaySet          *discovery.RelaySet
+	onEvent           relayEventFunc
 	udpEnabled        bool
 	tcpEnabled        bool
 	echEnabled        bool
@@ -153,6 +161,7 @@ func newListener(ctx context.Context, route discovery.Route, cfg listenerConfig)
 		identity:       cfg.Identity.Copy(),
 		overlay:        cfg.Overlay,
 		relaySet:       cfg.relaySet,
+		onEvent:        cfg.onEvent,
 		udpEnabled:     cfg.UDPEnabled,
 		tcpEnabled:     cfg.TCPEnabled,
 		echEnabled:     cfg.ECH,
@@ -176,9 +185,30 @@ func newListener(ctx context.Context, route discovery.Route, cfg listenerConfig)
 				Msg("quic backhaul disconnected; waiting to reconnect")
 		})
 	}
-
+	l.emitState(RelayStatePending, "", nil)
 	go l.run(listenerCtx)
 	return l, nil
+}
+
+// emitState reports a lifecycle state transition to the Exposure via the
+// onEvent callback. If the callback is nil (e.g. in unit tests) this is a no-op.
+func (l *listener) emitState(state RelayState, publicURL string, err error) {
+	if l.onEvent == nil {
+		return
+	}
+	relayURL := l.route.RelayURL
+	udpAddr := ""
+	datagramReady := false
+	if lease, ok := l.leaseSnapshot(); ok {
+		udpAddr = lease.udpAddr
+	}
+	if l.datagram != nil && l.datagram.Connected() && udpAddr != "" {
+		datagramReady = true
+		if state == RelayStateReady {
+			state = RelayStateDatagramReady
+		}
+	}
+	l.onEvent(relayURL, state, publicURL, err, udpAddr, datagramReady, l.releaseVersion, l.route.Explicit)
 }
 
 func (l *listener) metadataSnapshot() types.LeaseMetadata {
@@ -192,6 +222,7 @@ func (l *listener) run(ctx context.Context) {
 	var retries int
 
 	for {
+		l.emitState(RelayStateRegistering, "", nil)
 		err := l.registerAndConfigure(ctx)
 		switch {
 		case err == nil:
@@ -203,6 +234,7 @@ func (l *listener) run(ctx context.Context) {
 			}
 			retries++
 			if !l.waitRetry(ctx, "lease registration", err, retries, 0) {
+				l.emitState(RelayStateFailed, "", err)
 				_ = l.Close()
 				return
 			}
@@ -218,6 +250,7 @@ func (l *listener) run(ctx context.Context) {
 			udpAddr = lease.udpAddr
 			tcpAddr = lease.tcpAddr
 		}
+		l.emitState(RelayStateReady, publicURL, nil)
 		event := log.Info().Str("address", l.identity.Address)
 		if udpAddr != "" {
 			event = event.Str("udp_addr", udpAddr)
@@ -262,6 +295,7 @@ func (l *listener) run(ctx context.Context) {
 			Str("relay_url", relayURL).
 			Str("address", l.identity.Address).
 			Msg("listener connection retry budget exhausted; closing listener")
+		l.emitState(RelayStateFailed, "", err)
 		_ = l.Close()
 		return
 	}
@@ -632,6 +666,12 @@ func (l *listener) runDatagramLoop(ctx context.Context) {
 			}
 			continue
 		}
+
+		publicURL := ""
+		if lease, ok := l.leaseSnapshot(); ok {
+			publicURL = l.publicURLForLease(lease)
+		}
+		l.emitState(RelayStateDatagramReady, publicURL, nil)
 
 		select {
 		case <-ctx.Done():

--- a/sdk/relay_state_test.go
+++ b/sdk/relay_state_test.go
@@ -1,0 +1,367 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gosuda/portal-tunnel/v2/internal/discovery"
+	"github.com/gosuda/portal-tunnel/v2/utils"
+)
+
+// newTestExposure creates an Exposure with canonical state fields initialized
+// for unit testing without starting real listeners.
+func newTestExposure(t *testing.T, cfg ExposeConfig, relayURLs ...string) *Exposure {
+	t.Helper()
+	exposure := &Exposure{
+		cfg:            utils.NewSnapshot(cfg, ExposeConfig.snapshot),
+		relaySet:       discovery.NewRelaySet(relayURLs),
+		relayListeners: make(map[string]*listener),
+		relayStates:    make(map[string]*relayRuntimeState),
+		notifyCh:       make(chan struct{}),
+		updatesSubs:    make(map[chan RelayUpdate]struct{}),
+		done:           make(chan struct{}),
+	}
+	return exposure
+}
+
+func TestRelaysReturnsCanonicalState(t *testing.T) {
+	exposure := newTestExposure(t, ExposeConfig{RelayURLs: []string{"https://relay-a.example"}})
+
+	exposure.emitRelayEvent("https://relay-a.example", RelayStateReady, "https://app.example", nil, "", false, "v1.0", true)
+
+	relays := exposure.Relays()
+	if len(relays) != 1 {
+		t.Fatalf("Relays() = %d relays, want 1", len(relays))
+	}
+	r := relays[0]
+	if r.RelayURL != "https://relay-a.example" {
+		t.Fatalf("RelayURL = %q, want %q", r.RelayURL, "https://relay-a.example")
+	}
+	if r.State != RelayStateReady {
+		t.Fatalf("State = %q, want %q", r.State, RelayStateReady)
+	}
+	if r.PublicURL != "https://app.example" {
+		t.Fatalf("PublicURL = %q, want %q", r.PublicURL, "https://app.example")
+	}
+	if r.Version != "v1.0" {
+		t.Fatalf("Version = %q, want %q", r.Version, "v1.0")
+	}
+	if !r.Explicit {
+		t.Fatal("Explicit = false, want true")
+	}
+}
+
+func TestRelaysPreservesTerminalFailure(t *testing.T) {
+	exposure := newTestExposure(t, ExposeConfig{RelayURLs: []string{"https://relay-a.example"}})
+
+	relayErr := errors.New("hostname conflict")
+	exposure.emitRelayEvent("https://relay-a.example", RelayStateFailed, "", relayErr, "", false, "", true)
+
+	relays := exposure.Relays()
+	if len(relays) != 1 {
+		t.Fatalf("Relays() = %d relays, want 1", len(relays))
+	}
+	r := relays[0]
+	if r.State != RelayStateFailed {
+		t.Fatalf("State = %q, want %q", r.State, RelayStateFailed)
+	}
+	if r.Error != relayErr.Error() {
+		t.Fatalf("Error = %q, want %q", r.Error, relayErr.Error())
+	}
+	if r.PublicURL != "" {
+		t.Fatalf("PublicURL = %q, want empty", r.PublicURL)
+	}
+}
+
+func TestRelaysIndependentRelayFailure(t *testing.T) {
+	exposure := newTestExposure(t, ExposeConfig{RelayURLs: []string{"https://relay-a.example", "https://relay-b.example"}})
+
+	exposure.emitRelayEvent("https://relay-a.example", RelayStateReady, "https://app-a.example", nil, "", false, "v1", true)
+	exposure.emitRelayEvent("https://relay-b.example", RelayStateFailed, "", errors.New("banned"), "", false, "", true)
+
+	relays := exposure.Relays()
+	if len(relays) != 2 {
+		t.Fatalf("Relays() = %d relays, want 2", len(relays))
+	}
+
+	relayByURL := make(map[string]RelayStatus, len(relays))
+	for _, r := range relays {
+		relayByURL[r.RelayURL] = r
+	}
+
+	relayA := relayByURL["https://relay-a.example"]
+	if relayA.State != RelayStateReady {
+		t.Fatalf("relay-a State = %q, want %q", relayA.State, RelayStateReady)
+	}
+	if relayA.PublicURL != "https://app-a.example" {
+		t.Fatalf("relay-a PublicURL = %q, want %q", relayA.PublicURL, "https://app-a.example")
+	}
+
+	relayB := relayByURL["https://relay-b.example"]
+	if relayB.State != RelayStateFailed {
+		t.Fatalf("relay-b State = %q, want %q", relayB.State, RelayStateFailed)
+	}
+	if relayB.Error != "banned" {
+		t.Fatalf("relay-b Error = %q, want %q", relayB.Error, "banned")
+	}
+}
+
+func TestWaitReadyReturnsWhenRelayBecomesReady(t *testing.T) {
+	exposure := newTestExposure(t, ExposeConfig{RelayURLs: []string{"https://relay-a.example"}})
+
+	exposure.emitRelayEvent("https://relay-a.example", RelayStatePending, "", nil, "", false, "", true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- exposure.WaitReady(ctx)
+	}()
+
+	// Simulate the relay becoming ready after a short delay.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		exposure.emitRelayEvent("https://relay-a.example", RelayStateReady, "https://app.example", nil, "", false, "", true)
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("WaitReady() error = %v, want nil", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("WaitReady() timed out")
+	}
+}
+
+func TestWaitReadyReturnsErrNoRelaysWhenAllFailedNoDiscovery(t *testing.T) {
+	exposure := newTestExposure(t, ExposeConfig{RelayURLs: []string{"https://relay-a.example"}, Discovery: false})
+
+	exposure.emitRelayEvent("https://relay-a.example", RelayStateFailed, "", errors.New("banned"), "", false, "", true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := exposure.WaitReady(ctx)
+	if !errors.Is(err, ErrNoRelays) {
+		t.Fatalf("WaitReady() error = %v, want ErrNoRelays", err)
+	}
+}
+
+func TestWaitReadyWaitsWhenDiscoveryEnabled(t *testing.T) {
+	exposure := newTestExposure(t, ExposeConfig{RelayURLs: []string{"https://relay-a.example"}, Discovery: true})
+
+	exposure.emitRelayEvent("https://relay-a.example", RelayStateFailed, "", errors.New("banned"), "", false, "", true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := exposure.WaitReady(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WaitReady() error = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestWaitReadyReturnsErrNoRelaysWhenNoRelaysNoDiscovery(t *testing.T) {
+	exposure := newTestExposure(t, ExposeConfig{Discovery: false})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := exposure.WaitReady(ctx)
+	if !errors.Is(err, ErrNoRelays) {
+		t.Fatalf("WaitReady() error = %v, want ErrNoRelays", err)
+	}
+}
+
+func TestWaitDatagramReadyReturnsAddresses(t *testing.T) {
+	exposure := newTestExposeWithDone(t, ExposeConfig{UDPEnabled: true, RelayURLs: []string{"https://relay-a.example"}})
+
+	exposure.emitRelayEvent("https://relay-a.example", RelayStateDatagramReady, "https://app.example", nil, "1.2.3.4:5678", true, "", true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	addrs, err := exposure.WaitDatagramReady(ctx)
+	if err != nil {
+		t.Fatalf("WaitDatagramReady() error = %v, want nil", err)
+	}
+	if len(addrs) != 1 || addrs[0] != "1.2.3.4:5678" {
+		t.Fatalf("WaitDatagramReady() = %v, want [1.2.3.4:5678]", addrs)
+	}
+}
+
+func TestWaitDatagramReadyEventDriven(t *testing.T) {
+	exposure := newTestExposure(t, ExposeConfig{UDPEnabled: true, RelayURLs: []string{"https://relay-a.example"}})
+
+	exposure.emitRelayEvent("https://relay-a.example", RelayStateReady, "https://app.example", nil, "1.2.3.4:5678", false, "", true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	addrCh := make(chan []string, 1)
+	go func() {
+		addrs, err := exposure.WaitDatagramReady(ctx)
+		errCh <- err
+		addrCh <- addrs
+	}()
+
+	// Simulate the datagram backhaul connecting after a short delay.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		exposure.emitRelayEvent("https://relay-a.example", RelayStateDatagramReady, "https://app.example", nil, "1.2.3.4:5678", true, "", true)
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("WaitDatagramReady() error = %v, want nil", err)
+		}
+		addrs := <-addrCh
+		if len(addrs) != 1 || addrs[0] != "1.2.3.4:5678" {
+			t.Fatalf("WaitDatagramReady() = %v, want [1.2.3.4:5678]", addrs)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("WaitDatagramReady() timed out")
+	}
+}
+
+func TestWaitDatagramReadyReturnsErrorWhenNoUDP(t *testing.T) {
+	exposure := newTestExposure(t, ExposeConfig{UDPEnabled: true, RelayURLs: []string{"https://relay-a.example"}, Discovery: false})
+
+	// Relay is ready but has no UDP address.
+	exposure.emitRelayEvent("https://relay-a.example", RelayStateReady, "https://app.example", nil, "", false, "", true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	addrs, err := exposure.WaitDatagramReady(ctx)
+	if err == nil {
+		t.Fatalf("WaitDatagramReady() error = nil, want error; addrs=%v", addrs)
+	}
+	if !strings.Contains(err.Error(), "did not expose udp") && !errors.Is(err, ErrNoRelays) {
+		t.Fatalf("WaitDatagramReady() error = %v, want 'did not expose udp' or ErrNoRelays", err)
+	}
+}
+
+func TestUpdatesReceivesEvents(t *testing.T) {
+	exposure := newTestExposure(t, ExposeConfig{RelayURLs: []string{"https://relay-a.example"}})
+
+	updates := exposure.Updates()
+
+	exposure.emitRelayEvent("https://relay-a.example", RelayStatePending, "", nil, "", false, "", true)
+
+	select {
+	case update := <-updates:
+		if update.RelayURL != "https://relay-a.example" {
+			t.Fatalf("update.RelayURL = %q, want %q", update.RelayURL, "https://relay-a.example")
+		}
+		if update.State != RelayStatePending {
+			t.Fatalf("update.State = %q, want %q", update.State, RelayStatePending)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("did not receive update event")
+	}
+
+	exposure.emitRelayEvent("https://relay-a.example", RelayStateReady, "https://app.example", nil, "", false, "", true)
+
+	select {
+	case update := <-updates:
+		if update.State != RelayStateReady {
+			t.Fatalf("update.State = %q, want %q", update.State, RelayStateReady)
+		}
+		if update.PublicURL != "https://app.example" {
+			t.Fatalf("update.PublicURL = %q, want %q", update.PublicURL, "https://app.example")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("did not receive ready update event")
+	}
+}
+
+func TestUpdatesReceivesFailureEvent(t *testing.T) {
+	exposure := newTestExposure(t, ExposeConfig{RelayURLs: []string{"https://relay-a.example"}})
+
+	updates := exposure.Updates()
+
+	relayErr := errors.New("hostname conflict")
+	exposure.emitRelayEvent("https://relay-a.example", RelayStateFailed, "", relayErr, "", false, "", true)
+
+	select {
+	case update := <-updates:
+		if update.State != RelayStateFailed {
+			t.Fatalf("update.State = %q, want %q", update.State, RelayStateFailed)
+		}
+		if update.Error != relayErr.Error() {
+			t.Fatalf("update.Error = %q, want %q", update.Error, relayErr.Error())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("did not receive failure update event")
+	}
+}
+
+func TestSnapshotConsumesCanonicalState(t *testing.T) {
+	exposure := newTestExposure(t, ExposeConfig{
+		RelayURLs: []string{"https://relay-a.example"},
+	})
+
+	exposure.emitRelayEvent("https://relay-a.example", RelayStateReady, "https://app.example", nil, "", false, "v2.0", true)
+
+	snap := exposure.Snapshot()
+	if len(snap.Relays) != 1 {
+		t.Fatalf("Snapshot().Relays = %d, want 1", len(snap.Relays))
+	}
+	r := snap.Relays[0]
+	if r.State != string(RelayStateReady) {
+		t.Fatalf("State = %q, want %q", r.State, RelayStateReady)
+	}
+	if r.PublicURL != "https://app.example" {
+		t.Fatalf("PublicURL = %q, want %q", r.PublicURL, "https://app.example")
+	}
+}
+
+func TestEmitRelayEventDoesNotInferReadinessFromPublicURL(t *testing.T) {
+	exposure := newTestExposure(t, ExposeConfig{RelayURLs: []string{"https://relay-a.example"}})
+
+	// A relay in pending state with a non-empty public URL should still be pending.
+	exposure.emitRelayEvent("https://relay-a.example", RelayStatePending, "https://should-not-happen.example", nil, "", false, "", true)
+
+	relays := exposure.Relays()
+	if len(relays) != 1 {
+		t.Fatalf("Relays() = %d relays, want 1", len(relays))
+	}
+	if relays[0].State != RelayStatePending {
+		t.Fatalf("State = %q, want %q", relays[0].State, RelayStatePending)
+	}
+}
+
+func TestWaitReadyReturnsNetErrClosedWhenExposureClosed(t *testing.T) {
+	done := make(chan struct{})
+	close(done)
+	exposure := &Exposure{
+		cfg:         utils.NewSnapshot(ExposeConfig{RelayURLs: []string{"https://relay-a.example"}}, ExposeConfig.snapshot),
+		relayStates: make(map[string]*relayRuntimeState),
+		notifyCh:    make(chan struct{}),
+		updatesSubs: make(map[chan RelayUpdate]struct{}),
+		done:        done,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := exposure.WaitReady(ctx)
+	if !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("WaitReady() error = %v, want net.ErrClosed", err)
+	}
+}
+
+// newTestExposureWithDone is an alias for clarity in tests that need a
+// non-closed done channel.
+func newTestExposeWithDone(t *testing.T, cfg ExposeConfig, relayURLs ...string) *Exposure {
+	return newTestExposure(t, cfg, relayURLs...)
+}

--- a/types/agent.go
+++ b/types/agent.go
@@ -37,7 +37,9 @@ type AgentHTTPRoute struct {
 
 type AgentRelayStatus struct {
 	RelayURL    string `json:"relay_url"`
+	State       string `json:"state"`
 	PublicURL   string `json:"public_url,omitempty"`
+	Error       string `json:"error,omitempty"`
 	Version     string `json:"version,omitempty"`
 	Explicit    bool   `json:"explicit,omitempty"`
 	Connecting  bool   `json:"connecting"`


### PR DESCRIPTION
Closes #402. Parent: #400.

## Summary

Refactors the SDK so each relay has an independently supervised canonical state machine owned by `sdk.Exposure`. Public status and readiness APIs consume that state directly instead of inferring readiness from `PublicURL != ""` or polling on timers. Terminal failures are preserved in observable state, and one relay's failure no longer terminates healthy relays.

The canonical relay state types (`RelayState`, `RelayStatus`, `RelayUpdate`) live in package `sdk`. `types.AgentRelayStatus` is a wire projection built by `Exposure.Snapshot()` and by `cmd/portal-tunnel/agent`, not the authoritative source.

## Changes

- `sdk/expose.go`: add canonical per-relay state map, `Relays`, `Updates`, `WaitReady`, `WaitDatagramReady`, `ErrNoRelays`; make `Snapshot()` build the wire projection locally.
- `sdk/listener.go`: add `onEvent` callback so each relay runtime reports its own lifecycle transitions to `Exposure`.
- `types/agent.go`: remove `RelayState`; keep `AgentRelayStatus.State` as a plain `string` so `types` does not import `sdk`.
- `cmd/portal-tunnel/agent/dashboard.go`: consume `sdk` state directly via `string(sdk.RelayState*)`.
- `sdk/relay_state_test.go`: 15 new tests covering canonical state, terminal failure preservation, independent relay failure, event-driven readiness, and wire projection.

## Verification

```
go build ./...
go vet ./...
go test ./... -count=1
```

All pass. `golangci-lint` could not be run in this environment because it is not installed locally, but `gofmt -w` was applied to all changed Go files.

Refs #400