### PR TITLE
fix(relay): validate the canonical public origin against the local SNI listener

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,10 @@
 
 # Public HTTPS origin browsers and tunnel clients use. Must be publicly
 # resolvable when DISCOVERY=true; localhost and other local-only names are
-# rejected by public discovery.
+# rejected by public discovery. The origin is canonical: include the port
+# whenever it is not 443. On local hosts a portless PORTAL_URL with a
+# non-default SNI_PORT is rejected at startup; behind NAT or a load balancer
+# keep the external origin, which may differ from SNI_PORT.
 PORTAL_URL=https://localhost
 
 # Optional IVNP RouterConfig JSON file; requires DISCOVERY=true.

--- a/docs/src/routes/configuration/+page.md
+++ b/docs/src/routes/configuration/+page.md
@@ -55,6 +55,11 @@ A value that cannot be parsed is a startup error rather than a silent fallback:
 | `API_PORT` | `4017` | int | Admin/API server listen port |
 | `SNI_PORT` | `443` | int | TCP SNI router listen port; non-standard values are intended for local testing, while the bundled public deployment requires `443` |
 
+`PORTAL_URL` is the canonical public origin: a portless value implies public
+port `443`, and a non-default `SNI_PORT` on a local host must appear in
+`PORTAL_URL` or startup rejects the mismatch; NAT or load-balancer front-ends
+may use a different external origin.
+
 ### Optional HTTP redirect listener
 
 | Variable | Default | Type | Description |

