### PR TITLE
feat(identity): implement Portal SIWE without siwe-go

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,27 @@ CLI or agent callers, and routed HTTP payment settings belong to
 and discovery events update it, while `Relays`, `Updates`, and `WaitReady`
 read from that state. Agent status types are not part of the SDK contract.
 
+## Identity challenges
+
+`portal/identity` owns the EIP-4361 message formatter shared by tunnel
+registration and browser/admin wallet login. It emits Portal's existing version
+1, chain ID 1 message fields and LF separators. Nonces use `crypto/rand`; the
+existing secp256k1 and Keccak primitives own EIP-191 personal-sign hashing and
+signer recovery. Personal-sign signatures use `r || s || v`, with `v` in
+`0/1` or `27/28`.
+
+The server retains the exact challenge message, expected address, and expiry.
+Verification requires an exact message match, an unexpired challenge, and a
+signature recovering the expected address. It does not parse server-generated
+messages back into a second set of domain/nonce fields. The signed RFC3339
+expiration remains authoritative at second precision, including the existing
+inclusive cutoff. Registration challenge consumption and wallet allowlists,
+sessions, and challenge consumption remain with their respective owners.
+
+This supports Portal-issued EOA challenges, not arbitrary SIWE messages or
+contract-wallet verification. `siwe-go` is no longer required; `go-ethereum`
+remains an indirect dependency of the separate x402 payment integration.
+
 See [ADR index](adr/README.md) for the relay overlay migration decision and
 [the site architecture documentation](src/routes/architecture/+page.md) for the
 rest of the system.

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/quic-go/quic-go v0.59.0
 	github.com/rs/zerolog v1.34.0
-	github.com/spruceid/siwe-go v0.2.1
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/vultr/govultr/v3 v3.30.0
 	golang.org/x/crypto v0.55.0
