### PR TITLE
feat(sdk): keep concrete telemetry out of the core SDK

### DIFF
--- a/cmd/portal-tunnel/main.go
+++ b/cmd/portal-tunnel/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/gosuda/portal-tunnel/v2/cmd/portal-tunnel/installer"
+	"github.com/gosuda/portal-tunnel/v2/internal/telemetry"
 	"github.com/gosuda/portal-tunnel/v2/sdk"
 	"github.com/gosuda/portal-tunnel/v2/types"
 	"github.com/gosuda/portal-tunnel/v2/utils"
@@ -253,7 +254,10 @@ func runExposeCommand(args []string) error {
 		X402Asset:            flags.x402Asset,
 		X402Endpoints:        flags.x402Endpoints,
 		X402FacilitatorToken: flags.x402FacilitatorToken,
-	})
+	}, sdk.WithTunnelObserver(sdk.TunnelObserver{
+		Opened: func(relayURL string) { telemetry.ActiveTunnelsPerRelay.WithLabelValues(relayURL).Inc() },
+		Closed: func(relayURL string) { telemetry.ActiveTunnelsPerRelay.WithLabelValues(relayURL).Dec() },
+	}))
 	if err != nil {
 		return fmt.Errorf("failed to start relays: %w", err)
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,3 +18,28 @@ routes and the lease lifecycle contain no overlay topology.
 See [ADR index](adr/README.md) for the relay overlay migration decision and
 [the site architecture documentation](src/routes/architecture/+page.md) for the
 rest of the system.
+
+## Package boundary
+
+Ownership follows the client/relay split rather than the feature that
+happened to introduce the code:
+
+- `sdk` owns the Portal client network primitive: `Expose`, the `Exposure`
+  listener, the relay runtime it requires, and canonical status/readiness.
+- Adapter packages (for example HTTP serving, see #404) adapt an
+  already-created `Exposure` to another protocol or runtime.
+- Middleware packages compose policy over standard interfaces; application
+  payment policy is the x402 example in #405.
+- Extension/integration packages hold optional behavior with its own
+  dependency boundary, such as concrete metrics exporters.
+- `portal` owns the relay/server runtime: admission, leases, ingress,
+  ACME/DNS providers, and the IVNP overlay.
+- `internal` holds private protocol machinery genuinely shared by client and
+  relay; `types` holds wire/shared contracts; `cmd` composes the pieces.
+
+The core SDK must not import concrete telemetry/exporter implementations,
+application policy, or relay-only dependencies. Optional integrations observe
+the runtime through hooks such as `sdk.WithTunnelObserver` and are wired by
+the composing binary in `cmd`, keeping the `./sdk` dependency closure minimal.
+Identity persistence and local proxy targets leave tunnel construction in
+#403.

--- a/internal/telemetry/emit.go
+++ b/internal/telemetry/emit.go
@@ -13,7 +13,7 @@ package telemetry
 //
 // Metrics NOT updated here (wired by later phases / other code paths):
 //   - relay_pool_size — set by RelaySet pool management.
-//   - active_tunnels_per_relay — incremented/decremented at tunnel accept/close.
+//   - active_tunnels_per_relay — wired by the client CLI via sdk.WithTunnelObserver.
 //   - failures_total — incremented on discovery/active failure events.
 func EmitFromTrace(t SelectionTrace) {
 	// --- relay_selected_total ---

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -74,7 +74,8 @@ var RTTSeconds = promauto.NewHistogramVec(
 )
 
 // ActiveTunnelsPerRelay is a gauge of tunnel count for each relay.
-// SDK-local measurement: tracks this process's tunnel distribution only.
+// Client-local measurement: wired by the portal-tunnel CLI through
+// sdk.WithTunnelObserver; the core SDK does not import this package.
 var ActiveTunnelsPerRelay = promauto.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name: "portal_discovery_active_tunnels_per_relay",

--- a/sdk/expose.go
+++ b/sdk/expose.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/gosuda/portal-tunnel/v2/internal/discovery"
 	"github.com/gosuda/portal-tunnel/v2/internal/identity"
-	"github.com/gosuda/portal-tunnel/v2/internal/telemetry"
 	"github.com/gosuda/portal-tunnel/v2/types"
 	"github.com/gosuda/portal-tunnel/v2/utils"
 )
@@ -29,8 +28,9 @@ type Exposure struct {
 
 	cfg *utils.Snapshot[ExposeConfig]
 
-	accepted  chan net.Conn
-	datagrams chan types.DatagramFrame
+	accepted       chan *relayConn
+	datagrams      chan types.DatagramFrame
+	tunnelObserver TunnelObserver
 
 	relaySet       *discovery.RelaySet
 	mu             sync.RWMutex
@@ -38,6 +38,33 @@ type Exposure struct {
 
 	closeOnce sync.Once
 	connSeq   atomic.Uint64
+}
+
+// TunnelObserver reports per-relay tunnel connection lifecycle events. It
+// lets optional integrations such as metrics exporters observe tunnel
+// activity without the core SDK depending on them.
+type TunnelObserver struct {
+	// Opened is invoked with the relay URL when a tunnel connection is
+	// accepted through Exposure.Accept.
+	Opened func(relayURL string)
+	// Closed is invoked exactly once with the relay URL when a connection
+	// previously reported through Opened is closed.
+	Closed func(relayURL string)
+}
+
+// ExposeOption customizes an Exposure beyond its construction configuration.
+type ExposeOption func(*exposeOptions)
+
+type exposeOptions struct {
+	tunnelObserver TunnelObserver
+}
+
+// WithTunnelObserver registers per-relay tunnel connection notifications for
+// connections accepted through Exposure.Accept.
+func WithTunnelObserver(observer TunnelObserver) ExposeOption {
+	return func(opts *exposeOptions) {
+		opts.tunnelObserver = observer
+	}
 }
 
 type ExposeConfig struct {
@@ -78,7 +105,13 @@ func (cfg ExposeConfig) snapshot() ExposeConfig {
 
 // Expose creates relay listeners for the selected relay pool and exposes a
 // dynamic listener hub for accepting traffic from all of them.
-func Expose(ctx context.Context, cfg ExposeConfig) (*Exposure, error) {
+func Expose(ctx context.Context, cfg ExposeConfig, opts ...ExposeOption) (*Exposure, error) {
+	options := exposeOptions{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
 	explicitRelayURLs, err := utils.NormalizeRelayURLs(cfg.RelayURLs...)
 	if err != nil {
 		return nil, err
@@ -134,10 +167,11 @@ func Expose(ctx context.Context, cfg ExposeConfig) (*Exposure, error) {
 		cancel:         cancel,
 		done:           exposureCtx.Done(),
 		cfg:            utils.NewSnapshot(runtimeCfg, ExposeConfig.snapshot),
-		accepted:       make(chan net.Conn, max(initialRouteCount*defaultReadyTarget*2, 1)),
+		accepted:       make(chan *relayConn, max(initialRouteCount*defaultReadyTarget*2, 1)),
 		datagrams:      make(chan types.DatagramFrame, max(initialRouteCount*32, 1)),
 		relaySet:       discovery.NewRelaySet(relaySetURLs),
 		relayListeners: make(map[string]*listener, initialRouteCount),
+		tunnelObserver: options.tunnelObserver,
 	}
 
 	if cfg.Discovery {
@@ -517,10 +551,17 @@ func (c *exposureConn) Close() error {
 	return closeErr
 }
 
+// relayConn carries the serving relay URL alongside a connection accepted
+// from a relay listener so the public Accept path can account per-relay
+// tunnel activity.
+type relayConn struct {
+	net.Conn
+	relayURL string
+}
+
 // tunnelCounterConn wraps a net.Conn and calls decr exactly once on the first
-// Close invocation to decrement the active_tunnels_per_relay gauge. Subsequent
-// Close calls are forwarded to the underlying conn but do not double-decrement.
-// Concurrency is guaranteed by sync.Once.
+// Close invocation. Subsequent Close calls are forwarded to the underlying
+// conn but do not re-invoke decr. Concurrency is guaranteed by sync.Once.
 type tunnelCounterConn struct {
 	net.Conn
 	once sync.Once
@@ -548,8 +589,22 @@ func (e *Exposure) Accept() (net.Conn, error) {
 			Str("remote_addr", conn.RemoteAddr().String()).
 			Msg("exposure connection accepted")
 
+		accepted := net.Conn(conn)
+		if obs := e.tunnelObserver; obs.Opened != nil || obs.Closed != nil {
+			relayURL := conn.relayURL
+			if obs.Opened != nil {
+				obs.Opened(relayURL)
+			}
+			if obs.Closed != nil {
+				accepted = &tunnelCounterConn{
+					Conn: conn,
+					decr: func() { obs.Closed(relayURL) },
+				}
+			}
+		}
+
 		return &exposureConn{
-			Conn:       conn,
+			Conn:       accepted,
 			id:         connID,
 			localAddr:  conn.LocalAddr().String(),
 			remoteAddr: conn.RemoteAddr().String(),
@@ -793,19 +848,13 @@ func (e *Exposure) runListenerAcceptLoop(listener *listener) {
 			return
 		}
 
-		telemetry.ActiveTunnelsPerRelay.WithLabelValues(relayURL).Inc()
-		wrappedConn := &tunnelCounterConn{
-			Conn: conn,
-			decr: func() {
-				telemetry.ActiveTunnelsPerRelay.WithLabelValues(relayURL).Dec()
-			},
-		}
+		relayAccepted := &relayConn{Conn: conn, relayURL: relayURL}
 
 		select {
 		case <-e.done:
-			_ = wrappedConn.Close()
+			_ = relayAccepted.Close()
 			return
-		case e.accepted <- wrappedConn:
+		case e.accepted <- relayAccepted:
 		}
 	}
 }

--- a/sdk/expose_test.go
+++ b/sdk/expose_test.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"errors"
+	"net"
 	"net/url"
 	"testing"
 
@@ -379,5 +380,40 @@ func TestExposureSnapshotExcludesDeadRelayListener(t *testing.T) {
 	}
 	if !foundRelayB {
 		t.Fatalf("Snapshot() omitted active relay %q", relayB)
+	}
+}
+
+func TestTunnelObserverReportsAcceptAndClose(t *testing.T) {
+	var opened, closed []string
+	exposure := &Exposure{
+		accepted: make(chan *relayConn, 1),
+		tunnelObserver: TunnelObserver{
+			Opened: func(relayURL string) { opened = append(opened, relayURL) },
+			Closed: func(relayURL string) { closed = append(closed, relayURL) },
+		},
+	}
+	server, client := net.Pipe()
+	defer client.Close()
+	exposure.accepted <- &relayConn{Conn: server, relayURL: "https://relay.example"}
+
+	conn, err := exposure.Accept()
+	if err != nil {
+		t.Fatalf("Accept() error = %v", err)
+	}
+	if len(opened) != 1 || opened[0] != "https://relay.example" {
+		t.Fatalf("opened = %v, want one event for https://relay.example", opened)
+	}
+	if len(closed) != 0 {
+		t.Fatalf("closed = %v, want no events before Close", closed)
+	}
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("first Close() error = %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+	if len(closed) != 1 || closed[0] != "https://relay.example" {
+		t.Fatalf("closed = %v, want exactly one event for https://relay.example", closed)
 	}
 }


### PR DESCRIPTION
Refs #410. Parent #400.

## Summary

Establishes the first slice of the #410 boundary split: concrete telemetry/exporter dependencies leave the core SDK. `sdk` no longer imports `internal/telemetry`, so Prometheus is outside the `./sdk` dependency closure. Optional integrations now observe tunnel activity through a lightweight hook, and the composing binary wires the exporter.

Identity persistence and proxy targets (#403), the HTTP adapter (#404), and x402 middleware (#405) remain the follow-up execution slices and are intentionally out of scope here.

## Changes

- `sdk/expose.go`: add `ExposeOption`, `WithTunnelObserver`, and `TunnelObserver` (Opened/Closed per relay URL). `Expose` takes `opts ...ExposeOption` (source-compatible variadic). The listener loop now stamps accepted connections with their relay URL via an unexported `relayConn` carrier, and `Exposure.Accept` fires the observer and wraps the conn for exactly-once Closed accounting. The unconditional `tunnelCounterConn` wrap and the `internal/telemetry` import are gone.
- `cmd/portal-tunnel/main.go`: wires `sdk.WithTunnelObserver` to the existing `active_tunnels_per_relay` gauge, so the `--metrics-addr` surface is unchanged.
- `internal/telemetry`: comments updated to state the gauge is wired by the CLI, not the SDK.
- `docs/architecture.md`: documents the package boundary roles (sdk core, adapters, middleware, extensions, portal, internal, types, cmd) and the rule that core sdk must not import concrete telemetry/exporter dependencies.
- `sdk/expose_test.go`: contract test asserting Opened fires at Accept, Closed fires exactly once per connection even on double Close, and no Closed fires before Close.

## Verification

Run via docker `golang:1.27` / `golangci-lint:v2.13.2`:

```
gofmt -l sdk cmd internal types     # clean
go build ./...                        # pass
go vet ./...                         # pass
go test ./sdk/... ./cmd/... ./internal/telemetry/... -count=1   # pass
golangci-lint run . ./cmd/... ./internal/... ./portal/... ./sdk/... ./types/... ./utils/...   # 0 issues (CGO_ENABLED=0)
go list -deps -f '{{with .Module}}{{.Path}}{{end}}' ./sdk | sort -u | grep -Ei prometheus || echo none   # none
```

The last command proves the boundary: the sdk closure contains no prometheus/client_golang module. Lint also runs clean with CGO enabled except the known pre-existing libsecp256k1 typecheck noise in `internal/identity` (untouched by this diff).

Behavior notes:

- The gauge now increments when a connection is accepted through `Exposure.Accept` rather than when the relay listener accepts it; for the CLI proxy/HTTP paths these coincide, and accounting at the public surface matches the metric's client-local meaning.
- The agent and demo binaries never served `/metrics`, so no wiring was added there.