--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -38,6 +38,20 @@ type harness struct {
 
 func newHarness(t *testing.T) *harness {
 	t.Helper()
+	apiPort := harnessPort(t)
+	sniPort := harnessPort(t)
+	relayURL := "https://127.0.0.1:" + strconv.Itoa(apiPort)
+	return newHarnessWithRelayURL(t, relayURL, portal.ServerConfig{
+		PortalURL:     relayURL,
+		StateDir:      t.TempDir(),
+		APIListenAddr: "127.0.0.1:" + strconv.Itoa(apiPort),
+		SNIListenAddr: "127.0.0.1:" + strconv.Itoa(sniPort),
+		SNIPort:       sniPort,
+	})
+}
+
+func newHarnessWithRelayURL(t *testing.T, relayURL string, relayCfg portal.ServerConfig) *harness {
+	t.Helper()
 
 	service := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, marker)
@@ -49,17 +63,7 @@ func newHarness(t *testing.T) *harness {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	apiPort := harnessPort(t)
-	sniPort := harnessPort(t)
-	stateDir := t.TempDir()
-	relayURL := "https://127.0.0.1:" + strconv.Itoa(apiPort)
-	relay, err := portal.NewServer(portal.ServerConfig{
-		PortalURL:     relayURL,
-		StateDir:      stateDir,
-		APIListenAddr: "127.0.0.1:" + strconv.Itoa(apiPort),
-		SNIListenAddr: "127.0.0.1:" + strconv.Itoa(sniPort),
-		SNIPort:       sniPort,
-	})
+	relay, err := portal.NewServer(relayCfg)
 	if err != nil {
 		cancel()
 		service.Close()
@@ -97,8 +101,8 @@ func newHarness(t *testing.T) *harness {
 		server:      relay,
 		exposure:    exposure,
 		service:     service,
-		sniAddr:     "127.0.0.1:" + strconv.Itoa(sniPort),
-		certificate: filepath.Join(stateDir, "fullchain.pem"),
+		sniAddr:     relayCfg.SNIListenAddr,
+		certificate: filepath.Join(relayCfg.StateDir, "fullchain.pem"),
 		proxyDone:   make(chan error, 1),
 	}
 	go func() {

--- a/e2e/local_sni_origin_test.go
+++ b/e2e/local_sni_origin_test.go
@@ -1,0 +1,43 @@
+package e2e_test
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gosuda/portal-tunnel/v2/portal"
+)
+
+func TestLocalSNIPortWithoutPublicPortFailsFast(t *testing.T) {
+	_, err := portal.NewServer(portal.ServerConfig{
+		PortalURL: "https://localhost",
+		StateDir:  t.TempDir(),
+		SNIPort:   8443,
+	})
+	if err == nil {
+		t.Fatal("NewServer() error = nil, want validation error for portless local URL with non-default SNI port")
+	}
+	if !strings.Contains(err.Error(), "PORTAL_URL") {
+		t.Fatalf("error %q does not mention PORTAL_URL", err.Error())
+	}
+	if !strings.Contains(err.Error(), "SNI_PORT") {
+		t.Fatalf("error %q does not mention SNI_PORT", err.Error())
+	}
+}
+
+func TestCanonicalTunnelThroughLocalSNIOrigin(t *testing.T) {
+	apiPort := harnessPort(t)
+	sniPort := harnessPort(t)
+	relayURL := "https://localhost:" + strconv.Itoa(sniPort)
+	h := newHarnessWithRelayURL(t, relayURL, portal.ServerConfig{
+		PortalURL:     relayURL,
+		StateDir:      t.TempDir(),
+		APIListenAddr: "127.0.0.1:" + strconv.Itoa(apiPort),
+		SNIListenAddr: "127.0.0.1:" + strconv.Itoa(sniPort),
+		SNIPort:       sniPort,
+	})
+	publicURL := h.waitForPublicURL()
+	if got := h.get(publicURL); got != marker {
+		t.Fatalf("tenant response = %q, want %q", got, marker)
+	}
+}

--- a/portal/server.go
+++ b/portal/server.go
@@ -145,6 +145,15 @@ func normalizeServerConfig(cfg ServerConfig) (ServerConfig, error) {
 	cfg.SNIPort = utils.IntOrDefault(cfg.SNIPort, 443)
 	cfg.APIListenAddr = utils.StringOrDefault(cfg.APIListenAddr, fmt.Sprintf(":%d", cfg.APIPort))
 	cfg.SNIListenAddr = utils.StringOrDefault(cfg.SNIListenAddr, fmt.Sprintf(":%d", cfg.SNIPort))
+	// A portless portal URL advertises public port 443. On a local host nothing
+	// can translate that port to a non-default SNI listener, so every advertised
+	// endpoint would name an origin nothing serves and lease registration would
+	// fail far from the setting that caused it. Remote hosts keep NAT/LB
+	// freedom: an external port different from the SNI listener stays valid.
+	if portalURL, parseErr := url.Parse(cfg.PortalURL); parseErr == nil && portalURL.Port() == "" && cfg.SNIPort != 443 && utils.IsLocalRelayHost(portalURL.Hostname()) {
+		publicOrigin := url.URL{Scheme: "https", Host: net.JoinHostPort(portalURL.Hostname(), strconv.Itoa(cfg.SNIPort))}
+		return ServerConfig{}, fmt.Errorf("PORTAL_URL %s has no port but SNI_PORT=%d on local host %s; set PORTAL_URL=%s so the canonical public origin matches the SNI listener", cfg.PortalURL, cfg.SNIPort, portalURL.Hostname(), publicOrigin.String())
+	}
 	if cfg.PProfEnabled {
 		cfg.PProfListenAddr = utils.StringOrDefault(strings.TrimSpace(cfg.PProfListenAddr), DefaultPProfListenAddr)
 	}

--- a/portal/server_test.go
+++ b/portal/server_test.go
@@ -378,6 +378,57 @@ func TestHTTPRedirectBindFailure(t *testing.T) {
 	listener.Close()
 }
 
+func TestNewServerValidatesLocalPublicOrigin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		portalURL  string
+		sniPort    int
+		wantErr    bool
+		wantOrigin string
+	}{
+		{"default port local", "https://localhost", 443, false, ""},
+		{"non-default local SNI port requires public port", "https://localhost", 8443, true, "https://localhost:8443"},
+		{"explicit local public port", "https://localhost:8443", 8443, false, ""},
+		{"loopback IP host", "https://127.0.0.1", 8443, true, "https://127.0.0.1:8443"},
+		{"IPv6 loopback host", "https://[::1]", 8443, true, "https://[::1]:8443"},
+		{"dot-localhost host", "https://relay.localhost", 8443, true, "https://relay.localhost:8443"},
+		{"remote NAT public port 443", "https://relay.example.com", 8443, false, ""},
+		{"remote external port differs from listener", "https://relay.example.com:9443", 8443, false, ""},
+		{"local SNI port 80 requires public port", "https://localhost", 80, true, "https://localhost:80"},
+		{"explicit local port 80", "https://localhost:80", 80, false, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewServer(ServerConfig{
+				PortalURL: tc.portalURL,
+				SNIPort:   tc.sniPort,
+				StateDir:  tempStateDir(t),
+			})
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("NewServer() error = nil, want validation error")
+				}
+				msg := err.Error()
+				if !strings.Contains(msg, "PORTAL_URL") {
+					t.Fatalf("error %q does not mention PORTAL_URL", msg)
+				}
+				wantSNI := "SNI_PORT=" + strconv.Itoa(tc.sniPort)
+				if !strings.Contains(msg, wantSNI) {
+					t.Fatalf("error %q does not mention %s", msg, wantSNI)
+				}
+				if !strings.Contains(msg, tc.wantOrigin) {
+					t.Fatalf("error %q does not suggest origin %s", msg, tc.wantOrigin)
+				}
+			} else if err != nil {
+				t.Fatalf("NewServer() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
 func TestRelayDiscoveryEnabledServesDiscoveryEnvelope(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #385

## Problem

`PORTAL_URL` is the relay's canonical public HTTPS origin; every advertised endpoint — the `/sdk/connect` reverse endpoint, the redirect target, the discovery announce, `llms.txt`, the install scripts, and the x402 URLs — derives from it. A local deployment can still start with:

```text
PORTAL_URL=https://localhost
SNI_PORT=8443
```

Clients dial the SNI port, so the advertised portless origin no longer matches the address clients use. The SDK classifies the reverse endpoint as alternate and registration fails far from the setting that caused it.

## Change

Instead of patching only the reverse endpoint URL (the #384 approach — rejected in review because it leaves the relay advertising multiple origins), this enforces one configuration invariant in `normalizeServerConfig`, the single owner of server config validation:

- A portless `PORTAL_URL` advertises public port 443. On a **local host** (`localhost`, loopback IPs, `*.localhost`) nothing can translate 443 to a non-default SNI listener, so `portless PORTAL_URL + SNI_PORT != 443 + local host` is rejected at `NewServer` with an actionable message naming both settings and the fixed origin (`set PORTAL_URL=https://localhost:8443 ...`).
- Explicit ports are never rewritten, so `PORTAL_URL=https://localhost:8443` + `SNI_PORT=8443` works, and port 80 stays explicit (only 443 may be omitted).
- **Remote hosts keep NAT/LB freedom**: an external port different from the local SNI listener port remains valid because `PORTAL_URL` states the external origin — the relay cannot distinguish that from a misconfiguration and must not reject it.

The lease code keeps deriving `/sdk/connect` directly from the canonical origin; there is no per-endpoint port rewriting.

## Coverage

- `portal/server_test.go` — `TestNewServerValidatesLocalPublicOrigin`, a table over: default 443, non-default 8443 (rejected when portless, accepted when explicit), explicit port 80, loopback IPv4/IPv6/`*.localhost` hosts, remote NAT portless, and an external port that differs from the listener port.
- `e2e/local_sni_origin_test.go` — the issue's exact config fails fast at `NewServer`, and a full tunnel through the SNI listener as the single public entry on a non-default port (`https://localhost:<sniPort>`), proving the fixed shape end to end.
- Docs: `.env.example` and the configuration page state the invariant.

## Verification

- Local gate: `gofmt -l` empty, `go vet ./portal/... ./e2e/...`, `go build ./...` (golang:1.27).
- CI: `make vet` / `make lint` / `make test`.
