### PR TITLE
feat(sdk): separate tunnel construction from identity persistence and proxy targets

### DIFF
--- a/cmd/demo-app/main.go
+++ b/cmd/demo-app/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
+	"github.com/gosuda/portal-tunnel/v2/internal/identity"
 	"github.com/gosuda/portal-tunnel/v2/sdk"
 	"github.com/gosuda/portal-tunnel/v2/types"
 	"github.com/gosuda/portal-tunnel/v2/utils"
@@ -137,12 +138,19 @@ func runTCPDemo(ctx context.Context, cfg demoConfig) error {
 		Thumbnail:   cfg.thumbnail,
 		Hide:        cfg.hide,
 	}
+	listenerIdentity, _, err := identity.ResolveListenerIdentity(
+		types.Identity{Name: cfg.name},
+		"",
+		cfg.identityPath,
+		cfg.identityJSON,
+	)
+	if err != nil {
+		return fmt.Errorf("resolve identity: %w", err)
+	}
 	exposure, err := sdk.Expose(ctx, sdk.ExposeConfig{
 		RelayURLs:       utils.SplitCSV(cfg.relayURLs),
 		Discovery:       cfg.discovery,
-		Identity:        types.Identity{Name: cfg.name},
-		IdentityPath:    cfg.identityPath,
-		IdentityJSON:    cfg.identityJSON,
+		Identity:        listenerIdentity,
 		BanMITM:         cfg.banMITM,
 		MaxActiveRelays: cfg.maxActiveRelays,
 		Metadata:        metadata,
@@ -173,12 +181,19 @@ func runTCPDemo(ctx context.Context, cfg demoConfig) error {
 }
 
 func runUDPDemo(ctx context.Context, cfg demoConfig) error {
+	listenerIdentity, _, err := identity.ResolveListenerIdentity(
+		types.Identity{Name: cfg.name},
+		"",
+		cfg.identityPath,
+		cfg.identityJSON,
+	)
+	if err != nil {
+		return fmt.Errorf("resolve identity: %w", err)
+	}
 	exposure, err := sdk.Expose(ctx, sdk.ExposeConfig{
 		RelayURLs:       utils.SplitCSV(cfg.relayURLs),
 		Discovery:       cfg.discovery,
-		Identity:        types.Identity{Name: cfg.name},
-		IdentityPath:    cfg.identityPath,
-		IdentityJSON:    cfg.identityJSON,
+		Identity:        listenerIdentity,
 		UDPEnabled:      true,
 		BanMITM:         cfg.banMITM,
 		MaxActiveRelays: cfg.maxActiveRelays,

--- a/cmd/payment-app/main.go
+++ b/cmd/payment-app/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
+	"github.com/gosuda/portal-tunnel/v2/internal/identity"
 	"github.com/gosuda/portal-tunnel/v2/sdk"
 	"github.com/gosuda/portal-tunnel/v2/types"
 	"github.com/gosuda/portal-tunnel/v2/utils"
@@ -150,12 +151,19 @@ func runPaymentApp(ctx context.Context, cfg paymentConfig) error {
 		return err
 	}
 
+	listenerIdentity, _, err := identity.ResolveListenerIdentity(
+		types.Identity{Name: cfg.name},
+		"",
+		cfg.identityPath,
+		cfg.identityJSON,
+	)
+	if err != nil {
+		return fmt.Errorf("resolve identity: %w", err)
+	}
 	exposure, err := sdk.Expose(ctx, sdk.ExposeConfig{
 		RelayURLs:       utils.SplitCSV(cfg.relayURLs),
 		Discovery:       cfg.discovery,
-		Identity:        types.Identity{Name: cfg.name},
-		IdentityPath:    cfg.identityPath,
-		IdentityJSON:    cfg.identityJSON,
+		Identity:        listenerIdentity,
 		BanMITM:         cfg.banMITM,
 		MaxActiveRelays: cfg.maxActiveRelays,
 		Metadata:        metadata,

--- a/cmd/portal-tunnel/agent/manager.go
+++ b/cmd/portal-tunnel/agent/manager.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
+	"github.com/gosuda/portal-tunnel/v2/internal/identity"
 	"github.com/gosuda/portal-tunnel/v2/sdk"
 	"github.com/gosuda/portal-tunnel/v2/types"
 	"github.com/gosuda/portal-tunnel/v2/utils"
@@ -609,7 +610,7 @@ func (t *managedTunnel) Snapshot() types.AgentTunnelStatus {
 	if t.exposure == exposure {
 		t.runtime = types.AgentTunnelStatus{
 			Address:         snapshot.Address,
-			TargetAddr:      snapshot.TargetAddr,
+			TargetAddr:      cfg.TargetAddr,
 			MaxActiveRelays: snapshot.MaxActiveRelays,
 			Relays:          append([]types.AgentRelayStatus(nil), snapshot.Relays...),
 		}
@@ -617,7 +618,7 @@ func (t *managedTunnel) Snapshot() types.AgentTunnelStatus {
 	t.mu.Unlock()
 
 	status.Address = snapshot.Address
-	status.TargetAddr = snapshot.TargetAddr
+	status.TargetAddr = cfg.TargetAddr
 	status.Relays = append([]types.AgentRelayStatus(nil), snapshot.Relays...)
 	return status
 }
@@ -661,15 +662,20 @@ func (t *managedTunnel) runOnce(ctx context.Context) error {
 	}
 	x402FacilitatorToken := strings.TrimSpace(cfg.X402FacilitatorToken)
 	x402FacilitatorToken = cmp.Or(x402FacilitatorToken, strings.TrimSpace(os.Getenv("CSPR_CLOUD_API_KEY")))
+	listenerIdentity, _, err := identity.ResolveListenerIdentity(
+		types.Identity{Name: cfg.Name},
+		cfg.TargetAddr,
+		cfg.IdentityPath,
+		cfg.IdentityJSON,
+	)
+	if err != nil {
+		return fmt.Errorf("resolve identity: %w", err)
+	}
 	exposure, err := sdk.Expose(ctx, sdk.ExposeConfig{
 		RelayURLs:            append([]string(nil), cfg.RelayURLs...),
 		Discovery:            discovery,
 		Overlay:              cfg.Overlay,
-		Identity:             types.Identity{Name: cfg.Name},
-		IdentityPath:         cfg.IdentityPath,
-		IdentityJSON:         cfg.IdentityJSON,
-		TargetAddr:           cfg.TargetAddr,
-		UDPAddr:              cfg.UDPAddr,
+		Identity:             listenerIdentity,
 		UDPEnabled:           cfg.UDPEnabled,
 		TCPEnabled:           cfg.TCPEnabled,
 		ECH:                  cfg.ECH,
@@ -691,7 +697,7 @@ func (t *managedTunnel) runOnce(ctx context.Context) error {
 	t.exposure = exposure
 	t.runtime = types.AgentTunnelStatus{
 		Address:         snapshot.Address,
-		TargetAddr:      snapshot.TargetAddr,
+		TargetAddr:      cfg.TargetAddr,
 		MaxActiveRelays: snapshot.MaxActiveRelays,
 		Relays:          append([]types.AgentRelayStatus(nil), snapshot.Relays...),
 	}
@@ -712,7 +718,14 @@ func (t *managedTunnel) runOnce(ctx context.Context) error {
 		}
 		err = exposure.RunHTTPRoutes(ctx, routes, "")
 	} else {
-		err = sdk.ProxyExposure(ctx, exposure)
+		udpTarget := ""
+		if cfg.UDPEnabled {
+			udpTarget = cmp.Or(cfg.UDPAddr, cfg.TargetAddr)
+		}
+		err = sdk.ProxyWithConfig(ctx, exposure, sdk.ProxyConfig{
+			TCPTarget: cfg.TargetAddr,
+			UDPTarget: udpTarget,
+		})
 	}
 	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
 		return ctx.Err()

--- a/cmd/portal-tunnel/main.go
+++ b/cmd/portal-tunnel/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/gosuda/portal-tunnel/v2/cmd/portal-tunnel/installer"
+	"github.com/gosuda/portal-tunnel/v2/internal/identity"
 	"github.com/gosuda/portal-tunnel/v2/sdk"
 	"github.com/gosuda/portal-tunnel/v2/types"
 	"github.com/gosuda/portal-tunnel/v2/utils"
@@ -226,15 +227,20 @@ func runExposeCommand(args []string) error {
 		}()
 	}
 
+	listenerIdentity, _, err := identity.ResolveListenerIdentity(
+		types.Identity{Name: flags.name},
+		flags.targetAddr,
+		flags.identityPath,
+		flags.identityJSON,
+	)
+	if err != nil {
+		return fmt.Errorf("resolve identity: %w", err)
+	}
 	exposure, err := sdk.Expose(ctx, sdk.ExposeConfig{
 		RelayURLs:       utils.SplitCSV(flags.relayCSV),
 		Discovery:       flags.discovery,
 		Overlay:         flags.overlay,
-		Identity:        types.Identity{Name: flags.name},
-		IdentityPath:    flags.identityPath,
-		IdentityJSON:    flags.identityJSON,
-		TargetAddr:      flags.targetAddr,
-		UDPAddr:         flags.udpAddr,
+		Identity:        listenerIdentity,
 		UDPEnabled:      flags.udp,
 		TCPEnabled:      flags.tcp,
 		ECH:             flags.ech,
@@ -257,11 +263,18 @@ func runExposeCommand(args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to start relays: %w", err)
 	}
+	udpTarget := ""
+	if flags.udp {
+		udpTarget = cmp.Or(flags.udpAddr, flags.targetAddr)
+	}
 	if len(httpRoutes) > 0 {
 		defer exposure.Close()
 		return exposure.RunHTTPRoutes(ctx, httpRoutes, "")
 	}
-	return sdk.ProxyExposure(ctx, exposure)
+	return sdk.ProxyWithConfig(ctx, exposure, sdk.ProxyConfig{
+		TCPTarget: flags.targetAddr,
+		UDPTarget: udpTarget,
+	})
 }
 
 func parseHTTPRoutePayment(value string) ([]string, string, error) {

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -649,3 +649,29 @@ func normalizeUniqueStrings(inputs []string, normalize func(string) string) []st
 	}
 	return out
 }
+
+// GenerateIdentity creates a fresh lease identity for name without
+// persisting it.
+func GenerateIdentity(name string) (types.Identity, error) {
+	return resolveLeaseIdentity(types.Identity{Name: name})
+}
+
+// ParseIdentity decodes an identity JSON document in the same format
+// LoadIdentity reads and validates the result as a lease identity.
+func ParseIdentity(data []byte) (types.Identity, error) {
+	parsed, err := parseIdentityJSON(string(data))
+	if err != nil {
+		return types.Identity{}, err
+	}
+	return resolveLeaseIdentity(parsed)
+}
+
+// LoadIdentity reads an identity file from path and validates the result as
+// a lease identity.
+func LoadIdentity(path string) (types.Identity, error) {
+	loaded, err := loadIdentity(path)
+	if err != nil {
+		return types.Identity{}, err
+	}
+	return resolveLeaseIdentity(loaded)
+}

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -1,0 +1,65 @@
+package identity
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateParseLoadIdentityRoundTrip(t *testing.T) {
+	generated, err := GenerateIdentity("facade-roundtrip")
+	if err != nil {
+		t.Fatalf("GenerateIdentity: %v", err)
+	}
+	if generated.Name == "" || generated.Address == "" || generated.PublicKey == "" || generated.PrivateKey == "" {
+		t.Fatalf("generated identity incomplete: %+v", generated)
+	}
+
+	path := filepath.Join(t.TempDir(), "identity.json")
+	if err := saveIdentity(path, generated); err != nil {
+		t.Fatalf("saveIdentity: %v", err)
+	}
+
+	loaded, err := LoadIdentity(path)
+	if err != nil {
+		t.Fatalf("LoadIdentity: %v", err)
+	}
+	if loaded.Name != generated.Name || loaded.Address != generated.Address || loaded.PrivateKey != generated.PrivateKey {
+		t.Fatalf("loaded identity mismatch:\n loaded %+v\ngenerated %+v", loaded, generated)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read identity file: %v", err)
+	}
+	parsed, err := ParseIdentity(data)
+	if err != nil {
+		t.Fatalf("ParseIdentity: %v", err)
+	}
+	if parsed.Address != generated.Address || parsed.PrivateKey != generated.PrivateKey {
+		t.Fatalf("parsed identity mismatch:\n parsed %+v\ngenerated %+v", parsed, generated)
+	}
+}
+
+func TestParseIdentityRejectsInvalidInput(t *testing.T) {
+	if _, err := ParseIdentity([]byte("not json")); err == nil || !strings.Contains(err.Error(), "decode identity json") {
+		t.Fatalf("invalid json: got %v", err)
+	}
+	if _, err := ParseIdentity(nil); err == nil || !strings.Contains(err.Error(), "identity json is required") {
+		t.Fatalf("empty input: got %v", err)
+	}
+}
+
+func TestLoadIdentityRejectsMissingFile(t *testing.T) {
+	_, err := LoadIdentity(filepath.Join(t.TempDir(), "missing.json"))
+	if err == nil || !strings.Contains(err.Error(), "read identity file") {
+		t.Fatalf("missing file: got %v", err)
+	}
+}
+
+func TestGenerateIdentityRejectsEmptyName(t *testing.T) {
+	if _, err := GenerateIdentity("  "); err == nil {
+		t.Fatal("empty name must be rejected")
+	}
+}

--- a/sdk/expose.go
+++ b/sdk/expose.go
@@ -46,10 +46,6 @@ type ExposeConfig struct {
 	Overlay   bool
 
 	Identity             types.Identity
-	IdentityPath         string
-	IdentityJSON         string
-	TargetAddr           string
-	UDPAddr              string
 	UDPEnabled           bool
 	TCPEnabled           bool
 	ECH                  bool
@@ -79,6 +75,12 @@ func (cfg ExposeConfig) snapshot() ExposeConfig {
 // Expose creates relay listeners for the selected relay pool and exposes a
 // dynamic listener hub for accepting traffic from all of them.
 func Expose(ctx context.Context, cfg ExposeConfig) (*Exposure, error) {
+	if strings.TrimSpace(cfg.Identity.Name) == "" {
+		return nil, errors.New("sdk: identity name is required")
+	}
+	if strings.TrimSpace(cfg.Identity.PrivateKey) == "" && strings.TrimSpace(cfg.Identity.Mnemonic) == "" {
+		return nil, errors.New("sdk: resolved identity is required; use GenerateIdentity, ParseIdentity, or LoadIdentity")
+	}
 	explicitRelayURLs, err := utils.NormalizeRelayURLs(cfg.RelayURLs...)
 	if err != nil {
 		return nil, err
@@ -90,37 +92,13 @@ func Expose(ctx context.Context, cfg ExposeConfig) (*Exposure, error) {
 	if err != nil {
 		return nil, err
 	}
-	listenerIdentity, createdIdentity, err := identity.ResolveListenerIdentity(
-		cfg.Identity.Copy(),
-		cfg.TargetAddr,
-		cfg.IdentityPath,
-		cfg.IdentityJSON,
-	)
+	listenerIdentity, _, err := identity.ResolveListenerIdentity(cfg.Identity.Copy(), "", "", "")
 	if err != nil {
 		return nil, fmt.Errorf("resolve identity: %w", err)
-	}
-	if createdIdentity {
-		log.Info().
-			Str("identity_path", strings.TrimSpace(cfg.IdentityPath)).
-			Str("address", listenerIdentity.Address).
-			Msg("generated tunnel identity and saved it to disk")
-	}
-	targetAddr, err := utils.NormalizeLoopbackTarget(cfg.TargetAddr)
-	if err != nil {
-		return nil, fmt.Errorf("invalid target value %q: %w", cfg.TargetAddr, err)
-	}
-	udpAddr := cfg.UDPAddr
-	if cfg.UDPEnabled {
-		udpAddr, err = utils.NormalizeLoopbackTarget(utils.StringOrDefault(udpAddr, targetAddr))
-		if err != nil {
-			return nil, fmt.Errorf("invalid --udp-addr value %q: %w", cfg.UDPAddr, err)
-		}
 	}
 	runtimeCfg := cfg.snapshot()
 	runtimeCfg.RelayURLs = append([]string(nil), explicitRelayURLs...)
 	runtimeCfg.Identity = listenerIdentity.Copy()
-	runtimeCfg.TargetAddr = targetAddr
-	runtimeCfg.UDPAddr = udpAddr
 	runtimeCfg.Metadata = cfg.Metadata.Copy()
 	runtimeCfg.X402PayTo = x402PayTo
 	runtimeCfg.X402Testnet = cfg.X402Testnet
@@ -371,7 +349,6 @@ func (e *Exposure) Snapshot() types.AgentTunnelStatus {
 
 	return types.AgentTunnelStatus{
 		Address:         cfg.Identity.Address,
-		TargetAddr:      cfg.TargetAddr,
 		Overlay:         cfg.Overlay,
 		MaxActiveRelays: cfg.MaxActiveRelays,
 		Metadata:        cfg.Metadata,

--- a/sdk/expose_test.go
+++ b/sdk/expose_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/gosuda/portal-tunnel/v2/internal/discovery"
@@ -379,5 +380,31 @@ func TestExposureSnapshotExcludesDeadRelayListener(t *testing.T) {
 	}
 	if !foundRelayB {
 		t.Fatalf("Snapshot() omitted active relay %q", relayB)
+	}
+}
+
+func TestExposeRejectsUnresolvedIdentity(t *testing.T) {
+	if _, err := Expose(context.Background(), ExposeConfig{}); err == nil || !strings.Contains(err.Error(), "identity name is required") {
+		t.Fatalf("missing identity: got %v", err)
+	}
+	if _, err := Expose(context.Background(), ExposeConfig{Identity: types.Identity{Name: "svc"}}); err == nil || !strings.Contains(err.Error(), "resolved identity is required") {
+		t.Fatalf("name-only identity: got %v, want implicit generation rejected", err)
+	}
+}
+
+func TestExposeAcceptsResolvedIdentityWithoutPersistence(t *testing.T) {
+	resolved, err := GenerateIdentity("sdk-resolved")
+	if err != nil {
+		t.Fatalf("GenerateIdentity: %v", err)
+	}
+
+	exposure, err := Expose(context.Background(), ExposeConfig{Identity: resolved})
+	if err != nil {
+		t.Fatalf("Expose: %v", err)
+	}
+	defer exposure.Close()
+
+	if got := exposure.Identity().Address; got != resolved.Address {
+		t.Fatalf("identity address = %q, want %q", got, resolved.Address)
 	}
 }

--- a/sdk/identity.go
+++ b/sdk/identity.go
@@ -1,0 +1,22 @@
+package sdk
+
+import (
+	"github.com/gosuda/portal-tunnel/v2/internal/identity"
+	"github.com/gosuda/portal-tunnel/v2/types"
+)
+
+// GenerateIdentity creates a fresh lease identity for name without
+// persisting it.
+func GenerateIdentity(name string) (types.Identity, error) {
+	return identity.GenerateIdentity(name)
+}
+
+// ParseIdentity decodes and validates an identity JSON document.
+func ParseIdentity(data []byte) (types.Identity, error) {
+	return identity.ParseIdentity(data)
+}
+
+// LoadIdentity reads and validates an identity file.
+func LoadIdentity(path string) (types.Identity, error) {
+	return identity.LoadIdentity(path)
+}

--- a/sdk/proxy.go
+++ b/sdk/proxy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -14,20 +15,66 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/gosuda/portal-tunnel/v2/types"
+	"github.com/gosuda/portal-tunnel/v2/utils"
 )
 
-func ProxyExposure(ctx context.Context, exposure *Exposure) error {
+// ProxyConfig selects the local TCP and UDP targets that an exposure is
+// forwarded to. At least one target is required.
+type ProxyConfig struct {
+	TCPTarget string
+	UDPTarget string
+}
+
+// Proxy forwards tenant streams from the exposure to a local TCP target. It
+// blocks until the exposure ends and closes the exposure afterwards.
+func Proxy(ctx context.Context, exposure *Exposure, target string) error {
+	return ProxyWithConfig(ctx, exposure, ProxyConfig{TCPTarget: target})
+}
+
+// ProxyUDP forwards relayed datagrams from the exposure to a local UDP
+// target. It blocks until the exposure ends and closes the exposure
+// afterwards.
+func ProxyUDP(ctx context.Context, exposure *Exposure, target string) error {
+	return ProxyWithConfig(ctx, exposure, ProxyConfig{UDPTarget: target})
+}
+
+// ProxyWithConfig runs the TCP and UDP proxy loops for an exposure against
+// explicit local targets and closes the exposure after cancellation or the
+// first terminal proxy error. Local targets are a proxy concern, not part
+// of the exposure configuration, so callers pass them here instead.
+func ProxyWithConfig(ctx context.Context, exposure *Exposure, config ProxyConfig) error {
+	if ctx == nil {
+		return errors.New("sdk: context is nil")
+	}
+	if exposure == nil {
+		return errors.New("sdk: exposure is nil")
+	}
+	if strings.TrimSpace(config.TCPTarget) == "" && strings.TrimSpace(config.UDPTarget) == "" {
+		return errors.New("sdk: at least one proxy target is required")
+	}
 	defer exposure.Close()
 	if len(exposure.ActiveRelayURLs()) == 0 {
 		return errors.New("no relay URLs provided")
 	}
 
-	cfg := exposure.Config()
-	identity := cfg.Identity
-	tcpTarget := cfg.TargetAddr
-	udpTarget := cfg.UDPAddr
+	if target := strings.TrimSpace(config.TCPTarget); target != "" {
+		normalized, err := utils.NormalizeLoopbackTarget(target)
+		if err != nil {
+			return fmt.Errorf("invalid tcp target %q: %w", target, err)
+		}
+		config.TCPTarget = normalized
+	}
+	if target := strings.TrimSpace(config.UDPTarget); target != "" {
+		normalized, err := utils.NormalizeLoopbackTarget(target)
+		if err != nil {
+			return fmt.Errorf("invalid udp target %q: %w", target, err)
+		}
+		config.UDPTarget = normalized
+	}
+	tcpTarget, udpTarget := config.TCPTarget, config.UDPTarget
 	udpEnabled := udpTarget != ""
 
+	identity := exposure.Config().Identity
 	log.Info().
 		Str("release_version", types.ReleaseVersion).
 		Str("tcp_target", tcpTarget).
@@ -60,9 +107,20 @@ func ProxyExposure(ctx context.Context, exposure *Exposure) error {
 		_ = exposure.Close()
 	}()
 
-	waitErr := proxyRelayConnections(ctx, exposure, tcpTarget, &connWG, &connCount)
-	if waitErr != nil {
-		_ = exposure.Close()
+	var waitErr error
+	if tcpTarget != "" {
+		waitErr = proxyRelayConnections(ctx, exposure, tcpTarget, &connWG, &connCount)
+		if waitErr != nil {
+			_ = exposure.Close()
+		}
+	} else {
+		// UDP-only proxying waits on the datagram plane or context end;
+		// proxyRelayConnections would block on the TCP accept path.
+		select {
+		case <-ctx.Done():
+		case waitErr = <-udpErrCh:
+			_ = exposure.Close()
+		}
 	}
 
 	var udpErr error

--- a/sdk/proxy_test.go
+++ b/sdk/proxy_test.go
@@ -1,0 +1,27 @@
+package sdk
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestProxyWithConfigValidatesInputs(t *testing.T) {
+	if err := Proxy(context.Background(), nil, "127.0.0.1:8080"); err == nil || !strings.Contains(err.Error(), "exposure is nil") {
+		t.Fatalf("nil exposure: got %v", err)
+	}
+	//nolint:staticcheck // SA1012: intentionally tests nil-context rejection.
+	if err := Proxy(nil, &Exposure{}, "127.0.0.1:8080"); err == nil || !strings.Contains(err.Error(), "context is nil") {
+		t.Fatalf("nil context: got %v", err)
+	}
+	if err := ProxyWithConfig(context.Background(), &Exposure{}, ProxyConfig{}); err == nil || !strings.Contains(err.Error(), "at least one proxy target is required") {
+		t.Fatalf("empty targets: got %v", err)
+	}
+}
+
+func TestProxyWithConfigRequiresRelays(t *testing.T) {
+	err := ProxyWithConfig(context.Background(), &Exposure{}, ProxyConfig{TCPTarget: "127.0.0.1:8080"})
+	if err == nil || !strings.Contains(err.Error(), "no relay URLs provided") {
+		t.Fatalf("zero-relay exposure: got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #403. Parent #410, umbrella #400.

## Summary

`ExposeConfig` now carries only Portal client-runtime construction concerns. Identity persistence inputs (`IdentityPath`, `IdentityJSON`) and local forwarding targets (`TargetAddr`, `UDPAddr`) are gone from tunnel construction: identity is resolved explicitly before `Expose()`, and forwarding composes over an already-created `Exposure` with explicit targets. `Expose()` rejects partially populated identities instead of silently generating a private key.

Shape mined from the review-hardened sdk side of #401 (nil-guard ordering, UDP-target defaulting at the caller, validation before any `Close`).

## Changes

- `sdk/expose.go`: slim `ExposeConfig`; `Expose` validates that the identity has a name and key material, then resolves idempotently via `internal/identity`; target/UDP normalization and persistence moved out; `Snapshot()` no longer reports a target (the agent reports its own configured target).
- `sdk/identity.go` (new): `GenerateIdentity`, `ParseIdentity`, `LoadIdentity` backed by new exported owners in `internal/identity`.
- `sdk/proxy.go`: `ProxyExposure(ctx, exposure)` replaced by `Proxy(ctx, exposure, target)`, `ProxyUDP`, and `ProxyWithConfig(ctx, exposure, ProxyConfig{TCPTarget, UDPTarget})`. Nil-context/nil-exposure/empty-target guards run before any exposure close; targets are normalized inside; a UDP-only config waits on the datagram plane instead of the TCP accept loop.
- Callers compose instead of configuring: `cmd/portal-tunnel` and the agent resolve identity through `identity.ResolveListenerIdentity` (the existing single owner, preserving `--identity-path` defaulting, `--identity-json` persist-on-both, and name defaulting) and pass explicit proxy targets with the `--udp` → target fallback; demo-app and payment-app do the same for their flags.
- Tests: identity generate→save→load→parse round-trip plus rejection cases in `internal/identity`; `Expose` unresolved-identity rejection and resolved-identity happy path; proxy input validation.

## Behavior notes

- CLI/agent flag semantics are unchanged, including `--identity-path` defaulting to `identity.json`, `--identity-json` persisted to the path when both are set, and the auto-generated service name when `--name` is omitted.
- The active-tunnels gauge timing and `/metrics` surface are unaffected (that boundary landed in #411's branch if merged, or is untouched here otherwise).

## Verification

Run via docker `golang:1.27` / `golangci-lint:v2.13.2`:

```
gofmt -l sdk cmd internal types     # clean
go build ./...                        # pass
go vet ./...                         # pass
go test ./... -count=1               # all pass
golangci-lint run . ./cmd/... ./internal/... ./portal/... ./sdk/... ./types/... ./utils/...   # 0 issues (CGO_ENABLED=0)
```

With CGO enabled, lint shows only the known pre-existing libsecp256k1 typecheck noise in `internal/identity` files this diff does not touch functionally.

Note for review: this branch and #408/#411 all touch `sdk/expose.go`; merge order will need a mechanical rebase of the later ones.