### PR TITLE
fix(sdk): reserve the MITM probe nonce before the TLS dial

### DIFF
--- a/sdk/mitm.go
+++ b/sdk/mitm.go
@@ -108,12 +108,6 @@ func (m *mitmManager) probeTLSPassthrough(ctx context.Context) (mitmProbeReport,
 	}
 	nonceHex := hex.EncodeToString(nonceRaw)
 
-	// Reserve the nonce before dialing: the reverse side can hand the
-	// connection to Accept as soon as its TLS handshake completes, which
-	// can race ahead of the probe side exporting keying material.
-	resultCh, cleanupProbe := m.reserveProbe(nonceHex)
-	defer cleanupProbe()
-
 	dialAddr, err := m.probeDialAddress(publicURL)
 	if err != nil {
 		return report, err
@@ -126,19 +120,22 @@ func (m *mitmManager) probeTLSPassthrough(ctx context.Context) (mitmProbeReport,
 		EncryptedClientHelloConfigList: bytes.Clone(lease.echConfigList),
 	}
 
-	dialer := &tls.Dialer{
-		NetDialer: &net.Dialer{Timeout: l.dialTimeout},
-		Config:    probeTLSConf,
-	}
-	conn, err := dialer.DialContext(probeCtx, "tcp", dialAddr)
+	rawConn, err := (&net.Dialer{Timeout: l.dialTimeout}).DialContext(probeCtx, "tcp", dialAddr)
 	if err != nil {
 		return report, fmt.Errorf("dial mitm probe: %w", err)
 	}
-	defer conn.Close()
+	tlsConn := tls.Client(rawConn, probeTLSConf)
+	defer tlsConn.Close()
 
-	tlsConn, ok := conn.(*tls.Conn)
-	if !ok {
-		return report, errors.New("mitm probe connection is not tls")
+	// Reserve the nonce once the TCP connection exists but before the TLS
+	// handshake: the reverse side can hand the connection to Accept as soon
+	// as its handshake completes, which can race ahead of the probe side
+	// exporting keying material. Reserving after the TCP connect keeps the
+	// probe-inspection window off address resolution and connection setup.
+	resultCh, cleanupProbe := m.reserveProbe(nonceHex)
+	defer cleanupProbe()
+	if err := tlsConn.HandshakeContext(probeCtx); err != nil {
+		return report, fmt.Errorf("mitm probe tls handshake: %w", err)
 	}
 
 	clientState := tlsConn.ConnectionState()
@@ -163,7 +160,7 @@ func (m *mitmManager) probeTLSPassthrough(ctx context.Context) (mitmProbeReport,
 		return report, fmt.Errorf("generate probe frame: %w", err)
 	}
 	copy(frame, nonceRaw)
-	if _, err := conn.Write(frame); err != nil {
+	if _, err := tlsConn.Write(frame); err != nil {
 		return report, fmt.Errorf("write mitm probe: %w", err)
 	}
 

--- a/sdk/mitm.go
+++ b/sdk/mitm.go
@@ -108,6 +108,12 @@ func (m *mitmManager) probeTLSPassthrough(ctx context.Context) (mitmProbeReport,
 	}
 	nonceHex := hex.EncodeToString(nonceRaw)
 
+	// Reserve the nonce before dialing: the reverse side can hand the
+	// connection to Accept as soon as its TLS handshake completes, which
+	// can race ahead of the probe side exporting keying material.
+	resultCh, cleanupProbe := m.reserveProbe(nonceHex)
+	defer cleanupProbe()
+
 	dialAddr, err := m.probeDialAddress(publicURL)
 	if err != nil {
 		return report, err
@@ -141,8 +147,7 @@ func (m *mitmManager) probeTLSPassthrough(ctx context.Context) (mitmProbeReport,
 	if err != nil {
 		return report, fmt.Errorf("export client probe keying material: %w", err)
 	}
-	resultCh, cleanupProbe := m.startProbe(nonceHex, expected)
-	defer cleanupProbe()
+	m.attachExpected(nonceHex, expected)
 
 	paddingLen := mitmProbePaddingMin
 	if paddingRange := mitmProbePaddingMax - mitmProbePaddingMin; paddingRange > 0 {
@@ -339,12 +344,16 @@ func (m *mitmManager) maybeHandleConn(conn net.Conn) (net.Conn, bool, error) {
 	return nil, true, nil
 }
 
-func (m *mitmManager) startProbe(nonce string, expected []byte) (<-chan string, func()) {
-	m.mu.Lock()
+// reserveProbe registers the probe nonce before the TLS dial so the reverse
+// side recognizes the connection even if Accept runs the moment the reverse
+// handshake completes. attachExpected arms the reservation afterwards; until
+// then the entry holds no exporter value and a completion attempt reports a
+// mismatch.
+func (m *mitmManager) reserveProbe(nonce string) (<-chan string, func()) {
 	state := &mitmProbePending{
-		expected: bytes.Clone(expected),
 		resultCh: make(chan string, 1),
 	}
+	m.mu.Lock()
 	m.pending[nonce] = state
 	m.mu.Unlock()
 
@@ -355,21 +364,32 @@ func (m *mitmManager) startProbe(nonce string, expected []byte) (<-chan string, 
 	}
 }
 
+// attachExpected arms a reserved probe with the exporter value the reverse
+// side must reproduce for the connection to count as untampered.
+func (m *mitmManager) attachExpected(nonce string, expected []byte) {
+	m.mu.Lock()
+	if state := m.pending[nonce]; state != nil {
+		state.expected = bytes.Clone(expected)
+	}
+	m.mu.Unlock()
+}
+
 func (m *mitmManager) completeProbe(nonce string, actual []byte) {
 	m.mu.Lock()
 	state := m.pending[nonce]
-	m.mu.Unlock()
 	if state == nil {
+		m.mu.Unlock()
 		return
 	}
-
 	reason := ""
 	if !bytes.Equal(state.expected, actual) {
 		reason = types.MITMProbeReasonExporterMismatch
 	}
+	resultCh := state.resultCh
+	m.mu.Unlock()
 
 	select {
-	case state.resultCh <- reason:
+	case resultCh <- reason:
 	default:
 	}
 }

--- a/sdk/mitm_test.go
+++ b/sdk/mitm_test.go
@@ -214,6 +214,11 @@ func TestMITMProbeConnAtHandshakeCompletionIsHandled(t *testing.T) {
 			t.Fatalf("probe reason = %q, want empty", reason)
 		}
 	case <-time.After(2 * time.Second):
+		select {
+		case result := <-handleResultCh:
+			t.Fatalf("timed out waiting for probe result; handler resolved first: handled=%v passthrough=%v err=%v", result.handled, result.conn != nil, result.err)
+		default:
+		}
 		t.Fatal("timed out waiting for probe result")
 	}
 

--- a/sdk/mitm_test.go
+++ b/sdk/mitm_test.go
@@ -40,8 +40,9 @@ func TestMITMProbeConnMatchesExporter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("client ExportKeyingMaterial() error = %v", err)
 	}
-	resultCh, cleanupProbe := listener.mitmManager.startProbe(nonceHex, expected)
+	resultCh, cleanupProbe := listener.mitmManager.reserveProbe(nonceHex)
 	defer cleanupProbe()
+	listener.mitmManager.attachExpected(nonceHex, expected)
 
 	handleDone := make(chan struct{})
 	go func() {
@@ -95,8 +96,9 @@ func TestMITMProbeConnDetectsExporterMismatch(t *testing.T) {
 		t.Fatalf("rand.Read() error = %v", err)
 	}
 	nonceHex := hex.EncodeToString(nonce)
-	resultCh, cleanupProbe := listener.mitmManager.startProbe(nonceHex, make([]byte, 32))
+	resultCh, cleanupProbe := listener.mitmManager.reserveProbe(nonceHex)
 	defer cleanupProbe()
+	listener.mitmManager.attachExpected(nonceHex, make([]byte, 32))
 
 	handleDone := make(chan struct{})
 	go func() {
@@ -132,6 +134,100 @@ func TestMITMProbeConnDetectsExporterMismatch(t *testing.T) {
 
 	select {
 	case <-handleDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for probe handler")
+	}
+}
+
+func TestMITMProbeConnAtHandshakeCompletionIsHandled(t *testing.T) {
+	listener := &listener{}
+	listener.mitmManager = newMITMManager(context.Background(), listener, false)
+
+	nonce := make([]byte, 16)
+	if _, err := rand.Read(nonce); err != nil {
+		t.Fatalf("rand.Read() error = %v", err)
+	}
+	nonceHex := hex.EncodeToString(nonce)
+
+	// Production order from probeTLSPassthrough: the nonce is reserved
+	// before the dial, so the reservation exists before any handshake.
+	resultCh, cleanupProbe := listener.mitmManager.reserveProbe(nonceHex)
+	defer cleanupProbe()
+
+	cert := newMITMProbeCertificate(t)
+	clientRaw, serverRaw := net.Pipe()
+	clientConn := tls.Client(clientRaw, &tls.Config{
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS13,
+		NextProtos:         []string{"http/1.1"},
+	})
+	serverConn := tls.Server(serverRaw, &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+		NextProtos:   []string{"http/1.1"},
+	})
+	defer closeMITMProbeTLSConn(clientConn)
+	defer closeMITMProbeTLSConn(serverConn)
+
+	type handleResult struct {
+		conn    net.Conn
+		handled bool
+		err     error
+	}
+	handleResultCh := make(chan handleResult, 1)
+	probeSide := make(chan struct{})
+	go func() {
+		if err := serverConn.HandshakeContext(context.Background()); err != nil {
+			handleResultCh <- handleResult{err: err}
+			return
+		}
+		close(probeSide)
+		// Accept fires the moment the reverse handshake completes — before
+		// the probe side has attached the expected exporter or written the
+		// nonce frame.
+		nextConn, handled, err := listener.mitmManager.maybeHandleConn(serverConn)
+		handleResultCh <- handleResult{conn: nextConn, handled: handled, err: err}
+	}()
+
+	if err := clientConn.HandshakeContext(context.Background()); err != nil {
+		t.Fatalf("client handshake error = %v", err)
+	}
+	<-probeSide
+
+	clientState := clientConn.ConnectionState()
+	expected, err := (&clientState).ExportKeyingMaterial(mitmProbeExporterLabel, nil, 32)
+	if err != nil {
+		t.Fatalf("client ExportKeyingMaterial() error = %v", err)
+	}
+	listener.mitmManager.attachExpected(nonceHex, expected)
+
+	frame := bytes.Clone(nonce)
+	frame = append(frame, bytes.Repeat([]byte{0xAB}, 128)...)
+	if _, err := clientConn.Write(frame); err != nil {
+		t.Fatalf("clientConn.Write() error = %v", err)
+	}
+	_ = clientConn.Close()
+
+	select {
+	case reason := <-resultCh:
+		if reason != "" {
+			t.Fatalf("probe reason = %q, want empty", reason)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for probe result")
+	}
+
+	select {
+	case result := <-handleResultCh:
+		if result.err != nil {
+			t.Fatalf("maybeHandleConn() error = %v", result.err)
+		}
+		if !result.handled {
+			t.Fatal("maybeHandleConn() handled = false, want true: probe bypassed into normal traffic")
+		}
+		if result.conn != nil {
+			t.Fatal("maybeHandleConn() returned passthrough conn for probe")
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for probe handler")
 	}

--- a/sdk/mitm_test.go
+++ b/sdk/mitm_test.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 	"net"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -150,7 +151,8 @@ func TestMITMProbeConnAtHandshakeCompletionIsHandled(t *testing.T) {
 	nonceHex := hex.EncodeToString(nonce)
 
 	// Production order from probeTLSPassthrough: the nonce is reserved
-	// before the dial, so the reservation exists before any handshake.
+	// once the TCP connection exists but before the TLS handshake, so the
+	// reservation is in place before the reverse handshake can complete.
 	resultCh, cleanupProbe := listener.mitmManager.reserveProbe(nonceHex)
 	defer cleanupProbe()
 
@@ -161,7 +163,8 @@ func TestMITMProbeConnAtHandshakeCompletionIsHandled(t *testing.T) {
 		MinVersion:         tls.VersionTLS13,
 		NextProtos:         []string{"http/1.1"},
 	})
-	serverConn := tls.Server(serverRaw, &tls.Config{
+	signaling := &readSignalingConn{Conn: serverRaw, readStarted: make(chan struct{})}
+	serverConn := tls.Server(signaling, &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		MinVersion:   tls.VersionTLS13,
 		NextProtos:   []string{"http/1.1"},
@@ -175,24 +178,28 @@ func TestMITMProbeConnAtHandshakeCompletionIsHandled(t *testing.T) {
 		err     error
 	}
 	handleResultCh := make(chan handleResult, 1)
-	probeSide := make(chan struct{})
 	go func() {
 		if err := serverConn.HandshakeContext(context.Background()); err != nil {
 			handleResultCh <- handleResult{err: err}
 			return
 		}
-		close(probeSide)
-		// Accept fires the moment the reverse handshake completes — before
-		// the probe side has attached the expected exporter or written the
-		// nonce frame.
+		// Accept fires the moment the reverse handshake completes. Arming the
+		// wrapper makes its next read — maybeHandleConn's peek — signal, so
+		// the probe side provably attaches the expected exporter only after
+		// the handler has entered its peek.
+		signaling.arm()
 		nextConn, handled, err := listener.mitmManager.maybeHandleConn(serverConn)
 		handleResultCh <- handleResult{conn: nextConn, handled: handled, err: err}
 	}()
 
 	if err := clientConn.HandshakeContext(context.Background()); err != nil {
-		t.Fatalf("client handshake error = %v", err)
+		t.Fatalf("client handshake error: %v", err)
 	}
-	<-probeSide
+	select {
+	case <-signaling.readStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for maybeHandleConn to start reading; was the probe reservation removed?")
+	}
 
 	clientState := clientConn.ConnectionState()
 	expected, err := (&clientState).ExportKeyingMaterial(mitmProbeExporterLabel, nil, 32)
@@ -236,6 +243,27 @@ func TestMITMProbeConnAtHandshakeCompletionIsHandled(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for probe handler")
 	}
+}
+
+// readSignalingConn closes readStarted on the first Read after arm is
+// called. Reads before arming — the TLS handshake itself — do not signal.
+// Handshake reads and armed reads both happen on the goroutine that owns the
+// conn, so the flag needs no lock; the Once makes repeated armed reads a
+// single signal instead of a double close.
+type readSignalingConn struct {
+	net.Conn
+	readStarted chan struct{}
+	signalOnce  sync.Once
+	armed       bool
+}
+
+func (c *readSignalingConn) arm() { c.armed = true }
+
+func (c *readSignalingConn) Read(p []byte) (int, error) {
+	if c.armed {
+		c.signalOnce.Do(func() { close(c.readStarted) })
+	}
+	return c.Conn.Read(p)
 }
 
 func TestMITMProbeConnPassesThroughNormalTraffic(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #397.

`probeTLSPassthrough()` registered the probe nonce only after the client-side TLS handshake completed. The reverse side can hand the connection to `listener.Accept()` — and `maybeHandleConn()` — the moment its own handshake completes, so the probe connection could be classified as normal tenant traffic before the nonce was inserted into `pending`: the probe payload was eligible to reach the local application while the probe itself timed out.

## Change

- `startProbe` is split into `reserveProbe(nonce)` and `attachExpected(nonce, expected)` — armed after the handshake exports the client keying material. Probe registration no longer depends on the client-side handshake completing first.
- The reservation happens **after the TCP connect and before the TLS handshake**: the reverse side cannot observe the connection before its handshake completes, so this is the minimal window — address resolution and connection setup no longer make `pending` non-empty for unrelated accepted connections (review direction from #433).
- `completeProbe` reads `state.expected` while holding the manager mutex, since the value is now attached after publication.
- `TestMITMProbeConnAtHandshakeCompletionIsHandled` drives the production ordering with a deterministic gate: the server side wraps its raw connection in a read-signaling conn under `tls.Server` (no production test hooks), and the probe side attaches the exporter only after `maybeHandleConn` has actually entered its peek.

## Verification

- `gofmt -l sdk`, `go vet ./sdk/...`, `go build ./...` — clean
- `go test -race ./sdk/ -run TestMITM -count=2` — ok
- `TestMITMProbeConnAtHandshakeCompletionIsHandled -count=10` — 10/10 PASS (determinism)
- Negative control: moving the reservation to after the handler-side read signal (no reservation in place when `maybeHandleConn` enters) fails the test within seconds — the handler returns passthrough at the `hasPending` check without ever reading, so the test reports the missing reservation directly