@@ -78,7 +77,6 @@ require (
 	github.com/consensys/gnark-crypto v0.18.1 // indirect
 	github.com/crate-crypto/go-eth-kzg v1.4.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/dchest/uniuri v1.2.0 // indirect
 	github.com/deckarep/golang-set/v2 v2.8.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/ethereum/c-kzg-4844/v2 v2.1.6 // indirect
@@ -126,7 +124,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/relvacode/iso8601 v1.1.1-0.20210511065120-b30b151cc433 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/samber/lo v1.49.1 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/siphash v1.2.3 h1:QXwFc8cFOR2dSa/gE6o/HokBMWtLUaNDVd+22aKHeEA=
 github.com/dchest/siphash v1.2.3/go.mod h1:0NvQU092bT0ipiFN++/rXm69QG9tVxLAlQHIXMPAkHc=
-github.com/dchest/uniuri v1.2.0 h1:koIcOUdrTIivZgSLhHQvKgqdWZq5d7KdMEWF1Ud6+5g=
-github.com/dchest/uniuri v1.2.0/go.mod h1:fSzm4SLHzNZvWLvWJew423PhAzkpNQYq+uNLq4kxhkY=
 github.com/deckarep/golang-set/v2 v2.8.0 h1:swm0rlPCmdWn9mESxKOjWk8hXSqoxOp+ZlfuyaAdFlQ=
 github.com/deckarep/golang-set/v2 v2.8.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U0x++OzVrdms8=
@@ -364,8 +362,6 @@ github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzM
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
 github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
-github.com/relvacode/iso8601 v1.1.1-0.20210511065120-b30b151cc433 h1:mLbKGKe5gDGHE8uJLYMmA/fkp/htaXEMl2Hj0k4xfYE=
-github.com/relvacode/iso8601 v1.1.1-0.20210511065120-b30b151cc433/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH2h3sZCn0I=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
@@ -381,8 +377,6 @@ github.com/samber/lo v1.49.1 h1:4BIFyVfuQSEpluc7Fua+j1NolZHiEHEpaSEKdsH0tew=
 github.com/samber/lo v1.49.1/go.mod h1:dO6KHFzUKXgP8LDhU0oI8d2hekjXnGOu0DB8Jecxd6o=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
-github.com/spruceid/siwe-go v0.2.1 h1:BroySys6CyUzeyNppTseEOT/w56xTdOfcmECTI7rnuc=
-github.com/spruceid/siwe-go v0.2.1/go.mod h1:MHpHbptGsM3lHth2L8quhZ9ipiwST8zsJH1CjWpeO1k=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/portal/identity/register_challenge.go
+++ b/portal/identity/register_challenge.go
@@ -1,12 +1,10 @@
 package identity
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
-
-	"github.com/spruceid/siwe-go"
 
 	"github.com/gosuda/portal-tunnel/v2/types"
 	"github.com/gosuda/portal-tunnel/v2/utils"
@@ -23,9 +21,6 @@ type RegisterChallenge struct {
 	ExpiresAt   time.Time
 	Request     types.RegisterChallengeRequest
 	SIWEMessage string
-
-	domain string
-	nonce  string
 }
 
 func NewRegisterChallenge(req types.RegisterChallengeRequest, domain, uri string, now time.Time, ttl time.Duration) (*RegisterChallenge, error) {
@@ -35,15 +30,12 @@ func NewRegisterChallenge(req types.RegisterChallengeRequest, domain, uri string
 	}
 
 	challengeID := utils.RandomID("rch_")
-	nonce := siwe.GenerateNonce()
 	expiresAt := now.UTC().Add(ttl)
-	message, err := siwe.InitMessage(domain, normalizedIdentity.Address, uri, nonce, map[string]any{
-		"statement":      "Register a portal lease",
-		"chainId":        1,
-		"issuedAt":       now.UTC().Format(time.RFC3339),
-		"expirationTime": expiresAt.UTC().Format(time.RFC3339),
-		"requestId":      challengeID,
-	})
+	message, err := (siweMessage{
+		domain: domain, address: normalizedIdentity.Address, uri: uri,
+		statement: "Register a portal lease", nonce: rand.Text(), requestID: challengeID,
+		issuedAt: now, expiresAt: expiresAt,
+	}).format()
 	if err != nil {
 		return nil, fmt.Errorf("build siwe message: %w", err)
 	}
@@ -55,9 +47,7 @@ func NewRegisterChallenge(req types.RegisterChallengeRequest, domain, uri string
 		ChallengeID: challengeID,
 		ExpiresAt:   expiresAt,
 		Request:     req,
-		SIWEMessage: message.String(),
-		domain:      strings.TrimSpace(domain),
-		nonce:       nonce,
+		SIWEMessage: message,
 	}, nil
 }
 
@@ -69,17 +59,10 @@ func (c *RegisterChallenge) Verify(req types.RegisterRequest, now time.Time) err
 	if c == nil {
 		return ErrRegisterChallengeNotFound
 	}
-	if strings.TrimSpace(req.SIWEMessage) != c.SIWEMessage {
+	if req.SIWEMessage != c.SIWEMessage {
 		return errors.New("siwe message does not match register challenge")
 	}
-	message, err := siwe.ParseMessage(strings.TrimSpace(c.SIWEMessage))
-	if err != nil {
-		return ErrRegisterChallengeInvalidSignature
-	}
-	normalizedDomain := strings.TrimSpace(c.domain)
-	normalizedNonce := strings.TrimSpace(c.nonce)
-	verifiedAt := now.UTC()
-	if _, err := message.Verify(strings.TrimSpace(req.SIWESignature), &normalizedDomain, &normalizedNonce, &verifiedAt); err != nil {
+	if err := verifySIWEMessage(c.SIWEMessage, req.SIWESignature, c.Request.Identity.Address, c.ExpiresAt, now); err != nil {
 		return ErrRegisterChallengeInvalidSignature
 	}
 	return nil

--- a/portal/identity/register_challenge_test.go
+++ b/portal/identity/register_challenge_test.go
@@ -52,9 +52,9 @@ func TestRegisterChallengeSIWE(t *testing.T) {
 
 func siweTestAuthority(t *testing.T, keyDigit string) LocalAuthority {
 	t.Helper()
-	authority, err := NewLocalAuthority(types.Identity{Name: "siwe-test", PrivateKey: strings.Repeat("0", 63) + keyDigit})
+	resolved, err := resolve(types.Identity{Name: "siwe-test", PrivateKey: strings.Repeat("0", 63) + keyDigit})
 	if err != nil {
 		t.Fatal(err)
 	}
-	return authority
+	return NewLocalAuthority(resolved)
 }

--- a/portal/identity/register_challenge_test.go
+++ b/portal/identity/register_challenge_test.go
@@ -1,0 +1,60 @@
+package identity
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gosuda/portal-tunnel/v2/types"
+)
+
+func TestRegisterChallengeSIWE(t *testing.T) {
+	owner := siweTestAuthority(t, "1")
+	other := siweTestAuthority(t, "2")
+	now := time.Date(2026, 9, 12, 12, 0, 0, 500000000, time.UTC)
+	challenge, err := NewRegisterChallenge(types.RegisterChallengeRequest{Identity: owner.Identity()}, "localhost:8443", "https://localhost:8443/register", now, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(challenge.SIWEMessage, "\nRegister a portal lease\n\n") || !strings.HasSuffix(challenge.SIWEMessage, "Request ID: "+challenge.ChallengeID) {
+		t.Fatalf("registration message omitted challenge fields: %q", challenge.SIWEMessage)
+	}
+	for _, test := range []struct {
+		name    string
+		signer  LocalAuthority
+		message string
+		at      time.Time
+		valid   bool
+	}{
+		{"owner", owner, challenge.SIWEMessage, now, true},
+		{"wrong signer", other, challenge.SIWEMessage, now, false},
+		{"changed message", owner, challenge.SIWEMessage + "!", now, false},
+		{"added whitespace", owner, challenge.SIWEMessage + "\n", now, false},
+		{"expiration inclusive", owner, challenge.SIWEMessage, challenge.ExpiresAt.Truncate(time.Second), true},
+		{"signed expiration passed", owner, challenge.SIWEMessage, challenge.ExpiresAt.Truncate(time.Second).Add(time.Nanosecond), false},
+		{"expired", owner, challenge.SIWEMessage, now.Add(2 * time.Minute), false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			signature, err := test.signer.SignEthereumPersonalMessage(test.message)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = challenge.Verify(types.RegisterRequest{SIWEMessage: test.message, SIWESignature: signature}, test.at)
+			if (err == nil) != test.valid {
+				t.Fatalf("Verify() = %v; want valid=%v", err, test.valid)
+			}
+		})
+	}
+	if err := challenge.Verify(types.RegisterRequest{SIWEMessage: challenge.SIWEMessage, SIWESignature: "0x12"}, now); err == nil {
+		t.Fatal("short signature accepted")
+	}
+}
+
+func siweTestAuthority(t *testing.T, keyDigit string) LocalAuthority {
+	t.Helper()
+	authority, err := NewLocalAuthority(types.Identity{Name: "siwe-test", PrivateKey: strings.Repeat("0", 63) + keyDigit})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return authority
+}

--- a/portal/identity/secp256k1.go
+++ b/portal/identity/secp256k1.go
@@ -141,14 +141,7 @@ func signEthereumPersonalMessage(message, privateKeyHex string) (string, error) 
 		return "", err
 	}
 
-	data := []byte(message)
-	prefix := []byte(fmt.Sprintf("\x19Ethereum Signed Message:\n%d", len(data)))
-	hasher := sha3.NewLegacyKeccak256()
-	_, _ = hasher.Write(prefix)
-	_, _ = hasher.Write(data)
-	hash := hasher.Sum(nil)
-
-	compactSignature := ecdsa.SignCompact(privateKey, hash, false)
+	compactSignature := ecdsa.SignCompact(privateKey, ethereumPersonalMessageHash(message), false)
 	if len(compactSignature) != 65 {
 		return "", errors.New("invalid compact signature length")
 	}
@@ -158,6 +151,44 @@ func signEthereumPersonalMessage(message, privateKeyHex string) (string, error) 
 	copy(signature[32:64], compactSignature[33:65])
 	signature[64] = compactSignature[0]
 	return "0x" + hex.EncodeToString(signature), nil
+}
+
+// ethereumPersonalMessageHash is the shared EIP-191 personal-sign digest for
+// both signing and recovery. The prefix counts UTF-8 bytes, not characters.
+func ethereumPersonalMessageHash(message string) []byte {
+	hasher := sha3.NewLegacyKeccak256()
+	_, _ = fmt.Fprintf(hasher, "\x19Ethereum Signed Message:\n%d", len(message))
+	_, _ = hasher.Write([]byte(message))
+	return hasher.Sum(nil)
+}
+
+func recoverEthereumPersonalMessage(message, signature string) (string, error) {
+	encoded := strings.TrimSpace(signature)
+	if len(encoded) != 2+compactSecp256k1SignatureSize*2 || !strings.HasPrefix(strings.ToLower(encoded), "0x") {
+		return "", ErrSecp256k1SignatureInvalid
+	}
+	raw, err := hex.DecodeString(encoded[2:])
+	if err != nil {
+		return "", ErrSecp256k1SignatureInvalid
+	}
+	// Ethereum signatures are r || s || v. Accept the personal_sign recovery
+	// values 27/28 and their normalized 0/1 forms, not transaction chain IDs.
+	v := raw[64]
+	switch v {
+	case 0, 1:
+		v += 27
+	case 27, 28:
+	default:
+		return "", ErrSecp256k1SignatureInvalid
+	}
+	compact := make([]byte, compactSecp256k1SignatureSize)
+	compact[0] = v
+	copy(compact[1:], raw[:64])
+	publicKey, _, err := ecdsa.RecoverCompact(compact, ethereumPersonalMessageHash(message))
+	if err != nil {
+		return "", ErrSecp256k1SignatureInvalid
+	}
+	return AddressFromCompressedPublicKeyHex(hex.EncodeToString(publicKey.SerializeCompressed()))
 }
 
 func ResolveSecp256k1Identity(rawPrivateKey string) (types.Identity, error) {

--- a/portal/identity/siwe.go
+++ b/portal/identity/siwe.go
@@ -1,0 +1,79 @@
+package identity
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// siweMessage formats the EIP-4361 fields Portal issues for registration and
+// wallet login. Version and chain ID remain 1; this is not a general SIWE parser.
+type siweMessage struct {
+	domain, address, uri, statement, nonce, requestID string
+	issuedAt, expiresAt                               time.Time
+}
+
+func (m siweMessage) format() (string, error) {
+	domain, err := url.Parse("https://" + m.domain)
+	if err != nil || domain.Host == "" {
+		return "", errors.New("invalid siwe domain")
+	}
+	authority := domain.Host
+	if domain.User != nil {
+		authority = domain.User.String() + "@" + authority
+	}
+	if authority != m.domain {
+		return "", errors.New("invalid siwe domain")
+	}
+	uri, err := url.Parse(m.uri)
+	if err != nil || !uri.IsAbs() {
+		return "", errors.New("invalid siwe uri")
+	}
+	address, err := NormalizeEVMAddress(m.address)
+	if err != nil {
+		return "", err
+	}
+	if strings.IndexFunc(m.statement, func(r rune) bool { return r < ' ' || r > '~' }) >= 0 {
+		return "", errors.New("siwe statement must be a single ASCII line")
+	}
+	invalidNonce := strings.IndexFunc(m.nonce, func(r rune) bool {
+		lower := r >= 'a' && r <= 'z'
+		upper := r >= 'A' && r <= 'Z'
+		digit := r >= '0' && r <= '9'
+		return !lower && !upper && !digit
+	}) >= 0
+	if len(m.nonce) < 8 || invalidNonce {
+		return "", errors.New("siwe nonce must contain at least 8 alphanumeric characters")
+	}
+	if strings.ContainsAny(m.requestID, "\r\n") {
+		return "", errors.New("invalid siwe request ID")
+	}
+
+	header := fmt.Sprintf("%s wants you to sign in with your Ethereum account:\n%s\n\n", m.domain, address)
+	if m.statement != "" {
+		header += m.statement + "\n"
+	}
+	return fmt.Sprintf("%s\nURI: %s\nVersion: 1\nChain ID: 1\nNonce: %s\nIssued At: %s\nExpiration Time: %s\nRequest ID: %s",
+		header, uri.String(), m.nonce, m.issuedAt.UTC().Format(time.RFC3339), m.expiresAt.UTC().Format(time.RFC3339), m.requestID), nil
+}
+
+// verifySIWEMessage verifies the stored challenge, after the caller has matched
+// the submitted message byte-for-byte. Domain, nonce and request ID are bound by
+// that message; parsing them back out would create a second validation path.
+func verifySIWEMessage(message, signature, address string, expiresAt, now time.Time) error {
+	// The signed RFC3339 expiration has second precision. Preserve the existing
+	// inclusive cutoff even when the stored challenge timestamp has nanoseconds.
+	if now.After(expiresAt.Truncate(time.Second)) {
+		return errors.New("siwe message expired")
+	}
+	signer, err := recoverEthereumPersonalMessage(message, signature)
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(signer, address) {
+		return ErrSecp256k1SignatureInvalid
+	}
+	return nil
+}

--- a/portal/identity/siwe_test.go
+++ b/portal/identity/siwe_test.go
@@ -1,0 +1,130 @@
+package identity
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSIWEMessageFormat(t *testing.T) {
+	// EIP-4361's ABNF defines the literal field order and LF separators:
+	// https://eips.ethereum.org/EIPS/eip-4361#message-format
+	now := time.Date(2026, 9, 12, 12, 0, 0, 123456789, time.UTC)
+	message := siweMessage{
+		domain: "localhost:8443", address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+		uri: "https://localhost:8443/login", statement: "Sign in to Portal",
+		nonce: "32891756", requestID: "wac_example", issuedAt: now, expiresAt: now.Add(2 * time.Minute),
+	}
+	want := "localhost:8443 wants you to sign in with your Ethereum account:\n" +
+		"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\n" +
+		"Sign in to Portal\n\n" +
+		"URI: https://localhost:8443/login\nVersion: 1\nChain ID: 1\n" +
+		"Nonce: 32891756\nIssued At: 2026-09-12T12:00:00Z\n" +
+		"Expiration Time: 2026-09-12T12:02:00Z\nRequest ID: wac_example"
+	got, err := message.format()
+	if err != nil || got != want {
+		t.Fatalf("format() = %q, %v; want %q", got, err, want)
+	}
+
+	message.statement = ""
+	got, err = message.format()
+	want = strings.Replace(want, "Sign in to Portal\n", "", 1)
+	if err != nil || got != want {
+		t.Fatalf("format without statement = %q, %v; want %q", got, err, want)
+	}
+}
+
+func TestSIWEMessageRejectsInvalidFields(t *testing.T) {
+	for name, change := range map[string]func(*siweMessage){
+		"empty domain":       func(m *siweMessage) { m.domain = "" },
+		"domain with path":   func(m *siweMessage) { m.domain = "example.com/path" },
+		"domain with query":  func(m *siweMessage) { m.domain = "example.com?" },
+		"relative URI":       func(m *siweMessage) { m.uri = "/login" },
+		"invalid address":    func(m *siweMessage) { m.address = "0x1234" },
+		"statement new line": func(m *siweMessage) { m.statement = "Sign in\nNonce: attacker" },
+		"short nonce":        func(m *siweMessage) { m.nonce = "1234567" },
+		"invalid nonce":      func(m *siweMessage) { m.nonce = "1234567_" },
+		"request ID line":    func(m *siweMessage) { m.requestID = "id\r\nResources:" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			message := siweMessage{
+				domain: "example.com", address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+				uri: "https://example.com/login", nonce: "32891756", requestID: "wac_example",
+				issuedAt: time.Now(), expiresAt: time.Now().Add(time.Minute),
+			}
+			change(&message)
+			if _, err := message.format(); err == nil {
+				t.Fatal("invalid SIWE field accepted")
+			}
+		})
+	}
+}
+
+func TestEthereumPersonalMessageRecoveryVectors(t *testing.T) {
+	// Independent signatures from Spruce's SIWE interoperability vectors:
+	// https://github.com/spruceid/siwe/blob/911f6f2c73ef24deac73fec2f6b84930721d2fb4/test/verification_positive.json
+	// Keep the signed bytes literal, including fractional seconds. Recovery does
+	// not parse or rewrite the message, or depend on Portal's signing function.
+	for _, test := range []struct {
+		name, message, signature, address string
+	}{
+		{
+			name: "example message",
+			message: "login.xyz wants you to sign in with your Ethereum account:\n" +
+				"0x9D85ca56217D2bb651b00f15e694EB7E713637D4\n\n" +
+				"Sign-In With Ethereum Example Statement\n\n" +
+				"URI: https://login.xyz\nVersion: 1\nChain ID: 1\nNonce: bTyXgcQxn2htgkjJn\n" +
+				"Issued At: 2022-01-27T17:09:38.578Z\nExpiration Time: 2100-01-07T14:31:43.952Z",
+			signature: "0xdc35c7f8ba2720df052e0092556456127f00f7707eaa8e3bbff7e56774e7f2e05a093cfc9e02964c33d86e8e066e221b7d153d27e5a2e97ccd5ca7d3f2ce06cb1b",
+			address:   "0x9D85ca56217D2bb651b00f15e694EB7E713637D4",
+		},
+		{
+			name: "normalized recovery byte",
+			message: "www.tally.xyz wants you to sign in with your Ethereum account:\n" +
+				"0xc95EB884FE852e241D409234bfC7045CB9E31BD7\n\n" +
+				"Sign in with Ethereum to Tally\n\n" +
+				"URI: https://tally.xyz\nVersion: 1\nChain ID: 1\nNonce: 15050747\n" +
+				"Issued At: 2022-06-30T14:08:51.382Z",
+			signature: "0x8c46b6eb8505939892d8e9b075f89f8277321b17b993151f37810cdda38cce6f4a85909d2b53e6a14629c74c0ac38bf4becde78ee5b2529812bf6cceaf7b2a2501",
+			address:   "0xc95EB884FE852e241D409234bfC7045CB9E31BD7",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			alternate := test.signature[:130] + "00"
+			if strings.HasSuffix(test.signature, "01") {
+				alternate = test.signature[:130] + "1c"
+			}
+			for _, signature := range []string{test.signature, alternate} {
+				address, err := recoverEthereumPersonalMessage(test.message, signature)
+				if err != nil || address != test.address {
+					t.Fatalf("recover = %q, %v; want %q", address, err, test.address)
+				}
+			}
+			address, err := recoverEthereumPersonalMessage(test.message+"!", test.signature)
+			if err == nil && address == test.address {
+				t.Fatal("signature authenticated a changed message")
+			}
+		})
+	}
+}
+
+func TestEthereumPersonalMessageRejectsMalformedSignatures(t *testing.T) {
+	valid := "dc35c7f8ba2720df052e0092556456127f00f7707eaa8e3bbff7e56774e7f2e05a093cfc9e02964c33d86e8e066e221b7d153d27e5a2e97ccd5ca7d3f2ce06cb1b"
+	for name, signature := range map[string]string{
+		"empty": "", "short": "0x12", "long": "0x" + valid + "00", "missing prefix": valid,
+		"non hex":        "0xzz" + valid[2:],
+		"zero r and s":   "0x" + strings.Repeat("00", 64) + "1b",
+		"overflow r":     "0x" + strings.Repeat("ff", 32) + valid[64:],
+		"overflow s":     "0x" + valid[:64] + strings.Repeat("ff", 32) + "1b",
+		"invalid v":      "0x" + valid[:128] + "02",
+		"transaction v":  "0x" + valid[:128] + "25",
+		"v modulo alias": "0x" + valid[:128] + "36",
+		"compact header": "0x" + valid[:128] + "1f",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := recoverEthereumPersonalMessage("message", signature); err == nil {
+				t.Fatal("malformed personal-sign signature accepted")
+			}
+		})
+	}
+}

