### PR TITLE
feat(sdk): expose TCP relay readiness

### DIFF
--- a/cmd/portal-tunnel/agent/manager.go
+++ b/cmd/portal-tunnel/agent/manager.go
@@ -624,6 +624,7 @@ func agentRelayStatuses(relays []sdk.RelayStatus) []types.AgentRelayStatus {
 		statuses = append(statuses, types.AgentRelayStatus{
 			RelayURL:    relay.RelayURL,
 			PublicURL:   relay.PublicURL,
+			TCPAddr:     relay.TCPAddr,
 			Version:     relay.Version,
 			Explicit:    relay.Explicit,
 			Connecting:  relay.State == sdk.RelayConnecting,

--- a/sdk/expose.go
+++ b/sdk/expose.go
@@ -549,11 +549,11 @@ func (e *Exposure) noRelaysAvailable() bool {
 	return !cfg.Discovery
 }
 
-func (e *Exposure) readyRelays(datagram bool) ([]RelayStatus, <-chan struct{}) {
+func (e *Exposure) readyRelays(matches func(RelayStatus) bool) ([]RelayStatus, <-chan struct{}) {
 	e.mu.RLock()
 	ready := make([]RelayStatus, 0, len(e.statuses))
 	for _, status := range e.statuses {
-		if !relayReady(status, datagram) {
+		if !matches(status) {
 			continue
 		}
 		ready = append(ready, status)
@@ -564,16 +564,6 @@ func (e *Exposure) readyRelays(datagram bool) ([]RelayStatus, <-chan struct{}) {
 		return strings.Compare(a.RelayURL, b.RelayURL)
 	})
 	return ready, changed
-}
-
-func relayReady(status RelayStatus, datagram bool) bool {
-	if status.State == RelayFailed {
-		return false
-	}
-	if datagram {
-		return status.UDPAddr != ""
-	}
-	return status.State == RelayReady
 }
 
 // Updates reports relay lifecycle changes. Relays is the authoritative
@@ -594,7 +584,9 @@ func (e *Exposure) WaitReady(ctx context.Context) ([]RelayStatus, error) {
 		return nil, errors.New("portal sdk: context is nil")
 	}
 	for {
-		ready, changed := e.readyRelays(false)
+		ready, changed := e.readyRelays(func(status RelayStatus) bool {
+			return status.State == RelayReady
+		})
 		if len(ready) > 0 {
 			return ready, nil
 		}
@@ -665,7 +657,40 @@ func (e *Exposure) WaitDatagramReady(ctx context.Context) ([]RelayStatus, error)
 	}
 
 	for {
-		ready, changed := e.readyRelays(true)
+		ready, changed := e.readyRelays(func(status RelayStatus) bool {
+			return status.State != RelayFailed && status.UDPAddr != ""
+		})
+		if len(ready) > 0 {
+			return ready, nil
+		}
+		if e.noRelaysAvailable() {
+			return nil, ErrNoRelays
+		}
+
+		select {
+		case <-e.done:
+			return nil, net.ErrClosed
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-changed:
+		}
+	}
+}
+
+// WaitTCPReady waits until at least one relay has allocated a public TCP
+// address and returns the ready relay snapshots.
+func (e *Exposure) WaitTCPReady(ctx context.Context) ([]RelayStatus, error) {
+	if !e.config().TCPEnabled {
+		return nil, errors.New("exposure does not have tcp enabled")
+	}
+	if ctx == nil {
+		return nil, errors.New("portal sdk: context is nil")
+	}
+
+	for {
+		ready, changed := e.readyRelays(func(status RelayStatus) bool {
+			return status.State != RelayFailed && status.TCPAddr != ""
+		})
 		if len(ready) > 0 {
 			return ready, nil
 		}

--- a/sdk/expose_test.go
+++ b/sdk/expose_test.go
@@ -168,6 +168,38 @@ func TestExposureWaitDatagramReadyDoesNotRequireStreamReadiness(t *testing.T) {
 	}
 }
 
+func TestExposureWaitTCPReadyUsesRelayStatus(t *testing.T) {
+	const relayURL = "https://relay.example"
+	exposure := newExposureStateTest(t, relayURL)
+	exposure.cfg.UpdateCopy(func(cfg *ExposeConfig) { cfg.TCPEnabled = true })
+	exposure.setRelayStatus(relayURL, listenerStatus{
+		state:   RelayConnecting,
+		tcpAddr: "relay.example:40000",
+	})
+
+	ready, err := exposure.WaitTCPReady(context.Background())
+	if err != nil {
+		t.Fatalf("WaitTCPReady() error = %v", err)
+	}
+	if len(ready) != 1 || ready[0].RelayURL != relayURL || ready[0].TCPAddr != "relay.example:40000" {
+		t.Fatalf("WaitTCPReady() = %+v, want TCP-ready relay %q", ready, relayURL)
+	}
+}
+
+func TestExposureWaitTCPReadyReturnsAfterTerminalFailure(t *testing.T) {
+	const relayURL = "https://relay.example"
+	exposure := newExposureStateTest(t, relayURL)
+	exposure.cfg.UpdateCopy(func(cfg *ExposeConfig) { cfg.TCPEnabled = true })
+	exposure.setRelayStatus(relayURL, listenerStatus{
+		state: RelayFailed,
+		err:   errors.New("tcp_port_disabled"),
+	})
+
+	if _, err := exposure.WaitTCPReady(context.Background()); !errors.Is(err, ErrNoRelays) {
+		t.Fatalf("WaitTCPReady() error = %v, want ErrNoRelays", err)
+	}
+}
+
 func TestExposureConfigSnapshotsDoNotShareMutableState(t *testing.T) {
 	exposure := &Exposure{
 		cfg: utils.NewSnapshot(ExposeConfig{

--- a/types/agent.go
+++ b/types/agent.go
@@ -38,6 +38,7 @@ type AgentHTTPRoute struct {
 type AgentRelayStatus struct {
 	RelayURL    string `json:"relay_url"`
 	PublicURL   string `json:"public_url,omitempty"`
+	TCPAddr     string `json:"tcp_addr,omitempty"`
 	Version     string `json:"version,omitempty"`
 	Explicit    bool   `json:"explicit,omitempty"`
 	Connecting  bool   `json:"connecting"`


### PR DESCRIPTION
Supersedes #394 with a current-`main` implementation.

Closes #395.

## Summary

- add `Exposure.WaitTCPReady(ctx) ([]RelayStatus, error)` on the existing authoritative relay-status snapshot
- treat a relay as TCP-ready when its `RelayStatus.TCPAddr` is populated
- use the existing `stateChanged` notification path instead of ticker polling
- return `ErrNoRelays` immediately when all relevant explicit relays reach terminal failure
- add `TCPAddr` to `types.AgentRelayStatus` and copy it in the agent-owned status mapping

## Ownership

`Exposure.Relays()` remains the canonical public relay snapshot. This change does not add `ActiveTCPAddrs()` and does not inspect listener lease snapshots. Callers retain the relay-to-address association through the returned `RelayStatus` values.

## Tests

Focused SDK tests cover:

- returning the TCP-ready `RelayStatus`, including its relay URL and public TCP address
- terminating with `ErrNoRelays` after relay-side TCP failure while the exposure remains alive

## Verification

- `go test ./sdk ./cmd/portal-tunnel/agent ./types`
- `go vet . ./cmd/... ./portal/... ./sdk/... ./types/... ./utils/...`
- `golangci-lint` v2.13.1: 0 issues
- `gojgp` v1.1.1: clean