--- a/portal/identity/wallet_auth.go
+++ b/portal/identity/wallet_auth.go
@@ -2,13 +2,12 @@ package identity
 
 import (
 	"cmp"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/spruceid/siwe-go"
 
 	"github.com/gosuda/portal-tunnel/v2/types"
 	"github.com/gosuda/portal-tunnel/v2/utils"
@@ -44,9 +43,7 @@ type WalletAuthenticator struct {
 
 type walletAuthChallenge struct {
 	Address     string
-	Domain      string
 	ExpiresAt   time.Time
-	Nonce       string
 	SIWEMessage string
 }
 
@@ -96,25 +93,20 @@ func (a *WalletAuthenticator) IssueChallenge(req types.WalletAuthChallengeReques
 	}
 
 	challengeID := utils.RandomID("wac_")
-	nonce := siwe.GenerateNonce()
 	expiresAt := now.UTC().Add(defaultWalletAuthChallengeTTL)
-	message, err := siwe.InitMessage(domain, address, uri, nonce, map[string]any{
-		"statement":      a.statement,
-		"chainId":        1,
-		"issuedAt":       now.UTC().Format(time.RFC3339),
-		"expirationTime": expiresAt.UTC().Format(time.RFC3339),
-		"requestId":      challengeID,
-	})
+	message, err := (siweMessage{
+		domain: domain, address: address, uri: uri,
+		statement: a.statement, nonce: rand.Text(), requestID: challengeID,
+		issuedAt: now, expiresAt: expiresAt,
+	}).format()
 	if err != nil {
 		return types.WalletAuthChallengeResponse{}, fmt.Errorf("build wallet auth message: %w", err)
 	}
 
 	challenge := walletAuthChallenge{
 		Address:     address,
-		Domain:      strings.TrimSpace(domain),
 		ExpiresAt:   expiresAt,
-		Nonce:       nonce,
-		SIWEMessage: message.String(),
+		SIWEMessage: message,
 	}
 
 	a.mu.Lock()
@@ -151,25 +143,15 @@ func (a *WalletAuthenticator) Login(req types.WalletAuthLoginRequest, now time.T
 		a.mu.Unlock()
 		return "", "", ErrWalletAuthChallengeExpired
 	}
-	if strings.TrimSpace(req.SIWEMessage) != challenge.SIWEMessage {
+	if req.SIWEMessage != challenge.SIWEMessage {
 		return "", "", ErrWalletAuthInvalidSignature
 	}
 
-	message, err := siwe.ParseMessage(strings.TrimSpace(req.SIWEMessage))
-	if err != nil {
+	if err := verifySIWEMessage(challenge.SIWEMessage, req.SIWESignature, challenge.Address, challenge.ExpiresAt, now); err != nil {
 		return "", "", ErrWalletAuthInvalidSignature
 	}
-	domain := challenge.Domain
-	nonce := challenge.Nonce
-	verifiedAt := now.UTC()
-	if _, err := message.Verify(strings.TrimSpace(req.SIWESignature), &domain, &nonce, &verifiedAt); err != nil {
-		return "", "", ErrWalletAuthInvalidSignature
-	}
-	address, err := NormalizeEVMAddress(message.GetAddress().Hex())
-	if err != nil {
-		return "", "", ErrWalletAuthInvalidSignature
-	}
-	if !strings.EqualFold(address, challenge.Address) || !a.addressAllowed(address) {
+	address := challenge.Address
+	if !a.addressAllowed(address) {
 		return "", "", ErrWalletAuthUnauthorized
 	}
 

--- a/portal/identity/wallet_auth_test.go
+++ b/portal/identity/wallet_auth_test.go
@@ -1,0 +1,95 @@
+package identity
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gosuda/portal-tunnel/v2/types"
+)
+
+func TestWalletAuthSIWE(t *testing.T) {
+	owner := siweTestAuthority(t, "1")
+	other := siweTestAuthority(t, "2")
+	now := time.Now().UTC().Truncate(time.Second).Add(500 * time.Millisecond)
+	for _, test := range []struct {
+		name           string
+		signer         LocalAuthority
+		suffix         string
+		delay          time.Duration
+		shortSig       bool
+		otherChallenge bool
+		valid          bool
+	}{
+		{name: "owner", signer: owner, valid: true},
+		{name: "wrong signer", signer: other},
+		{name: "changed message", signer: owner, suffix: "!"},
+		{name: "added whitespace", signer: owner, suffix: "\n"},
+		{name: "expired", signer: owner, delay: 3 * time.Minute},
+		{name: "signed expiration passed", signer: owner, delay: defaultWalletAuthChallengeTTL - 500*time.Millisecond + time.Nanosecond},
+		{name: "expiration inclusive", signer: owner, delay: defaultWalletAuthChallengeTTL - 500*time.Millisecond, valid: true},
+		{name: "short signature", signer: owner, shortSig: true},
+		{name: "different challenge", signer: owner, otherChallenge: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			auth, err := NewWalletAuthenticator(WalletAuthConfig{AllowedAddresses: []string{owner.Identity().Address}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			challenge, err := auth.IssueChallenge(types.WalletAuthChallengeRequest{Address: owner.Identity().Address}, "example.com", "https://example.com/login", now)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(challenge.SIWEMessage, "\nSign in to Portal\n\n") || !strings.HasSuffix(challenge.SIWEMessage, "Request ID: "+challenge.ChallengeID) {
+				t.Fatalf("wallet message omitted challenge fields: %q", challenge.SIWEMessage)
+			}
+			message := challenge.SIWEMessage + test.suffix
+			if test.otherChallenge {
+				other, err := auth.IssueChallenge(types.WalletAuthChallengeRequest{Address: owner.Identity().Address}, "example.com", "https://example.com/login", now)
+				if err != nil {
+					t.Fatal(err)
+				}
+				message = other.SIWEMessage
+			}
+			signature, err := test.signer.SignEthereumPersonalMessage(message)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.shortSig {
+				signature = "0x12"
+			}
+			request := types.WalletAuthLoginRequest{ChallengeID: challenge.ChallengeID, SIWEMessage: message, SIWESignature: signature}
+			token, address, err := auth.Login(request, now.Add(test.delay))
+			if (err == nil) != test.valid {
+				t.Fatalf("Login() = %v; want valid=%v", err, test.valid)
+			}
+			if !test.valid {
+				if token != "" || address != "" {
+					t.Fatal("failed login returned a session")
+				}
+				return
+			}
+			if token == "" || address != owner.Identity().Address {
+				t.Fatalf("Login() token/address = %q/%q", token, address)
+			}
+			if sessionAddress, ok := auth.ValidateSession(token); !ok || sessionAddress != address {
+				t.Fatalf("ValidateSession() = %q, %v", sessionAddress, ok)
+			}
+			if _, _, err := auth.Login(request, now.Add(test.delay)); err == nil {
+				t.Fatal("consumed wallet challenge accepted a second time")
+			}
+		})
+	}
+}
+
+func TestWalletAuthRejectsDisallowedChallenge(t *testing.T) {
+	owner := siweTestAuthority(t, "1")
+	other := siweTestAuthority(t, "2")
+	auth, err := NewWalletAuthenticator(WalletAuthConfig{AllowedAddresses: []string{owner.Identity().Address}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := auth.IssueChallenge(types.WalletAuthChallengeRequest{Address: other.Identity().Address}, "example.com", "https://example.com/login", time.Now()); err == nil {
+		t.Fatal("disallowed wallet received a challenge")
+	}
+}


### PR DESCRIPTION
Supersedes #418, which GitHub automatically closed when its stacked base branch was deleted after #416 merged.

#416 is now merged into `main`; this PR retargets the same SIWE work directly to `main`.

Closes #417.

## Summary

Portal currently uses `siwe-go` to format and verify server-issued registration and wallet-login challenges, bringing in a second Ethereum signature stack. This change puts the supported SIWE subset in `portal/identity` and reuses the existing secp256k1, Keccak, and personal-sign primitives.

- Formats Portal's supported EIP-4361 message subset in-package.
- Uses `crypto/rand` for nonces.
- Compares submitted challenge messages exactly to stored messages and recovers the expected signer.
- Removes duplicate parse/revalidate paths and redundant stored challenge fields.
- Removes `github.com/spruceid/siwe-go`, `github.com/dchest/uniuri`, and `github.com/relvacode/iso8601` with no replacement dependency.
- Leaves x402's separate `go-ethereum` dependency untouched.

The source branch and commit are unchanged from #418 (`a05bb2a2edc4701213e61e84112e77a30245e5cd`).